### PR TITLE
Align CI workflows to Node.js 22 and update release process

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -41,9 +41,7 @@ jobs:
 
       - name: Run tests and validation
         run: |
-          npm run validate
-          npm run format:check
-          npm run lint
+          npm test
 
       - name: Configure Git
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - Unreleased
+
+### Initial Release
+
+Skill Forge (SKF) — an agent skill compiler that transforms code repositories, documentation, and developer discourse into [agentskills.io](https://agentskills.io)-compliant agent skills with AST-backed provenance.
+
+### Highlights
+
+- **1 agent** — Ferris (Skill Architect & Integrity Guardian) with 4 workflow-driven modes
+- **10 workflows** — full lifecycle from source analysis to ecosystem-ready export
+- **Progressive capability model** — Quick (gh), Forge (+ast-grep), Deep (+QMD)
+- **Zero hallucination tolerance** — every instruction traces to source code with provenance citations
+- **Dual-output strategy** — active skills (SKILL.md) + passive context (context-snippet.md) in ADR-L v2 format
+- **CLI installer** — `npx bmad-module-skill-forge install` with IDE command generation for 7 IDEs
+- **10 knowledge fragments** — curated cross-cutting principles loaded just-in-time by workflows
+
+### Workflows
+
+| Trigger | Name | Purpose |
+|---------|------|---------|
+| SF | Setup Forge | Initialize forge environment, detect tools, set tier |
+| AN | Analyze Source | Discover what to skill in a large repo |
+| BS | Brief Skill | Design a skill scope through guided discovery |
+| CS | Create Skill | Compile a skill from brief with AST extraction |
+| QS | Quick Skill | Fast skill from package name or GitHub URL |
+| SS | Stack Skill | Consolidated project stack skill with integration patterns |
+| US | Update Skill | Smart regeneration preserving manual sections |
+| AS | Audit Skill | Drift detection between skill and current source |
+| TS | Test Skill | Cognitive completeness verification |
+| EX | Export Skill | Package for distribution, inject into CLAUDE.md |
+
+### Confidence Tiers
+
+- **T1** — AST-verified structural truth (Forge/Deep)
+- **T1-low** — Source reading without structural verification (Quick)
+- **T2** — QMD-enriched temporal context (Deep)
+- **T3** — External documentation, quarantined as untrusted
+
+### IDE Support
+
+Claude Code, Cursor, Cline, Codex, GitHub Copilot, Roo Code, Windsurf
+
+### Links
+
+- Documentation: <https://armelhbobdad.github.io/bmad-module-skill-forge>
+- npm: <https://www.npmjs.com/package/bmad-module-skill-forge>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "js-yaml": "^4.1.0"
       },
       "bin": {
-        "bmad-module-skill-forge": "tools/skf-npx-wrapper.js",
-        "skill-forge": "tools/skf-npx-wrapper.js"
+        "bmad-module-skill-forge": "tools/skf-npx-wrapper.js"
       },
       "devDependencies": {
         "@astrojs/sitemap": "^3.6.0",


### PR DESCRIPTION
### Summary of Changes

- Updated CI workflows (`publish.yaml`, `docs.yaml`, `manual-release.yaml`) to use `.nvmrc` instead of hardcoded Node.js version 20, aligning with Node.js 22.
- Fixed the manual release script by replacing the non-existent `npm run validate` command with `npm test`, ensuring proper execution of the validation suite.
- Added v1.0.0 release summary to the `CHANGELOG.md`.
