### PR TITLE
Update documentation for standalone Skill Forge (SKF)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ Model(s) Used:
 Agentic IDE Used:
 WebSite Used:
 Project Language:
-BMad Method version:
+SKF version:
 
 **Screenshots or Links**
 If applicable, add screenshots or links (if web sharable record) to help explain your problem.

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -123,10 +123,10 @@ jobs:
           ## 📦 Installation
 
           ```bash
-          npx bmad-method install
+          npx bmad-module-skill-forge install
           ```
 
-          **Full Changelog**: https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite/compare/${{ steps.version.outputs.previous_tag }}...v${{ steps.version.outputs.new_version }}
+          **Full Changelog**: https://github.com/armelhbobdad/bmad-module-skill-forge/compare/${{ steps.version.outputs.previous_tag }}...v${{ steps.version.outputs.new_version }}
           EOF
 
           # Output for GitHub Actions
@@ -170,7 +170,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.new_version }}
-          name: "BMad Method v${{ steps.version.outputs.new_version }}"
+          name: "Skill Forge (SKF) v${{ steps.version.outputs.new_version }}"
           body: |
             ${{ steps.release_notes.outputs.RELEASE_NOTES }}
           draft: false
@@ -182,9 +182,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📦 Distribution" >> $GITHUB_STEP_SUMMARY
           echo "- **NPM**: Published with @latest tag" >> $GITHUB_STEP_SUMMARY
-          echo "- **GitHub Release**: https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite/releases/tag/v${{ steps.version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **GitHub Release**: https://github.com/armelhbobdad/bmad-module-skill-forge/releases/tag/v${{ steps.version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### ✅ Installation" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npx bmad-method@${{ steps.version.outputs.new_version }} install" >> $GITHUB_STEP_SUMMARY
+          echo "npx bmad-module-skill-forge@${{ steps.version.outputs.new_version }} install" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ Example breakdown:
 If you're new to GitHub or pull requests, here's a quick guide:
 
 1. **Fork the repository** - Click the "Fork" button on GitHub to create your own copy
-2. **Clone your fork** - `git clone https://github.com/YOUR-USERNAME/bmad-module-creative-intelligence-suite.git`
+2. **Clone your fork** - `git clone https://github.com/YOUR-USERNAME/bmad-module-skill-forge.git`
 3. **Create a new branch** - Never work on `main` directly!
    ```bash
    git checkout -b fix/description
@@ -255,9 +255,9 @@ By participating in this project, you agree to abide by our Code of Conduct. We 
   - **#bmad-development** - Technical questions and discussions
   - **#suggestions-feedback** - Feature ideas and suggestions
   - **#report-bugs-and-issues** - Get help with bugs before filing issues
-- 🐛 Report bugs using the [bug report template](https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite/issues/new?template=bug_report.md)
-- 💡 Suggest features using the [feature request template](https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite/issues/new?template=feature_request.md)
-- 📖 Browse the [GitHub Discussions](https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite/discussions)
+- 🐛 Report bugs using the [bug report template](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/new?template=bug_report.md)
+- 💡 Suggest features using the [feature request template](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/new?template=feature_request.md)
+- 📖 Browse the [GitHub Discussions](https://github.com/armelhbobdad/bmad-module-skill-forge/discussions)
 
 ---
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ This module is made possible by contributions from our community. We gratefully 
 
 - **Git history** — Every contribution is preserved in the project's commit history
 - **Contributors badge** — See the dynamic contributors list on our [README](README.md)
-- **GitHub contributors graph** — Visual representation at <https://github.com/bmad-code-org/YOUR-REPO-NAME/graphs/contributors>
+- **GitHub contributors graph** — Visual representation at <https://github.com/armelhbobdad/bmad-module-skill-forge/graphs/contributors>
 
 ## Becoming a Contributor
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docs: <https://armelhbobdad.github.io/bmad-module-skill-forge/>
 
 ## How BMad Works
 
-[BMad Method](https://github.com/bmad-code-org/BMAD-METHOD) works because it turns big, fuzzy work into **repeatable workflows**. Each workflow is broken into small steps with clear instructions, so the AI follows the same path every time. It also uses a **shared knowledge base** (standards and patterns) so outputs are consistent, not random. In short: **structured steps + shared standards = reliable results**.
+BMad works because it turns big, fuzzy work into **repeatable workflows**. Each workflow is broken into small steps with clear instructions, so the AI follows the same path every time. It also uses a **shared knowledge base** (standards and patterns) so outputs are consistent, not random. In short: **structured steps + shared standards = reliable results**.
 
 ## How SKF Fits In
 
@@ -73,8 +73,7 @@ Ferris operates in four workflow-driven modes (mode is determined by which workf
 ## Install
 
 ```bash
-npx bmad-method install
-# Select: Skill Forge (SKF)
+npx bmad-module-skill-forge install
 ```
 
 You'll be prompted for:
@@ -169,7 +168,10 @@ src/
         ├── test-skill/
         └── export-skill/
 ```
----
+
+## Contributing
+
+See [CONTRIBUTORS.md](CONTRIBUTORS.md) for guidelines.
 
 ## License
 
@@ -177,8 +179,8 @@ MIT License — see [LICENSE](LICENSE) for details.
 
 ---
 
-**Skill Forge (SKF)** — Part of the [BMad Method](https://github.com/bmad-code-org/BMAD-METHOD) ecosystem.
+**Skill Forge (SKF)** — A standalone [BMad](https://github.com/bmad-code-org/BMAD-METHOD) module for agent skill compilation.
 
-[![Contributors](https://contrib.rocks/image?repo=bmad-code-org/bmad-module-skill-forge)](https://github.com/bmad-code-org/bmad-module-skill-forge/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=armelhbobdad/bmad-module-skill-forge)](https://github.com/armelhbobdad/bmad-module-skill-forge/graphs/contributors)
 
 See [CONTRIBUTORS.md](CONTRIBUTORS.md) for contributor information.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,8 +20,7 @@ Skill Forge is an automated skill compiler for the AI agent ecosystem. It transf
 If you haven't installed the module yet:
 
 ```bash
-npx bmad-method install
-# Select: Skill Forge (SKF)
+npx bmad-module-skill-forge install
 ```
 
 Follow the prompts to configure the module for your needs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,7 @@ Skill Forge is an automated skill compiler for the AI agent ecosystem. It transf
 ## Quick Install
 
 ```bash
-npx bmad-method install
-# Select: Skill Forge (SKF)
+npx bmad-module-skill-forge install
 ```
 
 Then interact with the forge agent:


### PR DESCRIPTION
### Description of changes

- Updated install command to `npx bmad-module-skill-forge install`.
- Corrected repository references to `armelhbobdad/bmad-module-skill-forge`.
- Updated GitHub release name to "Skill Forge (SKF)".
- Fixed version label in the bug report template.
- Resolved placeholder URL in `CONTRIBUTORS.md`.
- Removed "Release Guide" section from README.
- Refined tagline to reflect standalone status.

### Checklist

- [x] Tests added for changes
- [x] Documentation updated where necessary
- [x] Code follows project style guidelines
- [x] Changes are ready for review