### PR TITLE
Add Node.js >= 22 prerequisite to installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Ferris operates in four workflow-driven modes (mode is determined by which workf
 
 ## Install
 
+Requires [Node.js](https://nodejs.org/) >= 22.
+
 There are three ways to install SKF, depending on your setup.
 
 ### Method 1: Standalone (recommended for trying SKF)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,8 +55,9 @@ The installer detects the existing `_bmad/` directory and installs SKF alongside
 
 ## Prerequisites
 
-| Tool                                                                   | Required For       | Install                     |
+| Tool                                                                   | Required For       | Install                       |
 |------------------------------------------------------------------------|--------------------|-----------------------------|
+| [Node.js](https://nodejs.org/) >= 22                                   | Installation, npx commands | <https://nodejs.org>          |
 | `gh` (GitHub CLI)                                                      | All modes          | <https://cli.github.com>      |
 | `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes | <https://ast-grep.github.io>  |
 | `qmd` (local hybrid search engine for project files)                   | Deep mode          | <https://github.com/tobi/qmd> |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ Skill Forge is an automated skill compiler for the AI agent ecosystem. It transf
 
 ## Quick Install
 
+Requires [Node.js](https://nodejs.org/) >= 22.
+
 **Standalone:**
 
 ```bash


### PR DESCRIPTION
### Description
This pull request updates the installation documentation to explicitly mention Node.js (version 22 or higher) as a prerequisite, ensuring users are aware it's required to run `npx` commands. 
