### PR TITLE
docs: warn that Snyk API requires Enterprise plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,14 @@ The `setup-forge` workflow detects available tools and writes the tier to `forge
 
 `skill-check` includes security scanning via [Snyk Agent Scan](https://github.com/snyk/agent-scan) to check for prompt injection risks, sensitive data exposure, and unsafe tool permissions. To enable:
 
-1. Create a free Snyk account at [app.snyk.io](https://app.snyk.io)
+1. You need a Snyk account with API access — the Snyk API requires an **Enterprise plan** (see [Snyk API authentication docs](https://docs.snyk.io/snyk-api/authentication-for-api))
 2. Copy your API token from Account Settings
 3. Add to your environment: `export SNYK_TOKEN=your-token`
 4. Re-run `@Ferris SF` to detect the token
 
-Security scanning runs automatically during validation. Use `--no-security-scan` to skip. Security scan availability does not affect your tier level.
+> **Note:** The Snyk API is not available on free or Team plans. If you don't have an Enterprise account, security scanning will be skipped gracefully — it does not affect your tier level or block skill compilation.
+
+Security scanning runs automatically during validation. Use `--no-security-scan` to skip.
 
 ## Knowledge Base
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,15 +55,16 @@ The installer detects the existing `_bmad/` directory and installs SKF alongside
 
 ## Prerequisites
 
-| Tool                                                                   | Required For       | Install                       |
-|------------------------------------------------------------------------|--------------------|-----------------------------|
-| [Node.js](https://nodejs.org/) >= 22                                   | Installation, npx commands | <https://nodejs.org>          |
-| `gh` (GitHub CLI)                                                      | All modes          | <https://cli.github.com>      |
-| `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes | <https://ast-grep.github.io>  |
-| `ast-grep` MCP server (recommended alongside CLI)                      | Forge + Deep modes | <https://github.com/ast-grep/ast-grep-mcp> |
-| `qmd` (local hybrid search engine for project files)                   | Deep mode          | <https://github.com/tobi/qmd> |
+| Tool                                                                   | Required For               | Install                                                |
+|------------------------------------------------------------------------|----------------------------|--------------------------------------------------------|
+| [Node.js](https://nodejs.org/) >= 22                                   | Installation, npx commands | <https://nodejs.org>                                   |
+| `gh` (GitHub CLI)                                                      | All modes                  | <https://cli.github.com>                               |
+| `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes         | <https://ast-grep.github.io>                           |
+| `ast-grep` MCP server (recommended alongside CLI)                      | Forge + Deep modes         | <https://github.com/ast-grep/ast-grep-mcp>             |
+| `qmd` (local hybrid search engine for project files)                   | Deep mode                  | <https://github.com/tobi/qmd>                          |
+| `SNYK_TOKEN` (Snyk API token — **Enterprise plan required**)           | Optional security scan     | <https://docs.snyk.io/snyk-api/authentication-for-api> |
 
-Don't worry if you don't have all tools — SKF detects what's available and sets your tier automatically.
+Don't worry if you don't have all tools — SKF detects what's available and sets your tier automatically. Security scanning via Snyk is optional and requires an Enterprise plan; it does not affect your tier level.
 
 ---
 

--- a/src/workflows/create-skill/steps-c/step-06-validate.md
+++ b/src/workflows/create-skill/steps-c/step-06-validate.md
@@ -122,13 +122,13 @@ Record any security warnings in evidence-report. Security findings are advisory 
 
 Display actionable guidance:
 
-"Security scan requires a Snyk token. To enable:
-1. Create a free account at [app.snyk.io](https://app.snyk.io)
+"Security scan requires a Snyk API token. **Important:** The Snyk API requires an Enterprise plan ([authentication docs](https://docs.snyk.io/snyk-api/authentication-for-api)). To enable:
+1. Obtain a Snyk Enterprise account with API access
 2. Get your API token from Account Settings → API Token
 3. Set `SNYK_TOKEN=your-token` in your environment or `.env`
 4. Re-run [SF] Setup Forge to update tool detection, then re-run [CS] Create Skill
 
-Use `--no-security-scan` flag in skill-check to skip, or `--security-scan-runner pipx|uvx|local` to control the execution method."
+If you don't have an Enterprise account, use `--no-security-scan` flag in skill-check to skip, or `--security-scan-runner pipx|uvx|local` to control the execution method. Security scanning is optional and does not affect tier level or block skill compilation."
 
 Record: "Security scan skipped — SNYK_TOKEN not configured"
 


### PR DESCRIPTION
## Summary
- Updated README, docs/getting-started, and create-skill validation step to warn that the Snyk API requires an **Enterprise plan** — the previous "free account" guidance was misleading
- Added link to [Snyk API authentication docs](https://docs.snyk.io/snyk-api/authentication-for-api) across all three files
- Added `SNYK_TOKEN` row to getting-started prerequisites table

## Test plan
- [x] All 52 schema tests passing
- [x] All 89 CLI integration tests passing
- [x] All 58 knowledge base tests passing
- [x] Markdown lint, ESLint, Prettier all clean
- [x] Verify rendered markdown in README and docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)