### PR TITLE
Refactor QMD indexing with collection-based registry

### DIFF
--- a/src/workflows/audit-skill/steps-c/step-02-re-index.md
+++ b/src/workflows/audit-skill/steps-c/step-02-re-index.md
@@ -117,12 +117,22 @@ Identify all source files in the source directory that contain public exports.
 
 **IF forge tier is Deep:**
 
-Query qmd_bridge for temporal context on each extracted export:
+Read the `qmd_collections` registry from `{sidecar_path}/forge-tier.yaml`.
+
+Find the collection entry matching the current skill: look for an entry where `skill_name` matches the current skill being audited AND `type` is `"extraction"`.
+
+**If a matching extraction collection is found:**
+Query qmd_bridge against the `{skill_name}-extraction` collection for temporal context on each extracted export:
 - When was this export first added?
 - Has it been modified recently?
 - What is its usage frequency across the codebase?
+- How does the current extraction compare to the previously compiled skill content?
 
 Append temporal metadata to each export in the snapshot.
+
+**If no matching collection found in registry:**
+Log: "No QMD extraction collection found for {skill_name}. Temporal enrichment skipped. Re-run [CS] Create Skill to generate the collection."
+Continue without T2 enrichment — this is not an error.
 
 **IF forge tier is Quick or Forge:**
 Skip this section. Temporal context requires Deep tier.

--- a/src/workflows/create-skill/steps-c/step-07-generate-artifacts.md
+++ b/src/workflows/create-skill/steps-c/step-07-generate-artifacts.md
@@ -124,16 +124,58 @@ Display brief confirmation:
 
 Proceeding to compilation report..."
 
-### 5. Menu Handling Logic
+### 5. QMD Collection Registration (Deep Tier Only)
+
+**IF forge tier is Deep AND QMD tool is available:**
+
+Index the generated skill artifacts into a QMD collection so that audit-skill and update-skill can perform high-signal searches against curated extraction data instead of raw source files.
+
+**Collection creation:**
+
+Create a QMD collection from both artifact directories:
+```bash
+qmd collection add {project-root}/skills/{name} --name {name}-extraction --mask "**/*"
+```
+
+If collection already exists (re-run): remove and recreate for atomic replace:
+```bash
+qmd collection remove {name}-extraction
+qmd collection add {project-root}/skills/{name} --name {name}-extraction --mask "**/*"
+```
+
+**Registry update:**
+
+Read `{project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml` and update the `qmd_collections` array.
+
+If an entry with `name: "{name}-extraction"` already exists, replace it. Otherwise, append:
+
+```yaml
+  - name: "{name}-extraction"
+    type: "extraction"
+    source_workflow: "create-skill"
+    skill_name: "{name}"
+    created_at: "{current ISO date}"
+```
+
+Write the updated forge-tier.yaml.
+
+**Error handling:**
+- If QMD collection creation fails: log the error, note that indexing can be retried via [SF] setup-forge. Do NOT fail the workflow.
+- If forge-tier.yaml update fails: log the error, continue. The collection exists in QMD even if the registry entry failed.
+
+**IF forge tier is NOT Deep:** Skip this section silently. No messaging.
+
+### 6. Menu Handling Logic
 
 **Auto-proceed step — no user interaction.**
 
-After all artifacts are written and verified, immediately load, read entire file, then execute `{nextStepFile}`.
+After all artifacts are written, verified, and optionally indexed into QMD, immediately load, read entire file, then execute `{nextStepFile}`.
 
 #### EXECUTION RULES:
 
 - This is an auto-proceed file writing step with no user choices
 - All 7 files must be written before proceeding
+- QMD indexing failure does NOT block proceeding
 - File write failures are real errors — halt, do not proceed with partial output
 - Proceed directly to next step after successful generation
 
@@ -151,6 +193,8 @@ ONLY WHEN all 7 artifact files are written and verified will you proceed to load
 - All 4 deliverable files written to skills/{name}/
 - All 3 workspace artifact files written to forge-data/{name}/
 - Write completion verified — all 7 files exist
+- Deep tier: QMD collection `{name}-extraction` created/updated and registered in forge-tier.yaml
+- Non-Deep tier: QMD indexing skipped silently
 - Brief confirmation displayed with file list
 - Auto-proceeded to step-08
 
@@ -161,5 +205,6 @@ ONLY WHEN all 7 artifact files are written and verified will you proceed to load
 - Proceeding with partial output if a write fails
 - Not creating directories before writing
 - Not verifying all files were written
+- Failing the workflow due to QMD indexing errors (should degrade gracefully)
 
-**Master Rule:** This step ONLY writes. All content was compiled and validated in previous steps. Write faithfully, verify completely.
+**Master Rule:** This step writes artifacts and registers QMD collections. All content was compiled and validated in previous steps. Write faithfully, verify completely. QMD indexing failures never block the workflow.

--- a/src/workflows/setup-forge/steps-c/step-02-write-config.md
+++ b/src/workflows/setup-forge/steps-c/step-02-write-config.md
@@ -68,6 +68,10 @@ tools:
 # Quick = no tools | Forge = ast-grep | Deep = ast-grep + gh + qmd
 tier: {calculated_tier}
 tier_detected_at: {current ISO timestamp}
+
+# QMD collection registry (populated by create-skill, consumed by audit/update-skill)
+# Each entry tracks a QMD collection created during skill workflows
+qmd_collections: []
 ```
 
 **This file is ALWAYS overwritten** on every run — it reflects current tool state.
@@ -125,7 +129,7 @@ ONLY WHEN forge-tier.yaml has been written successfully and preferences.yaml exi
 
 ### ✅ SUCCESS:
 
-- forge-tier.yaml written with accurate tool booleans, tier, and timestamp
+- forge-tier.yaml written with accurate tool booleans, tier, timestamp, and empty qmd_collections registry
 - preferences.yaml exists (created with defaults on first run, preserved on re-run)
 - forge-data/ directory exists (created or pre-existing)
 - Auto-proceeded to step-03

--- a/src/workflows/setup-forge/steps-c/step-03-auto-index.md
+++ b/src/workflows/setup-forge/steps-c/step-03-auto-index.md
@@ -1,49 +1,15 @@
 ---
-name: 'step-03-auto-index'
-description: 'Smart-index user project directories as QMD collections (Deep tier only)'
+name: 'step-03-qmd-hygiene'
+description: 'Verify and clean QMD collections against the forge-tier.yaml registry (Deep tier only)'
 
 nextStepFile: './step-04-report.md'
-
-# Directories ALWAYS excluded regardless of git status — module internals and forge artifacts
-alwaysExcluded:
-  - _bmad
-  - forge-data
-
-# Directory name patterns ALWAYS excluded (glob-style matching)
-# _*-learn: module learning material directories (e.g., _skf-learn, _xyz-learn)
-alwaysExcludedPatterns:
-  - '_*-learn'
-
-# Fallback exclusion list for non-git projects only
-# Used ONLY when the project is not a git repository
-fallbackExcludedDirs:
-  - _bmad
-  - forge-data
-  - node_modules
-  - .git
-  - dist
-  - build
-  - coverage
-  - __pycache__
-  - target
-  - .next
-  - .nuxt
-  - .cache
-  - vendor
-  - out
-  - .turbo
-  - venv
-  - .venv
-  - .output
 ---
 
-# Step 3: Smart Auto-Index Project
+# Step 3: QMD Collection Hygiene
 
 ## STEP GOAL:
 
-If the detected tier is Deep, discover **user project directories** and index each as a targeted QMD collection. Uses `git ls-files` as the authoritative source for what belongs to the project (respects all `.gitignore` rules), with a hardcoded fallback for non-git projects.
-
-Directories in `{alwaysExcluded}` and patterns in `{alwaysExcludedPatterns}` are excluded regardless of git status. Empty directories are skipped. Stale collections from prior runs are cleaned up.
+If the detected tier is Deep, verify the health of existing QMD collections by cross-referencing them against the `qmd_collections` registry in `forge-tier.yaml`. Identify orphaned collections (in QMD but not in registry) and stale registry entries (in registry but collection missing from QMD). Prompt the user before removing orphaned collections.
 
 For Quick and Forge tiers, skip silently and proceed.
 
@@ -53,39 +19,37 @@ For Quick and Forge tiers, skip silently and proceed.
 
 - 📖 CRITICAL: Read the complete step file before taking any action
 - 🔄 CRITICAL: When loading next step, ensure entire file is read
-- 🎯 Execute all operations autonomously — no user interaction
+- 🎯 Execute all operations autonomously — minimal user interaction (only prompt before deletion)
 
 ### Role Reinforcement:
 
-- ✅ You are a system executor performing smart conditional indexing
-- ✅ Graceful degradation is paramount — never fail the workflow over indexing
+- ✅ You are a system executor performing QMD collection maintenance
+- ✅ Graceful degradation is paramount — never fail the workflow over hygiene checks
 - ✅ No negative messaging — do not mention what non-Deep tiers are missing
 
 ### Step-Specific Rules:
 
-- 🎯 Focus only on targeted QMD indexing (Deep tier) or graceful skip (other tiers)
+- 🎯 Focus only on verifying and cleaning QMD collections (Deep tier) or graceful skip (other tiers)
 - 🚫 FORBIDDEN to display "missing" or "skipped" messages for non-Deep tiers
-- 🚫 FORBIDDEN to fail the workflow if QMD indexing encounters errors
-- 🚫 FORBIDDEN to index directories matching `{alwaysExcluded}` or `{alwaysExcludedPatterns}`
-- 🚫 FORBIDDEN to index the entire project root as a single collection
-- 🚫 FORBIDDEN to create collections for empty directories
-- 💬 If indexing fails: log the issue, note that index can be retried, continue
+- 🚫 FORBIDDEN to fail the workflow if QMD hygiene encounters errors
+- 🚫 FORBIDDEN to create new QMD collections — that responsibility belongs to create-skill
+- 🚫 FORBIDDEN to silently delete collections — always prompt user before removal
+- 💬 If hygiene fails: log the issue, note that it can be retried, continue
 
 ## EXECUTION PROTOCOLS:
 
 - 🎯 Follow the MANDATORY SEQUENCE exactly
-- 💾 QMD indexing targets only user project directories — never module internals
+- 💾 QMD hygiene only verifies and cleans — it does NOT index new content
 - 📖 Use {calculated_tier} from step-01 context
-- 🚫 FORBIDDEN to attempt indexing for Quick or Forge tiers
-- 🚫 FORBIDDEN to use `**/*.md` as the mask — use `**/*` to capture all file types (source code, docs, configs)
+- 🚫 FORBIDDEN to attempt hygiene for Quick or Forge tiers
 
 ## CONTEXT BOUNDARIES:
 
 - Available: {calculated_tier} from step-01, forge-tier.yaml written in step-02
 - Available: {project_name} from workflow config
-- Focus: conditional QMD indexing only
-- Limits: only index if Deep tier AND user content exists
-- Dependencies: step-02 must have completed (forge-tier.yaml exists)
+- Focus: QMD collection verification and cleanup only
+- Limits: only run if Deep tier
+- Dependencies: step-02 must have completed (forge-tier.yaml exists with qmd_collections registry)
 
 ## MANDATORY SEQUENCE
 
@@ -95,143 +59,105 @@ For Quick and Forge tiers, skip silently and proceed.
 
 Read `{calculated_tier}` from context.
 
-**If tier is NOT Deep:** Proceed directly to section 7 (Auto-Proceed) — no output, no messaging.
+**If tier is NOT Deep:** Proceed directly to section 6 (Auto-Proceed) — no output, no messaging.
 
 **If tier IS Deep:** Continue to section 2.
 
-### 2. Discover User Project Directories
+### 2. Load Registry and QMD State
 
-Determine which top-level directories contain user project content that should be indexed.
+Read the `qmd_collections` array from `{project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml`.
 
-#### 2a. Check if project is a git repository
-
-Run: `git -C {project-root} rev-parse --is-inside-work-tree 2>/dev/null`
-
-**If git repo (exit code 0):** Use the **git-aware strategy** (section 2b).
-
-**If NOT a git repo:** Use the **fallback strategy** (section 2c).
-
-#### 2b. Git-Aware Strategy (preferred)
-
-Use `git ls-files` to discover which top-level directories contain tracked content. This automatically respects ALL `.gitignore` rules (project-level, nested, global, and `.git/info/exclude`).
-
-Run:
+List live QMD collections:
 ```bash
-cd {project-root} && git ls-files | cut -d/ -f1 | sort -u
+qmd collection list
 ```
 
-This produces a list of top-level entries (files and directories) that git tracks.
+**Store both lists for cross-reference:**
+- `{registry_collections}` — entries from forge-tier.yaml qmd_collections
+- `{live_collections}` — collections currently in QMD
 
-**Filter the results:**
-- Keep only **directories** (ignore root-level files — the agent can read those directly)
-- Remove all directories matching `{alwaysExcluded}` (exact match)
-- Remove all directories matching `{alwaysExcludedPatterns}` (glob match — e.g., `_*-learn` matches `_skf-learn`, `_xyz-learn`)
+**Error handling:** If `qmd collection list` fails, log the error, store `{hygiene_result: "qmd_unavailable"}`, and proceed to section 6.
 
-**Store the result as `{user_dirs}`.**
+### 3. Cross-Reference and Classify
 
-#### 2c. Fallback Strategy (non-git projects)
+Compare the two lists:
 
-List top-level directories in the project root:
+**Healthy** — collection exists in both registry AND QMD:
+- Mark as verified
+- No action needed
 
-Run: `ls -d {project-root}/*/ 2>/dev/null`
+**Orphaned** — collection exists in QMD but NOT in registry:
+- These may be leftover from prior auto-indexing or manual indexing
+- Flag for user-prompted removal
 
-**Filter the results:**
-- Remove all directories listed in `{fallbackExcludedDirs}` (exact match)
-- Remove all directories matching `{alwaysExcludedPatterns}` (glob match)
-- Remove all dot-directories (any directory starting with `.`)
+**Stale** — entry exists in registry but collection is missing from QMD:
+- The QMD collection was deleted or lost
+- Remove the stale entry from the registry
 
-**Store the result as `{user_dirs}`.**
+### 4. Handle Orphaned Collections
 
-### 3. Filter Empty Directories
+**If orphaned collections found:**
 
-For each directory in `{user_dirs}`, check if it contains any meaningful files (not just git placeholder files):
+Display to user:
+"**QMD Hygiene: Found {count} orphaned collection(s) not tracked in the forge registry:**
 
-Run: `find {dir_path} -type f -maxdepth 3 -not -name '.gitkeep' -not -name '.keep' -not -name '.placeholder' | head -1`
+{list orphaned collection names}
 
-- If output is empty (no meaningful files found within 3 levels): **remove from `{user_dirs}`**
-- If output has a result: keep in `{user_dirs}`
+These collections exist in QMD but are not managed by any skill workflow. They may be from a previous auto-index run or manual creation.
 
-This prevents creating QMD collections for directories that only contain placeholder files like `.gitkeep`.
+**[R]emove** orphaned collections — clean up QMD
+**[K]eep** orphaned collections — leave them as-is"
 
-### 4. Evaluate Indexability
-
-**If `{user_dirs}` is empty** (no user content directories with files found):
-
-- Store in context: `{qmd_indexed: false, qmd_skip_reason: "no_project_content"}`
-- Note for step-04: "No project source directories found to index. QMD collections will be created automatically on next [SF] run after adding project content."
-- Proceed directly to section 7 (Auto-Proceed)
-
-**If `{user_dirs}` has entries:** Continue to section 5.
-
-### 5. Clean Up Stale Collections (Re-run Only)
-
-Check for existing QMD collections that belong to this project but no longer map to a valid directory.
-
-Run: `qmd collection list` and identify collections whose name starts with `{project_name}-`.
-
-For each such collection:
-- Extract the directory name from the collection name (the part after `{project_name}-`)
-- Check if that directory still exists in `{user_dirs}`
-- If NOT found in `{user_dirs}`: remove the stale collection with `qmd collection remove {collection_name}`
-- If found: it will be updated in section 6
-
-**Error handling:** If collection listing or removal fails, log and continue — stale cleanup is best-effort.
-
-### 6. Index User Directories with QMD (Deep Tier Only)
-
-For **each directory** in `{user_dirs}`, create a QMD collection:
-
-- **Collection name**: `{project_name}-{sanitized_dirname}`
-  - Sanitize the dirname: strip any leading underscores or dots (e.g., `_src` → `src`, `.config` → `config`)
-  - Examples: `myapp-src`, `myapp-docs`, `myapp-lib`
-- **Path**: the full absolute path to the directory
-- **Mask**: `**/*` (captures all file types — source code, markdown, configs, etc.)
-
-**Command per directory:**
+**If user selects R (Remove):**
+For each orphaned collection:
 ```bash
-qmd collection add {dir_path} --name {project_name}-{sanitized_dirname} --mask "**/*"
+qmd collection remove {collection_name}
 ```
+Log each removal.
 
-**Re-run handling:** If QMD reports "already exists" for a collection:
-- Do NOT fail — this means it was indexed on a prior run
-- Run `qmd update` once at the end to re-index all existing collections with fresh content
-- Note the collection as "updated" rather than "created"
+**If user selects K (Keep):**
+Skip removal. Log that orphaned collections were kept.
 
-**After all collections are processed:**
-- Store in context: `{qmd_indexed: true, qmd_collections: [list of names], qmd_total_files: total}`
-- Count total files indexed across all collections from QMD output
+**If no orphaned collections:** Skip this section silently.
 
-**Timeout handling:** If indexing takes excessively long on a large project:
-- Log that indexing is in progress but may need more time
-- Note in context that index may be incomplete
-- Do NOT halt or fail the workflow
+### 5. Handle Stale Registry Entries
 
-**Error handling:** If QMD indexing fails for a specific directory:
-- Log the specific error for that directory
-- Continue with remaining directories — do not abort the loop
-- Note which collections succeeded and which failed
+**If stale registry entries found:**
 
-If ALL directories fail:
-- Store in context: `{qmd_indexed: false, qmd_skip_reason: "all_indexing_failed"}`
-- Note that indexing can be retried by re-running [SF]
-- The forge-tier.yaml already records `qmd: true` — the tool is available even if indexing failed
+Remove stale entries from the `qmd_collections` array in forge-tier.yaml.
 
-### 7. Auto-Proceed
+Display: "**Cleaned {count} stale registry entry/entries** (collection no longer exists in QMD)."
+
+Update forge-tier.yaml with the cleaned registry.
+
+**If no stale entries:** Skip this section silently.
+
+### 6. Store Hygiene Results and Auto-Proceed
+
+Store in context for step-04 reporting:
+```
+{hygiene_result: "completed"|"skipped"|"qmd_unavailable"}
+{hygiene_healthy: count}
+{hygiene_orphaned_removed: count}
+{hygiene_orphaned_kept: count}
+{hygiene_stale_cleaned: count}
+```
 
 "**Proceeding to forge status report...**"
 
 #### Menu Handling Logic:
 
-- After indexing completes (or is skipped), immediately load, read entire file, then execute {nextStepFile}
+- After hygiene completes (or is skipped), immediately load, read entire file, then execute {nextStepFile}
 
 #### EXECUTION RULES:
 
-- This is an auto-proceed step with no user choices
-- Proceed directly to next step after indexing or skip
+- This step has one optional user interaction (orphan removal prompt)
+- If no orphans found, this is an auto-proceed step
+- Proceed directly to next step after hygiene or skip
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN the tier check has been performed (and indexing completed or skipped accordingly) will you load and read fully `{nextStepFile}` to execute the report step.
+ONLY WHEN the hygiene check has been performed (or skipped for non-Deep tiers) will you load and read fully `{nextStepFile}` to execute the report step.
 
 ---
 
@@ -239,32 +165,23 @@ ONLY WHEN the tier check has been performed (and indexing completed or skipped a
 
 ### ✅ SUCCESS:
 
-- Git repo: `git ls-files` used to discover indexable directories (respects all .gitignore rules)
-- Non-git: fallback exclusion list applied correctly
-- `{alwaysExcluded}` directories excluded in ALL cases (git or non-git)
-- `{alwaysExcludedPatterns}` patterns excluded in ALL cases (e.g., `_skf-learn` matched by `_*-learn`)
-- Empty directories skipped — no collections created for dirs with no files
-- Stale collections from prior runs detected and removed
-- Collection names sanitized (leading `_` and `.` stripped from dirname portion)
-- Deep tier with user content: each user directory indexed as its own QMD collection with `**/*` mask
-- Deep tier with no user content: skipped with informative note for step-04
-- Deep tier re-run: stale collections removed, existing updated via `qmd update`, new directories added
+- Deep tier: forge-tier.yaml registry cross-referenced with live QMD collections
+- Healthy collections identified and verified
+- Orphaned collections flagged and user prompted before removal
+- Stale registry entries cleaned from forge-tier.yaml
+- Hygiene results stored for step-04 reporting
 - Quick/Forge tier: skipped silently with no negative messaging
-- Workflow continues regardless of indexing outcome
+- Workflow continues regardless of hygiene outcome
 - Auto-proceeded to step-04
 
 ### ❌ SYSTEM FAILURE:
 
-- Indexing `_bmad/` or `forge-data/` under any circumstance
-- Indexing directories matching `_*-learn` pattern
-- Creating collections for empty directories
-- Using `**/*.md` mask instead of `**/*` (misses source code files critical for skill generation)
-- Indexing the entire project root as a single collection (pollutes results with module internals)
-- Not using `git ls-files` when the project IS a git repo
-- Leaving stale collections from deleted directories on re-run
-- Attempting QMD indexing for Quick or Forge tiers
+- Creating new QMD collections (that's create-skill's responsibility)
+- Silently deleting collections without user prompt
+- Attempting QMD hygiene for Quick or Forge tiers
 - Displaying "skipped" or "missing" messages for non-Deep tiers
-- Halting the workflow due to QMD indexing failure
+- Halting the workflow due to QMD hygiene failure
+- Indexing project directories (old auto-index behavior — removed)
 - Not proceeding to step-04 after this step
 
-**Master Rule:** This step must NEVER fail the workflow. Use git as the authority for what belongs to the project. Always exclude `{alwaysExcluded}` and `{alwaysExcludedPatterns}`. Skip empty directories. Clean up stale collections. Index only user project directories with `**/*` mask. Non-Deep tiers skip silently.
+**Master Rule:** This step ONLY verifies and cleans. It never indexes new content. QMD collection creation is the responsibility of create-skill. Non-Deep tiers skip silently. Always prompt before removing orphaned collections.

--- a/src/workflows/setup-forge/steps-c/step-04-report.md
+++ b/src/workflows/setup-forge/steps-c/step-04-report.md
@@ -43,7 +43,7 @@ Display the forge status report with positive capability framing, report tier ch
 
 - Available: {detected_tools}, {calculated_tier}, {previous_tier}, {tier_override} from step-01
 - Available: tool version strings from step-01
-- Available: {qmd_indexed}, {qmd_collections}, {qmd_total_files}, {qmd_skip_reason} from step-03
+- Available: {hygiene_result}, {hygiene_healthy}, {hygiene_orphaned_removed}, {hygiene_orphaned_kept}, {hygiene_stale_cleaned} from step-03
 - Focus: report display only — no file modifications
 - Dependencies: steps 01-03 must have completed
 
@@ -70,14 +70,16 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
   Tools Detected:
   {for each tool that is available, show: tool name — version}
 
-  {if qmd_indexed is true:}
-  QMD Index:
-  {for each collection in qmd_collections, show: collection name — file count}
-  {total qmd_total_files files indexed}
+  {if hygiene_result is "completed":}
+  QMD Registry:
+  {hygiene_healthy} collection(s) healthy
+  {if hygiene_orphaned_removed > 0: {hygiene_orphaned_removed} orphaned collection(s) removed}
+  {if hygiene_orphaned_kept > 0: {hygiene_orphaned_kept} orphaned collection(s) kept}
+  {if hygiene_stale_cleaned > 0: {hygiene_stale_cleaned} stale registry entry/entries cleaned}
   {end if}
 
-  {if qmd_skip_reason is "no_project_content":}
-  QMD Index: pending — no project directories found yet. Re-run [SF] after adding source files.
+  {if hygiene_result is "completed" and hygiene_healthy is 0:}
+  QMD Registry: empty — collections are created automatically when you run [CS] Create Skill.
   {end if}
 
 {if tier_override is active:}

--- a/src/workflows/update-skill/steps-c/step-03-re-extract.md
+++ b/src/workflows/update-skill/steps-c/step-03-re-extract.md
@@ -97,10 +97,19 @@ DO NOT BE LAZY — For EACH file in the change manifest with status MODIFIED, AD
 
 **ONLY if forge_tier == Deep:**
 
+Read the `qmd_collections` registry from `{sidecar_path}/forge-tier.yaml`.
+
+Find the collection entry matching the current skill: look for an entry where `skill_name` matches the skill being updated AND `type` is `"extraction"`.
+
+**If a matching extraction collection is found:**
 Launch a subprocess that loads qmd_bridge and for each changed export:
-1. Queries QMD collection for semantic context related to the export
+1. Queries the `{skill_name}-extraction` collection for semantic context related to the export
 2. Searches for usage patterns, documentation references, temporal history
 3. Returns T2 evidence per export (usage frequency, context snippets, related concepts)
+
+**If no matching collection found in registry:**
+Log: "No QMD extraction collection found for {skill_name}. T2 enrichment skipped. Re-run [CS] Create Skill to generate the collection."
+Continue without T2 enrichment — extraction still produces T1 results.
 
 **If forge_tier != Deep:** Skip this section with notice: "QMD enrichment skipped (tier: {forge_tier})"
 


### PR DESCRIPTION
### Description of the changes

This pull request refactors the QMD indexing process by replacing the auto-indexing previously conducted during `setup-forge` with a progressive collection-based registry. Key updates include:

- Moving QMD indexing to the `create-skill` step for high-signal artifact indexing.
- Repurposing `setup-forge` for registry hygiene tasks like verifying registry health, cleaning orphaned collections, and removing stale entries.
- Adding a `qmd_collections` registry array to the `forge-tier.yaml` schema.
- Updating `audit-skill` and `update-skill` to consume data from the new registry.
