### PR TITLE
feat: persistent workspace for remote source caching (Layer 0)

### DIFF
--- a/src/knowledge/ccc-bridge.md
+++ b/src/knowledge/ccc-bridge.md
@@ -98,14 +98,15 @@ The configured exclusion patterns are stored in `ccc_index.exclude_patterns` in 
 
 ### Deferred Discovery (Remote Sources)
 
-For remote repository sources (GitHub URLs), CCC cannot operate during step-02b because no local code exists yet. The ephemeral clone happens in step-03. To provide CCC pre-ranking for remote sources:
+For remote repository sources (GitHub URLs), CCC cannot operate during step-02b because no local code exists yet. The workspace clone or ephemeral clone happens in step-03. To provide CCC pre-ranking for remote sources:
 
 1. **step-02b:** Detects remote source, sets `{ccc_discovery: []}`, displays deferred message
-2. **step-03:** After ephemeral clone succeeds, detects the deferred scenario (`tools.ccc == true AND {ccc_discovery} is empty AND ephemeral_clone_active == true AND tier is Forge+/Deep`)
-3. **step-03:** Runs `cd {temp_path} && ccc init` on the ephemeral clone, then applies brief `exclude_patterns` (if present) to `{temp_path}/.cocoindex_code/settings.yml` before running `ccc index` (extended timeout or background mode, verified via `ccc status`). This prevents CCC from indexing files the brief explicitly excludes, keeping search results focused on in-scope source code and reducing indexing time for large repositories.
-4. **step-03:** Executes CCC search and populates `{ccc_discovery}` before AST extraction begins
+2. **step-03:** After source resolution succeeds, detects the deferred scenario (`tools.ccc == true AND {ccc_discovery} is empty AND remote_clone_path is set AND tier is Forge+/Deep`)
+3. **step-03 (workspace fast path):** If `{remote_clone_path}/.cocoindex_code/` already exists (persisted workspace index), skips init/index and uses `ccc search --refresh` — CCC daemon re-indexes only if files changed since last index. This is near-instant for unchanged repos.
+4. **step-03 (first-time path):** If no existing CCC index, runs `cd {remote_clone_path} && ccc init`, applies standard build/dependency exclusions (node_modules, dist, .git, vendor, etc.) to `settings.yml`, then runs `ccc index`. Brief-specific `include_patterns`/`exclude_patterns` are NOT written to `settings.yml` — the CCC index is general-purpose. Filtering happens at search result time.
+5. **step-03:** Executes CCC search and populates `{ccc_discovery}` before AST extraction begins
 
-The ephemeral clone index is not registered in `ccc_index_registry` — the clone is deleted after extraction and the CCC daemon's own GC handles orphaned indexes.
+For workspace repos, the CCC index persists at `{workspace_repo_path}/.cocoindex_code/` and is reused across forges, projects, and sessions. For ephemeral fallback clones, the index is not registered in `ccc_index_registry` — the clone is deleted after extraction.
 
 ### Relationship to QMD Registry
 
@@ -130,8 +131,8 @@ To prevent excessive daemon calls, workflow steps cap ccc queries:
 - Running ccc_bridge.ensure_index() without checking ccc_index.status first — unnecessary re-indexing
 - Passing ccc results directly to the extraction inventory — they are candidates, not extractions
 - Listing ccc as "unavailable" in reports for Quick/Forge tiers — ccc is a Forge+ capability, not something Quick/Forge tiers are missing
-- Indexing without configuring SKF exclusions — framework and output directories pollute search results
-- Indexing an ephemeral clone without applying brief `exclude_patterns` — excluded files pollute CCC search results and waste indexing time on large repositories
+- Indexing without configuring exclusions — for project root indexes, apply SKF exclusions (framework/output directories); for workspace repo indexes, apply standard build artifact exclusions (node_modules, dist, .git, etc.)
+- Writing brief-specific `exclude_patterns` to a workspace repo's `settings.yml` — workspace indexes are general-purpose and serve multiple briefs. Apply brief patterns at search result time, not index time. (Exception: ephemeral fallback clones are single-use, so brief exclusions may be applied to their `settings.yml` to reduce indexing time.)
 - Skipping CCC discovery for remote sources without deferring to step-03 — remote repos deserve the same pre-ranking as local sources
 
 ## Related Fragments

--- a/src/skf-create-skill/references/source-resolution-protocols.md
+++ b/src/skf-create-skill/references/source-resolution-protocols.md
@@ -170,7 +170,7 @@ Also store `source_ref` in context (from tag resolution above, or `HEAD` if no t
 
 **If `source_type: "docs-only"`:** skip this section — no source files exist to reconcile.
 
-After the source path is accessible (local path from step-01, or ephemeral clone from above), check whether the source contains a version identifier and reconcile it with `brief.version`. Look for the first matching version file in the resolved source path:
+After the source path is accessible (local path from step-01, or workspace/ephemeral clone from above), check whether the source contains a version identifier and reconcile it with `brief.version`. Look for the first matching version file in the resolved source path:
 
 - Python: `pyproject.toml` (`[project] version`), `setup.py` (`version=`), `__version__` in `__init__.py`
 - JavaScript/TypeScript: `package.json` (`"version"`). **Monorepo resolution:** When multiple `package.json` files exist (workspace root + packages), resolve version using this priority:

--- a/src/skf-create-skill/references/source-resolution-protocols.md
+++ b/src/skf-create-skill/references/source-resolution-protocols.md
@@ -40,119 +40,111 @@ If `source_repo` is a remote URL (GitHub URL or owner/repo format) AND tier is F
 
 1. **Check `git` availability:** Verify `git` is functional (`git --version`). If `git` is not available, skip to the fallback warning below.
 
-2. **Ephemeral shallow clone:** Clone the repository to a system temp path for AST access. Use `source_ref` from tag resolution (or `{branch}` for the default branch if no tag was resolved):
+2. **Compute workspace path:** Derive a persistent local path from the remote URL:
+
+   - **Parse the URL** to extract `{host}`, `{owner}`, `{repo}`:
+     - `https://github.com/facebook/react` or `https://github.com/facebook/react.git` → `github.com/facebook/react`
+     - `git@github.com:facebook/react.git` → `github.com/facebook/react`
+     - `facebook/react` (owner/repo shorthand) → `github.com/facebook/react`
+   - **Resolve workspace root:** Use environment variable `SKF_WORKSPACE` if set, otherwise `~/.skf/workspace/` (where `~` is the user's home directory on all platforms)
+   - **Workspace repo path:** `{workspace_root}/repos/{host}/{owner}/{repo}/`
+
+3. **Workspace check — resolve the source locally:**
+
+   **If `{workspace_repo_path}/.git/` exists (workspace hit):**
+
+   The repo was previously cloned into the workspace. Fetch updates and checkout the requested ref:
+
+   ```
+   git -C {workspace_repo_path} fetch origin {source_ref}
+   ```
+
+   Check if checkout is needed — skip if the requested ref is already checked out:
+
+   ```
+   current_head = git -C {workspace_repo_path} rev-parse HEAD
+   fetched_head = git -C {workspace_repo_path} rev-parse FETCH_HEAD
+   ```
+
+   If `current_head != fetched_head`:
+   ```
+   git -C {workspace_repo_path} -c advice.detachedHead=false checkout FETCH_HEAD
+   ```
+
+   If fetch or checkout fails, proceed to the **ephemeral fallback** (step 5).
+
+   **If `{workspace_repo_path}/.git/` does NOT exist (workspace miss):**
+
+   Clone the repository into the workspace for persistent reuse. Create the parent directory first (`{workspace_root}/repos/{host}/{owner}/`):
+
+   ```
+   mkdir -p "{workspace_root}/repos/{host}/{owner}/"
+   ```
+
+   Clone with the appropriate branch flag — `--branch` is only valid for real branch/tag names, not for `HEAD`:
+
+   ```
+   # If source_ref is a real branch or tag (not HEAD/null):
+   git clone --depth 1 --branch {source_ref} --single-branch {source_repo} {workspace_repo_path}
+
+   # If source_ref is HEAD or not set (default branch):
+   git clone --depth 1 --single-branch {source_repo} {workspace_repo_path}
+   ```
+
+   **Note:** No `--filter=blob:none` — blobs for the current tree are needed for indexing and the cost is amortized across all future forges. No sparse-checkout — a full checkout serves all consumers (different briefs with different include/exclude patterns) without configuration conflicts.
+
+   If this is the **first repo** in the workspace (workspace root was just created), print an informational message:
+
+   "Caching source at `{workspace_repo_path}` (saves time on re-forges). Override location with `SKF_WORKSPACE` env var."
+
+   If clone fails, proceed to the **ephemeral fallback** (step 5).
+
+4. **If workspace resolution succeeds:** Set `source_root = {workspace_repo_path}` — this updates the working source path for all subsequent operations (AST extraction, CCC indexing, artifact generation). Capture the source commit: `git -C {workspace_repo_path} rev-parse HEAD` — store as `source_commit` in context. Proceed with the **Forge/Deep Tier** extraction strategy below. Set context:
+   - `source_root = {workspace_repo_path}`
+   - `remote_clone_path = {workspace_repo_path}`
+   - `remote_clone_type = "workspace"`
+
+   **Scope filtering:** Since the workspace uses a full checkout (no sparse-checkout), apply `include_patterns` and `exclude_patterns` from the brief as **file-level filters** when building the extraction file list. Always-included root files (`pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `setup.py`, `setup.cfg`, `VERSION`) are exempt from pattern filtering.
+
+5. **Ephemeral fallback (on any workspace failure):**
+
+   If workspace clone or fetch fails for any reason (network error, auth failure, disk full, timeout), fall back to ephemeral cloning — the pre-workspace behavior that always works:
 
    ```
    temp_path = {system_temp}/skf-ephemeral-{skill-name}-{timestamp}/
+
+   # If source_ref is a real branch or tag (not HEAD/null):
    git clone --depth 1 --branch {source_ref} --single-branch --filter=blob:none {source_repo} {temp_path}
+
+   # If source_ref is HEAD or not set (default branch):
+   git clone --depth 1 --single-branch --filter=blob:none {source_repo} {temp_path}
    ```
 
-   **If `include_patterns` are NOT specified:**
+   If ephemeral clone succeeds: Set `source_root = {temp_path}`. Capture `source_commit`. Set context:
+   - `source_root = {temp_path}`
+   - `remote_clone_path = {temp_path}`
+   - `remote_clone_type = "ephemeral"`
 
-   ```
-   git clone --depth 1 --branch {source_ref} --single-branch --filter=blob:none {source_repo} {temp_path}
-   ```
+   Apply `include_patterns` and `exclude_patterns` from the brief as file-level filters when building the extraction file list.
 
-   **If `include_patterns` ARE specified**, use sparse-checkout to limit the clone scope:
-
-   ```
-   git clone --depth 1 --branch {branch} --single-branch --filter=blob:none --sparse {source_repo} {temp_path}
-   ```
-
-   **Mode selection:** Choose sparse-checkout mode based on whether `exclude_patterns` exist:
-
-   - **No `exclude_patterns`:** Use default **cone mode** (faster). Convert `include_patterns` to directory roots.
-   - **`exclude_patterns` present:** Use **`--no-cone` mode** which supports gitignore-style negation patterns (`!` prefix). This applies both include and exclude at the git level, avoiding unnecessary blob downloads.
-
-   **Cone mode (no exclude patterns):**
-
-   **IMPORTANT:** `git sparse-checkout set` expects **directories**, not glob patterns. Convert `include_patterns` before passing them:
-
-   **Classification rule:** A pattern is an **individual file** if it contains no glob characters (`*`, `?`, `[`) AND does not end with `/`. Everything else is a glob — strip it to its directory root (the path prefix before the first glob character or wildcard segment).
-
-   - Strip glob suffixes to directory roots (e.g., `src/core/**/*.py` → `src/core`, `src/api/*.ts` → `src/api`)
-   - Deduplicate the resulting directory list
-   - Individual files (e.g., `pyproject.toml`, `src/utils/helpers.py`) are kept as-is
-
-   **If only directory roots (no individual files):**
-
-   ```
-   git -C {temp_path} sparse-checkout set {converted_directory_roots}
-   ```
-
-   **If any individual files are present (or mixed):**
-
-   ```
-   git -C {temp_path} sparse-checkout set --skip-checks {converted_directory_roots} {individual_files}
-   ```
-
-   Example transformation:
-   ```
-   Brief include_patterns:        sparse-checkout args:
-   src/core/**/*.py          →    src/core          (directory root)
-   src/api/*.ts              →    src/api           (directory root)
-   examples/**/*.py          →    examples          (directory root)
-   pyproject.toml            →    pyproject.toml    (individual file, needs --skip-checks)
-   src/utils/helpers.py      →    src/utils/helpers.py (individual file, needs --skip-checks)
-   ```
-
-   **No-cone mode (exclude patterns present):**
-
-   When `exclude_patterns` exist, use `--no-cone` mode to pass both include and exclude patterns directly as gitignore-style rules:
-
-   1. Convert `include_patterns` to gitignore-style patterns. For patterns without glob characters (`*`, `?`, `[`) that do not end with `/`, apply the **file-detection heuristic**: if the last path segment contains a `.` (file extension), it is an **individual file** — prepend `/` and keep as-is (e.g., `packages/registry/registry.json` → `/packages/registry/registry.json`). If the last path segment has no extension, it is a **bare directory name** — append `/**` (e.g., `cognee` → `cognee/**`). Patterns that already contain glob characters are kept as-is (e.g., `cognee/**` → kept as-is).
-   2. Convert `exclude_patterns` to negation patterns by prepending `!`. Apply the same file-detection heuristic: individual files (last segment has `.` extension) get `!/` prefix only (e.g., `src/internal/config.json` → `!/src/internal/config.json`); bare directory names get `/**` appended (e.g., `cognee/tests` → `!cognee/tests/**`). Patterns with globs are kept as-is with `!` prefix (e.g., `cognee/tests/**` → `!cognee/tests/**`; `**/test_*` → `!**/test_*`).
-   3. **CRITICAL:** List all include patterns BEFORE negated exclude patterns — git processes patterns in order and a negation can only suppress a prior inclusion.
-   4. Pass to sparse-checkout — include patterns first, then negated exclude patterns:
-
-   ```
-   git -C {temp_path} sparse-checkout set --no-cone {include_gitignore_patterns} {negated_exclude_patterns}
-   ```
-
-   Example transformation:
-   ```
-   Brief include_patterns:          Brief exclude_patterns:
-   cognee/**                        cognee/tests/**
-   packages/registry/registry.json  cognee/alembic/**
-                                    **/test_*
-
-   sparse-checkout args (--no-cone):
-   'cognee/**' '/packages/registry/registry.json' '!cognee/tests/**' '!cognee/alembic/**' '!**/test_*'
-   ```
-
-   Note: `registry.json` is an individual file (has `.json` extension), so it gets `/` prefix instead of `/**` suffix.
-
-   **Note:** `--no-cone` mode is slower than cone mode for very large repositories but eliminates downloading excluded blobs entirely.
-
-   **Always-included root files:**
-
-   Regardless of `include_patterns`, always add these root-level version/manifest files to the sparse-checkout pattern list. These are needed for version reconciliation and must not require a fallback to `gh api`:
-
-   `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `setup.py`, `setup.cfg`, `VERSION`
-
-   In cone mode, always use the `--skip-checks` command form when adding these files — even if `include_patterns` resolved to only directory roots (which would normally use the form without `--skip-checks`). The command becomes: `git -C {temp_path} sparse-checkout set --skip-checks {directory_roots} pyproject.toml package.json Cargo.toml go.mod setup.py setup.cfg VERSION`. In no-cone mode, list them as explicit include patterns before any negation patterns. Do not flag them as extraneous inclusions during post-checkout filtering.
-
-   **Post-checkout filtering:**
-
-   After checkout, apply the original glob `include_patterns` as file-level filters when building the extraction file list — sparse-checkout gets the right directories, glob filtering narrows to the exact files. When `--no-cone` mode was used, most exclude filtering is already done at the git level, but apply `exclude_patterns` as a final pass to catch any edge cases where gitignore pattern matching diverges from the brief's glob semantics. Always-included root files (see above) are exempt from post-checkout filtering.
-
-3. **If clone succeeds:** Update the working source path to `{temp_path}` for all subsequent AST operations in this step. Capture the source commit: `git -C {temp_path} rev-parse HEAD` — store as `source_commit` in context. Proceed with the **Forge/Deep Tier** extraction strategy below. Mark `ephemeral_clone_active = true` for cleanup.
-
-4. **If clone fails (network error, auth failure, timeout):**
+6. **If all cloning fails (workspace AND ephemeral):**
 
    ⚠️ **Warn the user explicitly:**
 
-   "Ephemeral clone of `{source_repo}` failed: {error}. Degrading to source reading (T1-low) for this run. For T1 (AST-verified) confidence, clone the repository locally and update `source_repo` in your brief to the local path."
+   "Clone of `{source_repo}` failed: {error}. Degrading to source reading (T1-low) for this run. For T1 (AST-verified) confidence, clone the repository locally and update `source_repo` in your brief to the local path."
 
    Proceed with Quick tier extraction strategy below. Note the degradation reason in context for the evidence report.
 
-**Ephemeral clone cleanup:** After extraction is complete for all files in scope (whether successful or partially failed), before presenting the Gate 2 summary (Section 6), if `ephemeral_clone_active`:
+**Remote clone cleanup:** After extraction is complete for all files in scope (whether successful or partially failed), before presenting the Gate 2 summary (Section 6):
 
-1. **Reset working directory first:** Before deleting the clone, ensure the shell working directory is not inside the temp path. Run `cd {project-root}` using the **absolute path** captured at workflow start (not a relative path). This prevents `getcwd` errors when the temp directory is deleted while it is the shell's cwd — which happens if `cd {temp_path}` was used during CCC init or extraction operations.
-2. **Delete the clone:** `rm -rf {temp_path}`
-3. **Log:** "Ephemeral source clone cleaned up."
+- **If `remote_clone_type == "ephemeral"`:** Cleanup is required.
+  1. **Reset working directory first:** Run `cd {project-root}` using the **absolute path** captured at workflow start.
+  2. **Delete the clone:** `rm -rf {temp_path}`
+  3. **Log:** "Ephemeral source clone cleaned up."
 
-This ensures cleanup runs even if some extractions failed, as long as the step itself is still executing. **If any error halts the extraction step before Gate 2 is reached**, cleanup must still occur: reset cwd to `{project-root}` and attempt to delete `{temp_path}` before halting. Log the cleanup attempt regardless of success.
+  This ensures cleanup runs even if some extractions failed. If any error halts the step before Gate 2, cleanup must still occur.
+
+- **If `remote_clone_type == "workspace"`:** No cleanup. The workspace checkout persists for future forges.
 
 ---
 

--- a/src/skf-create-skill/references/tier-degradation-rules.md
+++ b/src/skf-create-skill/references/tier-degradation-rules.md
@@ -6,14 +6,15 @@ When `source_repo` is a remote URL (GitHub URL or owner/repo format) and the tie
 
 - **ast-grep requires local files** — it cannot operate on remote URLs
 
-**Ephemeral clone strategy (preferred):**
+**Workspace-first clone strategy (preferred):**
 
 1. Check `git` availability (`git --version`). `git` is effectively guaranteed at Deep tier (via `gh` dependency) but NOT guaranteed at Forge tier.
-2. If `git` is available: perform an ephemeral shallow clone to a system temp path (`{system_temp}/skf-ephemeral-{skill-name}-{timestamp}/`).
-3. For create-skill: use `--depth 1 --single-branch --filter=blob:none`; if `include_patterns` are specified, apply mode selection: if `exclude_patterns` are absent, use cone mode (convert include_patterns to directory roots; use `--skip-checks` for individual file paths); if `exclude_patterns` are present, use `--no-cone` mode (pass gitignore-style patterns with `!`-prefixed excludes — includes first, then negations). See source-resolution-protocols.md for the full conversion rules.
-4. For update-skill: use sparse-checkout with `--skip-checks` scoped to the changed files from the change manifest only (file paths require `--skip-checks`). No `--branch` flag — uses the remote default branch (must match the branch used during original create-skill run).
-5. If clone succeeds: use the local clone path for AST extraction. All results are T1 with `[AST:...]` citations.
-6. Cleanup: delete the temp directory after extraction inventory is built and all data is in context. The clone never persists beyond the extraction step.
+2. If `git` is available: check for an existing workspace checkout at `{workspace_root}/repos/{host}/{owner}/{repo}/`. If found, `git fetch` to update. If not found, clone into the workspace path with `--depth 1 --single-branch`. See `source-resolution-protocols.md` for the full workspace resolution algorithm.
+3. The workspace uses a full checkout (no sparse-checkout). Brief `include_patterns` and `exclude_patterns` are applied as file-level filters at extraction time, not at the git level. This allows a single workspace checkout to serve multiple briefs with different scope filters.
+4. For update-skill: `changed_files_from_manifest` scoping is applied as file-level filters at extraction time on the full workspace checkout.
+5. If workspace clone/fetch succeeds: use the workspace path for AST extraction. All results are T1 with `[AST:...]` citations.
+6. If workspace fails: fall back to ephemeral clone (`{system_temp}/skf-ephemeral-{skill-name}-{timestamp}/`). If ephemeral succeeds, use it. Ephemeral clone is deleted after extraction.
+7. Workspace checkouts persist across forges — CCC indexes, tool outputs, and the checkout itself are reused.
 
 **Fallback (clone fails or `git` unavailable):**
 

--- a/src/skf-create-skill/steps-c/step-01-load-brief.md
+++ b/src/skf-create-skill/steps-c/step-01-load-brief.md
@@ -83,7 +83,7 @@ Halt with specific error: "Brief validation failed: missing required field `{fie
 **If source_repo is a GitHub URL or owner/repo format:**
 - Verify repository exists via `gh_bridge.list_tree(owner, repo, branch)` — **Tool resolution:** `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` or direct file listing if local; see `knowledge/tool-resolution.md`
 - If branch not specified, detect default branch
-- Store resolved: owner, repo, branch, file tree — note: `source_root` for remote repos is set to the ephemeral clone path during extraction (step-03)
+- Store resolved: owner, repo, branch, file tree — note: `source_root` for remote repos is set to the workspace or ephemeral clone path during extraction (step-03)
 
 **If source_repo is a local path:**
 - Verify path exists and contains source files

--- a/src/skf-create-skill/steps-c/step-02b-ccc-discover.md
+++ b/src/skf-create-skill/steps-c/step-02b-ccc-discover.md
@@ -32,7 +32,7 @@ Check `tools.ccc` from forge-tier.yaml. If `tools.ccc` is false, set `{ccc_disco
 
 If `tools.ccc` is true, check the remote source guard **before** proceeding to section 2:
 
-**Remote source guard:** If `source_root` is a remote URL (GitHub repository not yet cloned locally — ephemeral clone happens in step-03), CCC cannot operate yet. Set `{ccc_discovery: []}` and display: "CCC discovery deferred — remote source will be indexed after ephemeral clone in step-03." Auto-proceed to section 5 (step completion). Step-03 will detect the deferred scenario and run CCC discovery on the ephemeral clone before AST extraction begins.
+**Remote source guard:** If `source_root` is a remote URL (GitHub repository — workspace clone or ephemeral clone happens in step-03), CCC cannot operate yet. Set `{ccc_discovery: []}` and display: "CCC discovery deferred — remote source will be indexed after clone in step-03." Auto-proceed to section 5 (step completion). Step-03 will detect the deferred scenario and run CCC discovery on the resolved clone (workspace or ephemeral) before AST extraction begins.
 
 If `source_root` is a local path, continue to section 2.
 

--- a/src/skf-create-skill/steps-c/step-03-extract.md
+++ b/src/skf-create-skill/steps-c/step-03-extract.md
@@ -46,29 +46,39 @@ Load `{sourceResolutionData}` completely. Follow the **Remote Source Resolution*
 If ALL of these conditions are true:
 - `tools.ccc` is true in forge-tier.yaml
 - `{ccc_discovery}` is empty (step-02b deferred because source was remote)
-- `ephemeral_clone_active` is true (clone succeeded in source resolution above)
+- `remote_clone_path` is set (source resolution succeeded for a remote URL)
 - Tier is Forge+ or Deep
 
-Then run CCC indexing and discovery on the ephemeral clone:
+Then run CCC indexing and discovery on the resolved clone (workspace or ephemeral):
 
-1. **Initialize index:** Run `cd {temp_path} && ccc init` — `ccc init` takes no positional arguments and initializes the index for the current working directory. If init fails, set `{ccc_discovery: []}` and continue — this is not an error.
+1. **Check existing index:** If `{remote_clone_path}/.cocoindex_code/` already exists (workspace repo with a persisted CCC index), skip steps 2-3 and proceed directly to step 4 using `ccc search --refresh` instead of plain `ccc search`. The `--refresh` flag tells CCC to re-index if files have changed since the last index, then search. This is the fast path for workspace repos that have been indexed before.
 
-2. **Apply brief exclusions:** If `brief.exclude_patterns` is present and non-empty, apply them to `{temp_path}/.cocoindex_code/settings.yml` before indexing:
-   1. Read `{temp_path}/.cocoindex_code/settings.yml` (created by `ccc init`)
-   2. For each pattern in `brief.exclude_patterns`: if the pattern is NOT already present in the `exclude_patterns` array, append it
-   3. Write the updated `settings.yml` back
-   This prevents CCC from indexing excluded files, keeping search results focused on in-scope source code. If `brief.exclude_patterns` is absent or empty, skip this step.
+2. **Initialize index (first time only):** Run `cd {remote_clone_path} && ccc init`. If init fails, set `{ccc_discovery: []}` and continue — this is not an error.
 
-3. **Index the clone:** Run `cd {temp_path} && ccc index` with an extended timeout or in background mode. Indexing can take several minutes on large codebases (1000+ files). Use `ccc status` to verify completion — check that `Chunks` and `Files` counts are non-zero. If indexing fails, set `{ccc_discovery: []}` and continue — this is not an error.
+   **Apply standard exclusions:** After `ccc init`, apply generic build/dependency exclusions to `{remote_clone_path}/.cocoindex_code/settings.yml`. These are standard artifact patterns, NOT SKF-specific paths (the workspace checkout is a source repo, not an SKF project):
+
+   ```
+   node_modules/, dist/, build/, .git/, vendor/, __pycache__/, .cache/, .next/, .nuxt/, target/, out/, .venv/, .tox/
+   ```
+
+   Read `settings.yml`, append any patterns not already present to the `exclude_patterns` array, write back.
+
+   **Note:** Brief-specific `include_patterns` and `exclude_patterns` are NOT written to `settings.yml`. The CCC index is general-purpose — it indexes everything (minus standard artifacts). Brief-specific filtering happens at search result time, not index time. This allows a single workspace CCC index to serve multiple briefs with different scope filters.
+
+3. **Index the clone:** Run `cd {remote_clone_path} && ccc index` with an extended timeout or in background mode. Indexing can take several minutes on large codebases (1000+ files). Use `ccc status` to verify completion — check that `Chunks` and `Files` counts are non-zero. If indexing fails, set `{ccc_discovery: []}` and continue — this is not an error.
 
 4. **Construct semantic query:** Build from brief data: `"{brief.name} {brief.scope}"`. Truncate to 80 characters — keep the full skill name and trim `brief.scope` from the end. If `brief.scope` is very short (< 10 chars), append terms from `brief.description` to fill the remaining space.
 
-5. **Execute search:** Run `ccc_bridge.search(query, temp_path, top_k=20)`:
-   - **Tool resolution:** Use `/ccc` skill search (Claude Code), ccc MCP server (Cursor), or `cd {temp_path} && ccc search --limit 20 "{query}"` (CLI). Note: `ccc search` operates on the index in the current working directory. See `knowledge/tool-resolution.md`.
+5. **Execute search:** Run `ccc_bridge.search(query, remote_clone_path, top_k=20)`:
+   - **If existing index was found (step 1):** Use `cd {remote_clone_path} && ccc search --refresh --limit 20 "{query}"` — this re-indexes if files changed, then searches.
+   - **Otherwise:** Use `cd {remote_clone_path} && ccc search --limit 20 "{query}"` after indexing in step 3.
+   - **Tool resolution:** Use `/ccc` skill search (Claude Code), ccc MCP server (Cursor), or CLI. Note: `ccc search` operates on the index in the current working directory. See `knowledge/tool-resolution.md`.
 
-6. **Store results:** If search succeeds, store as `{ccc_discovery: [{file, score, snippet}]}`. Display: "**CCC semantic discovery (post-clone): {N} relevant regions identified across {M} unique files.**"
+6. **Store results:** If search succeeds, store as `{ccc_discovery: [{file, score, snippet}]}`. Display: "**CCC semantic discovery: {N} relevant regions identified across {M} unique files.**"
 
-7. **On failure:** Set `{ccc_discovery: []}`. Display: "CCC post-clone discovery unavailable — proceeding with standard extraction." Do NOT halt.
+   If `remote_clone_type == "workspace"` and an existing index was reused, append: "(reused workspace index)"
+
+7. **On failure:** Set `{ccc_discovery: []}`. Display: "CCC discovery unavailable — proceeding with standard extraction." Do NOT halt.
 
 **CCC Discovery Integration (Forge+ and Deep with ccc only):**
 

--- a/src/skf-create-skill/steps-c/step-03-extract.md
+++ b/src/skf-create-skill/steps-c/step-03-extract.md
@@ -39,7 +39,7 @@ Build the filtered file list from the source tree resolved in step-01. Record th
 
 ### 2a. Resolve Source Access
 
-Load `{sourceResolutionData}` completely. Follow the **Remote Source Resolution** protocol for Forge/Deep tiers (ephemeral clone, sparse-checkout, cleanup), the **Source Commit Capture** protocol for all tiers, and the **Version Reconciliation** protocol for all tiers. This ensures source code is accessible regardless of which extraction path is taken below (standard, component-library, or docs-only).
+Load `{sourceResolutionData}` completely. Follow the **Remote Source Resolution** protocol for Forge/Deep tiers (workspace or ephemeral clone, cleanup), the **Source Commit Capture** protocol for all tiers, and the **Version Reconciliation** protocol for all tiers. This ensures source code is accessible regardless of which extraction path is taken below (standard, component-library, or docs-only).
 
 **Deferred CCC Discovery (Forge+ and Deep — remote sources only):**
 

--- a/src/skf-update-skill/references/remote-source-resolution.md
+++ b/src/skf-update-skill/references/remote-source-resolution.md
@@ -8,41 +8,76 @@ If `source_root` (from metadata.json) is a remote URL (GitHub URL or owner/repo 
 
 2. **Resolve source ref:** Read `source_ref` from the existing `metadata.json`. If the user provided a new `target_version`, resolve its tag first (using the Tag Resolution algorithm in `create-skill/references/source-resolution-protocols.md`).
 
-3. **Ephemeral sparse clone:** Clone only the changed files from the change manifest to a system temp path. Note: at this point in the flow, `{source_root}` is known to be a remote URL (the local-path case was already handled above).
+3. **Workspace check:** Compute the workspace path using the same algorithm as `create-skill/references/source-resolution-protocols.md` (parse URL → `{workspace_root}/repos/{host}/{owner}/{repo}/`).
 
+   **If workspace repo exists (`{workspace_repo_path}/.git/` present):**
+
+   Fetch and checkout the requested ref. For update-skill, `changed_files_from_manifest` scoping happens at extraction time via file-level filtering — the workspace has a full checkout.
+
+   ```
+   git -C {workspace_repo_path} fetch origin {source_ref}
+   ```
+
+   Check if checkout is needed — skip if the requested ref is already checked out:
+
+   ```
+   current_head = git -C {workspace_repo_path} rev-parse HEAD
+   fetched_head = git -C {workspace_repo_path} rev-parse FETCH_HEAD
+   ```
+
+   If `current_head != fetched_head`:
+   ```
+   git -C {workspace_repo_path} -c advice.detachedHead=false checkout FETCH_HEAD
+   ```
+
+   Set `remote_clone_path = {workspace_repo_path}`, `remote_clone_type = "workspace"`.
+
+   **If workspace repo does NOT exist:**
+
+   Clone into workspace. Create the parent directory first:
+
+   ```
+   mkdir -p "{workspace_root}/repos/{host}/{owner}/"
+   ```
+
+   Clone with the appropriate branch flag — `--branch` is only valid for real branch/tag names, not for `HEAD`:
+
+   ```
+   # If source_ref is a real branch or tag (not HEAD/null/"local"):
+   git clone --depth 1 --branch {source_ref} --single-branch {source_repo} {workspace_repo_path}
+
+   # If source_ref is HEAD or not set (default branch):
+   git clone --depth 1 --single-branch {source_repo} {workspace_repo_path}
+   ```
+
+   Set `remote_clone_path = {workspace_repo_path}`, `remote_clone_type = "workspace"`.
+
+   **On any workspace failure:** Fall back to ephemeral clone:
    ```
    temp_path = {system_temp}/skf-ephemeral-{skill-name}-{timestamp}/
+
+   # If source_ref is a real branch or tag (not HEAD/null/"local"):
+   git clone --depth 1 --branch {source_ref} --single-branch --filter=blob:none {source_root} {temp_path}
+
+   # If source_ref is HEAD or not set (default branch):
+   git clone --depth 1 --single-branch --filter=blob:none {source_root} {temp_path}
    ```
+   Set `remote_clone_path = {temp_path}`, `remote_clone_type = "ephemeral"`.
 
-   If `source_ref` exists and is not `HEAD`/null/`"local"`:
-   ```
-   git clone --depth 1 --branch {source_ref} --single-branch --filter=blob:none --sparse {source_root} {temp_path}
-   ```
+4. **If clone/fetch succeeds:** Set `source_root = {remote_clone_path}` — this updates the working source path for all subsequent operations. Apply `changed_files_from_manifest` as file-level filters at extraction time. Proceed with the **Forge tier** extraction strategy below.
 
-   If `source_ref` is `HEAD`/null/`"local"` (or absent):
-   ```
-   git clone --depth 1 --single-branch --filter=blob:none --sparse {source_root} {temp_path}
-   ```
+5. **If all cloning fails (workspace AND ephemeral):**
 
-   ```
-   git -C {temp_path} sparse-checkout set --skip-checks {changed_files_from_manifest}
-   ```
-
-   **Note:** `--skip-checks` is required because `changed_files_from_manifest` contains individual file paths (e.g., `src/core/parser.py`), not directories. Without this flag, `git sparse-checkout set` rejects non-directory entries.
-
-   When `source_ref` is a tag (e.g., `v0.5.0`), the clone targets that specific tag to ensure update-skill extracts from the same source version as the original create-skill run. When `source_ref` is `HEAD`, null, or `"local"`, no `--branch` flag is used — the clone targets the remote's default branch. This scopes the clone to only the files identified in step-02's change manifest, avoiding a full repository download.
-
-4. **If clone succeeds:** Update the working source path to `{temp_path}` for all subsequent AST operations in this step. Proceed with the **Forge tier** extraction strategy below. Mark `ephemeral_clone_active = true` for cleanup.
-
-5. **If clone fails (network error, auth failure, timeout):**
-
-   Warning message: "Ephemeral clone of `{source_root}` failed: {error}. Degrading to source reading (T1-low) for this run. For T1 (AST-verified) confidence, clone the repository locally and re-run [CS] Create Skill with the local path, then re-run this update."
+   Warning message: "Clone of `{source_root}` failed: {error}. Degrading to source reading (T1-low) for this run. For T1 (AST-verified) confidence, clone the repository locally and re-run [CS] Create Skill with the local path, then re-run this update."
 
    Override the extraction strategy to Quick tier for this run. Note the degradation reason in context for the evidence report.
 
-## Ephemeral Clone Cleanup
+## Remote Clone Cleanup
 
-After extraction is complete for all files in scope (whether successful or partially failed), before presenting the extraction summary, if `ephemeral_clone_active`, delete the `{temp_path}` directory. Log: "Ephemeral source clone cleaned up." This ensures cleanup runs even if some extractions failed, as long as the step itself is still executing.
+After extraction is complete for all files in scope (whether successful or partially failed), before presenting the extraction summary:
+
+- **If `remote_clone_type == "ephemeral"`:** Reset the working directory first (`cd {project-root}` using the absolute path captured at workflow start), then delete the `{temp_path}` directory. Log: "Ephemeral source clone cleaned up." This ensures cleanup runs even if some extractions failed.
+- **If `remote_clone_type == "workspace"`:** No cleanup. The workspace checkout persists for future forges and updates.
 
 ## Version Reconciliation
 

--- a/src/skf-update-skill/steps-c/step-03-re-extract.md
+++ b/src/skf-update-skill/steps-c/step-03-re-extract.md
@@ -39,7 +39,7 @@ Perform tier-aware extraction on only the changed files identified in step 02, p
 
 **Remote Source Resolution (Forge/Deep only):**
 
-**MCP source access (ordered fallback):** When `source_repo` is set in metadata.json, try each MCP tool in order to fetch only the changed files from the change manifest. This avoids ephemeral clone overhead entirely. Tools are ordered by data freshness — gh API returns live GitHub content and is preferred for update-skill where current file versions are required. zread and deepwiki depend on manual indexing and may return stale data if indexes haven't been refreshed since the changes being extracted.
+**MCP source access (ordered fallback):** When `source_repo` is set in metadata.json, try each MCP tool in order to fetch only the changed files from the change manifest. This avoids clone overhead entirely. Tools are ordered by data freshness — gh API returns live GitHub content and is preferred for update-skill where current file versions are required. zread and deepwiki depend on manual indexing and may return stale data if indexes haven't been refreshed since the changes being extracted.
 
 1. **gh API** — `gh api repos/{owner}/{repo}/contents/{path}` for raw file content
    - If accessible: fetch file content (base64-decoded), always current
@@ -55,7 +55,7 @@ Perform tier-aware extraction on only the changed files identified in step 02, p
 
 **Confidence labeling:** MCP-fetched content written to a temp file and analyzed with ast-grep → T1. MCP-fetched content analyzed with pattern matching (AST unavailable) → T1-low.
 
-**If all MCP tools fail for this repo:** Fall back to ephemeral clone — load and follow `{remoteSourceResolutionData}` for clone setup, version reconciliation, and AST tool unavailability handling.
+**If all MCP tools fail for this repo:** Fall back to workspace or ephemeral clone — load and follow `{remoteSourceResolutionData}` for clone setup, version reconciliation, and AST tool unavailability handling.
 
 **If all approaches fail (MCP + ephemeral clone):** Degrade to provenance-map-only analysis (State 2, T1 confidence from compilation-time data). Warn user: "Source access failed for {source_repo}. Analysis limited to provenance-map baseline."
 
@@ -118,7 +118,7 @@ This helps the merge step (section 4) prioritize which changes are most likely t
 
 CCC failures: skip ranking silently, all changes treated equally.
 
-**Note on remote sources:** If `source_root` is an ephemeral clone (remote source), the clone path is not indexed by CCC. The search will return empty results and semantic ranking will be skipped. This is expected — deferred CCC indexing is implemented in create-skill step-03 but not in update-skill. All changes are treated equally for remote sources.
+**Note on remote sources:** If `source_root` is a workspace clone, the CCC index may already exist from a prior forge and can be reused via `ccc search --refresh`. If the source is an ephemeral fallback clone, the clone path is not indexed by CCC — the search will return empty results and semantic ranking will be skipped. Deferred CCC indexing is implemented in create-skill step-03 but not in update-skill. All changes are treated equally for ephemeral remote sources.
 
 **IF `tools.ccc` is false:** Skip this section silently.
 

--- a/src/skf-update-skill/steps-c/step-03-re-extract.md
+++ b/src/skf-update-skill/steps-c/step-03-re-extract.md
@@ -57,7 +57,7 @@ Perform tier-aware extraction on only the changed files identified in step 02, p
 
 **If all MCP tools fail for this repo:** Fall back to workspace or ephemeral clone — load and follow `{remoteSourceResolutionData}` for clone setup, version reconciliation, and AST tool unavailability handling.
 
-**If all approaches fail (MCP + ephemeral clone):** Degrade to provenance-map-only analysis (State 2, T1 confidence from compilation-time data). Warn user: "Source access failed for {source_repo}. Analysis limited to provenance-map baseline."
+**If all approaches fail (MCP + workspace/ephemeral clone):** Degrade to provenance-map-only analysis (State 2, T1 confidence from compilation-time data). Warn user: "Source access failed for {source_repo}. Analysis limited to provenance-map baseline."
 
 **Quick tier (text pattern matching):**
 - Extract function/class/type names via regex patterns


### PR DESCRIPTION
## Summary
- **Persistent workspace**: Remote repos are now cloned to `~/.skf/workspace/repos/{host}/{owner}/{repo}/` and reused across forges, projects, and sessions — eliminating redundant clones
- **CCC index reuse**: Workspace repos retain their `.cocoindex_code/` index; subsequent forges use `ccc search --refresh` for near-instant semantic discovery
- **Ephemeral fallback**: If workspace clone/fetch fails, falls back to the previous ephemeral clone behavior transparently
- **Consistency fixes**: Updated 3 stale references to ephemeral-only clone terminology post-workspace refactor

## Test plan
- [x] Verify existing local-path source resolution is unaffected (no workspace logic triggers)
- [x] Test remote source forge creates workspace directory at expected path
- [x] Test re-forge of same remote source reuses workspace checkout (fetch-only, no re-clone)
- [x] Test CCC index persistence — second forge should skip init/index and use `--refresh`
- [x] Test ephemeral fallback by simulating workspace failure (e.g., disk full, permissions)
- [x] Grep for any remaining `ephemeral_clone_active` or stale `sparse-checkout` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)