### PR TITLE
docs: add Python and uv to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The skill told the agent the real function name, the real parameters, and that t
 
 ## Install
 
-Requires [Node.js](https://nodejs.org/) >= 22.
+Requires [Node.js](https://nodejs.org/) >= 22, [Python](https://www.python.org/) >= 3.10, and [uv](https://docs.astral.sh/uv/) (Python package runner).
 
 ```bash
 npx bmad-module-skill-forge install

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,6 +70,8 @@ The installer reads the installed version from your manifest and shows the delta
 | Tool                                                                   | Required For                                     | Install                                                |
 |------------------------------------------------------------------------|--------------------------------------------------|--------------------------------------------------------|
 | [Node.js](https://nodejs.org/) >= 22                                   | Installation, npx commands                       | <https://nodejs.org>                                   |
+| [Python](https://www.python.org/) >= 3.10                              | Deterministic scoring, validation, and utility scripts | <https://www.python.org>                               |
+| [uv](https://docs.astral.sh/uv/) (Python package runner)              | Running Python scripts with automatic dependency management | <https://docs.astral.sh/uv/getting-started/installation/> |
 | `gh` (GitHub CLI)                                                      | Required for Deep mode. Optional convenience in Quick/Forge/Forge+ for source access. | <https://cli.github.com>                               |
 | `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes                               | <https://ast-grep.github.io>                           |
 | `ast-grep` MCP server (recommended alongside CLI)                      | Forge + Deep modes                               | <https://github.com/ast-grep/ast-grep-mcp>             |
@@ -77,7 +79,7 @@ The installer reads the installed version from your manifest and shows the delta
 | `qmd` (local hybrid search engine for project files)                   | Deep mode                                        | <https://github.com/tobi/qmd>                          |
 | `SNYK_TOKEN` (Snyk API token — **Enterprise plan required**)           | Optional security scan                           | <https://docs.snyk.io/snyk-api/authentication-for-api> |
 
-Don't worry if you don't have all tools — SKF detects what's available and sets your tier automatically. Security scanning via Snyk is optional and requires an Enterprise plan; it does not affect your tier level.
+Node.js, Python, and uv are required for all tiers. Don't worry about the rest — SKF detects what's available and sets your tier automatically. Security scanning via Snyk is optional and requires an Enterprise plan; it does not affect your tier level.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ AI agents hallucinate API calls. They invent function names, guess parameter typ
 
 ## Quick Install
 
-Requires [Node.js](https://nodejs.org/) >= 22.
+Requires [Node.js](https://nodejs.org/) >= 22, [Python](https://www.python.org/) >= 3.10, and [uv](https://docs.astral.sh/uv/) (Python package runner).
 
 ```bash
 npx bmad-module-skill-forge install


### PR DESCRIPTION
## Summary

- Add Python >= 3.10 and uv (Python package runner) to prerequisite requirements in README.md, docs/index.md, and docs/getting-started.md
- Update getting-started prerequisites table with install links for both tools
- Clarify that Node.js, Python, and uv are required for all tiers

## Test plan

- [x] Markdown lint passes (171 files, 0 errors)
- [x] All tests pass (full suite via pre-commit hook)
- [x] Verify links point to correct destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)