### PR TITLE
docs: document completeness scoring formula and threshold override

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -71,6 +71,18 @@ SKF detects drift by comparing the skill's recorded provenance against the curre
 
 ---
 
+## Completeness Score
+
+The completeness score is a weighted measure of how thoroughly a skill documents its target. The Test Skill workflow (`@Ferris TS`) calculates it across five categories: **Export Coverage** (are all source exports documented?), **Signature Accuracy** (do documented signatures match the actual code?), **Type Coverage** (are referenced types complete?), **Coherence** (do cross-references and integration patterns resolve?), and **External Validation** (do skill-check and tessl confirm quality?).
+
+The default pass threshold is **80%**. Skills that pass are ready for export (`@Ferris EX`); skills that fail route to update (`@Ferris US`) with a gap report showing what to fix.
+
+**Example:** A skill scores 92% export coverage, 85% signature accuracy, 100% type coverage, 80% coherence, and 78% external validation. With the default weights (36/22/14/18/10), the weighted total is 88.0% — a pass.
+
+Your forge tier determines which categories are scored. Quick-tier skills skip signature accuracy and type coverage (no AST available), and the weights redistribute proportionally. See [How It Works](../how-it-works/#completeness-scoring) for the full formula and tier adjustments.
+
+---
+
 ## Version Pinning
 
 Every skill records the exact version (or commit) of the source code it was built from. This means you always know which version of the library the instructions apply to.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -75,7 +75,7 @@ SKF detects drift by comparing the skill's recorded provenance against the curre
 
 The completeness score is a weighted measure of how thoroughly a skill documents its target. The Test Skill workflow (`@Ferris TS`) calculates it across five categories: **Export Coverage** (are all source exports documented?), **Signature Accuracy** (do documented signatures match the actual code?), **Type Coverage** (are referenced types complete?), **Coherence** (do cross-references and integration patterns resolve?), and **External Validation** (do skill-check and tessl confirm quality?).
 
-The default pass threshold is **80%**. Skills that pass are ready for export (`@Ferris EX`); skills that fail route to update (`@Ferris US`) with a gap report showing what to fix.
+The default pass threshold is **80%**, overridable by specifying a custom threshold when invoking `@Ferris TS`. Skills that pass are ready for export (`@Ferris EX`); skills that fail route to update (`@Ferris US`) with a gap report showing what to fix.
 
 **Example:** A skill scores 92% export coverage, 85% signature accuracy, 100% type coverage, 80% coherence, and 78% external validation. With the default weights (36/22/14/18/10), the weighted total is 88.0% — a pass.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -185,6 +185,105 @@ Your forge tier limits what authority claims a skill can make:
 
 ---
 
+## Completeness Scoring
+
+The Test Skill workflow (`@Ferris TS`) calculates a **completeness score** — a weighted measure of how thoroughly and accurately a skill documents its target. This score is the quality gate: pass and the skill is ready for export; fail and it routes to update-skill for remediation.
+
+### Categories & Weights
+
+The score is the weighted sum of five categories:
+
+| Category | Weight | What It Measures |
+|----------|--------|------------------|
+| **Export Coverage** | 36% | Percentage of source exports documented in SKILL.md |
+| **Signature Accuracy** | 22% | Documented function signatures match actual source signatures (parameter names, types, order, return types) |
+| **Type Coverage** | 14% | Types and interfaces referenced in exports are fully documented |
+| **Coherence** | 18% | Cross-references resolve, integration patterns are complete (contextual mode only) |
+| **External Validation** | 10% | Average of skill-check quality score (0-100) and tessl content score (0-100%) |
+
+### Formula
+
+```
+total_score = sum(category_weight × category_score)
+```
+
+Each category score is a percentage: `(items_passing / items_total) × 100`.
+
+**Coherence** (contextual mode) combines two sub-scores:
+
+```
+coherence = (reference_validity × 0.6) + (integration_completeness × 0.4)
+```
+
+If no integration patterns exist, coherence equals reference validity alone.
+
+**External validation** averages the two tools when both are available. When only one tool is available, that tool's score is used. When neither is available, the 10% weight is redistributed proportionally to the other active categories.
+
+### Naive vs Contextual Mode
+
+Test Skill runs in one of two modes, detected automatically:
+
+- **Contextual mode** (stack skills) — All five categories scored with the default weights above.
+- **Naive mode** (individual skills) — Coherence is not scored. Its 18% weight is redistributed:
+
+| Category | Naive Weight |
+|----------|-------------|
+| Export Coverage | 45% |
+| Signature Accuracy | 25% |
+| Type Coverage | 20% |
+| External Validation | 10% |
+
+### Tier Adjustments
+
+Your forge tier determines which categories can be scored:
+
+| Tier | Skipped Categories | Reason |
+|------|-------------------|--------|
+| **Quick** | Signature Accuracy, Type Coverage | No AST parsing available |
+| **Docs-only** | Signature Accuracy, Type Coverage | No source code to compare against |
+| **Provenance-map** (State 2) | Signature Accuracy, Type Coverage | String comparison only, no semantic AST verification |
+| **Forge / Forge+ / Deep** | None | Full AST-backed scoring |
+
+When categories are skipped, their combined weight (36%) is redistributed proportionally to the remaining active categories. A Quick-tier skill and a Deep-tier skill both pass at the same 80% threshold — the score reflects what your tier can actually measure.
+
+### Pass/Fail
+
+```
+Default threshold: 80%
+
+score >= 80%  →  PASS  →  Recommend export-skill
+score <  80%  →  FAIL  →  Recommend update-skill
+```
+
+### Gap Severities
+
+When the score is calculated, each finding is classified by severity to guide remediation:
+
+| Severity | Examples |
+|----------|----------|
+| **Critical** | Missing exported function/class documentation |
+| **High** | Signature mismatch between source and SKILL.md |
+| **Medium** | Missing type/interface documentation; scripts/assets directory inconsistencies |
+| **Low** | Missing optional metadata or examples; description optimization opportunities |
+| **Info** | Style suggestions; discovery testing recommendations |
+
+### Score Report Output
+
+The test report includes a score breakdown table showing each category's raw score, weight, and weighted contribution:
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Export Coverage | 92% | 36% | 33.1% |
+| Signature Accuracy | 85% | 22% | 18.7% |
+| Type Coverage | 100% | 14% | 14.0% |
+| Coherence | 80% | 18% | 14.4% |
+| External Validation | 78% | 10% | 7.8% |
+| **Total** | | **100%** | **88.0%** |
+
+The report also records `analysisConfidence` (full, provenance-map, metadata-only, remote-only, or docs-only) and includes a degradation notice when source access was limited.
+
+---
+
 ## Output Architecture
 
 ### Per-Skill Output

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -249,11 +249,13 @@ When categories are skipped, their combined weight (36%) is redistributed propor
 ### Pass/Fail
 
 ```
-Default threshold: 80%
+threshold = custom_threshold OR 80% (default)
 
-score >= 80%  →  PASS  →  Recommend export-skill
-score <  80%  →  FAIL  →  Recommend update-skill
+score >= threshold  →  PASS  →  Recommend export-skill
+score <  threshold  →  FAIL  →  Recommend update-skill
 ```
+
+The default is 80%. You can override it by specifying a custom threshold when invoking the workflow (e.g., "test this skill with a 70% threshold").
 
 ### Gap Severities
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -139,6 +139,8 @@ SKF has 12 workflows. You trigger them by typing commands to [Ferris](../agents/
 
 **Key Steps:** Load skill → Detect mode → Coverage check → Coherence check → External validation (skill-check, tessl) → Score → Gap report
 
+**Scored Categories:** Export Coverage (36%), Signature Accuracy (22%), Type Coverage (14%), Coherence (18%), External Validation (10%). Default pass threshold: **80%**. Pass routes to Export Skill; fail routes to Update Skill with a gap report. See [Completeness Scoring](../how-it-works/#completeness-scoring) for the full formula and tier adjustments.
+
 **Agent:** Ferris (Audit mode)
 
 ---

--- a/src/workflows/brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/workflows/brief-skill/steps-c/step-01-gather-intent.md
@@ -96,7 +96,7 @@ Let's get started."
 Provide one of:
 - A **GitHub URL** (e.g., `https://github.com/org/repo`)
 - A **local path** (e.g., `/path/to/project`)
-- **Documentation URLs** for a docs-only skill (e.g., `https://docs.cognee.ai/`) — use this when no source code is available (SaaS, closed-source)
+- **Documentation URLs** for a docs-only skill (e.g., `https://docs.stripe.com/api`) — use this when no source code is available (SaaS, closed-source)
 
 **Target:**"
 


### PR DESCRIPTION
## Summary

Documents how the completeness score is computed (formula, per-section weights, tier adjustments) and clarifies that the threshold is overridable via workflow input rather than hardcoded. Also swaps a docs-only example URL in `brief-skill` for a real closed-source SaaS reference so the example is self-consistent.

## Changes

- **docs**: replace docs-only example URL with real closed-source SaaS reference
- **docs**: document completeness scoring formula, weights, and tier adjustments
- **docs**: clarify that completeness score threshold is overridable via workflow input

## Test plan

- [x] `npm test`
- [x] `npm run docs:build`
- [x] `npm run docs:validate-links`

_Second of five sequential PRs splitting up the accumulated work on `dev`._