### PR TITLE
Release audit fixes: workflow issues, publish gating, npm packaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ A clear and concise description of what the bug is.
 What lead to the bug and can it be reliable recreated - if so with what steps.
 
 **PR**
-If you have an idea to fix and would like to contribute, please indicate here you are working on a fix, or link to a proposed PR to fix the issue. Please review the contribution.md - contributions are always welcome!
+If you have an idea to fix and would like to contribute, please indicate here you are working on a fix, or link to a proposed PR to fix the issue. Please review the [CONTRIBUTING.md](../../CONTRIBUTING.md) - contributions are always welcome!
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Have you discussed this in Discord first?**
+We encourage discussing feature ideas in the [#suggestions-feedback](https://discord.gg/gk8jAdXWmj) channel before opening an issue.
+
+**Is your feature request related to a problem?**
+A clear and concise description of what the problem is. Example: "I'm always frustrated when..."
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Which workflows or components does this affect?**
+List the SKF workflows (e.g., Create Skill, Test Skill) or components (CLI, knowledge base) this would impact.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - "docs/**"
-      - "src/modules/*/docs/**"
       - "website/**"
       - "tools/build-docs.js"
       - ".github/workflows/docs.yaml"

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -39,6 +39,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
       - name: Run tests and validation
         run: |
           npm test
@@ -61,13 +66,9 @@ jobs:
           echo "new_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
           echo "previous_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
-      - name: Update installer package.json
+      - name: Update marketplace.json version
         run: |
-          sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.new_version }}"/' tools/installer/package.json
-
-      # TODO: Re-enable web bundles once tools/cli/bundlers/ is restored
-      # - name: Generate web bundles
-      #   run: npm run bundle
+          sed -i 's/"version": "[^"]*"/"version": "${{ steps.version.outputs.new_version }}"/' .claude-plugin/marketplace.json
 
       - name: Commit version bump
         run: |
@@ -87,45 +88,40 @@ jobs:
           OTHERS=$(echo "$COMMITS" | grep -v -E "^- (feat|Feature|fix|Fix|chore|Chore|release:|Release:)" || true)
 
           # Build release notes
-          cat > release_notes.md << 'EOF'
-          ## 🚀 What's New in v${{ steps.version.outputs.new_version }}
+          echo "## What's New" > release_notes.md
+          echo "" >> release_notes.md
 
-          EOF
-
-          if [ ! -z "$FEATURES" ]; then
-            echo "### ✨ New Features" >> release_notes.md
+          if [ -n "$FEATURES" ]; then
+            echo "### New Features" >> release_notes.md
             echo "$FEATURES" >> release_notes.md
             echo "" >> release_notes.md
           fi
 
-          if [ ! -z "$FIXES" ]; then
-            echo "### 🐛 Bug Fixes" >> release_notes.md
+          if [ -n "$FIXES" ]; then
+            echo "### Bug Fixes" >> release_notes.md
             echo "$FIXES" >> release_notes.md
             echo "" >> release_notes.md
           fi
 
-          if [ ! -z "$OTHERS" ]; then
-            echo "### 📦 Other Changes" >> release_notes.md
+          if [ -n "$OTHERS" ]; then
+            echo "### Other Changes" >> release_notes.md
             echo "$OTHERS" >> release_notes.md
             echo "" >> release_notes.md
           fi
 
-          if [ ! -z "$CHORES" ]; then
-            echo "### 🔧 Maintenance" >> release_notes.md
+          if [ -n "$CHORES" ]; then
+            echo "### Maintenance" >> release_notes.md
             echo "$CHORES" >> release_notes.md
             echo "" >> release_notes.md
           fi
 
-          cat >> release_notes.md << 'EOF'
-
-          ## 📦 Installation
-
-          ```bash
-          npx bmad-module-skill-forge install
-          ```
-
-          **Full Changelog**: https://github.com/armelhbobdad/bmad-module-skill-forge/compare/${{ steps.version.outputs.previous_tag }}...v${{ steps.version.outputs.new_version }}
-          EOF
+          echo "## Installation" >> release_notes.md
+          echo "" >> release_notes.md
+          echo '```bash' >> release_notes.md
+          echo "npx bmad-module-skill-forge install" >> release_notes.md
+          echo '```' >> release_notes.md
+          echo "" >> release_notes.md
+          echo "**Full Changelog**: https://github.com/armelhbobdad/bmad-module-skill-forge/compare/${{ steps.version.outputs.previous_tag }}...v${{ steps.version.outputs.new_version }}" >> release_notes.md
 
           # Output for GitHub Actions
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
@@ -156,9 +152,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.new_version }}"
-          if [[ "$VERSION" == *"alpha"* ]] || [[ "$VERSION" == *"beta"* ]]; then
-            echo "Publishing prerelease version with --tag alpha"
+          if [[ "$VERSION" == *"alpha"* ]]; then
+            echo "Publishing alpha prerelease with --tag alpha"
             npm publish --tag alpha
+          elif [[ "$VERSION" == *"beta"* ]]; then
+            echo "Publishing beta prerelease with --tag beta"
+            npm publish --tag beta
           else
             echo "Publishing stable version with --tag latest"
             npm publish --tag latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,11 +22,16 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Run format check
-        run: npm run format:check
+      - name: Run full test suite
+        run: npm test
 
       - name: Publish to NPM
         run: npm publish --provenance

--- a/.npmignore
+++ b/.npmignore
@@ -33,6 +33,17 @@ prettier.config.mjs
 .husky/
 .npmrc
 
+# Quality reports and build output
+skills/
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Dev-only validation tools (not needed at runtime)
+tools/validate-skills.js
+tools/validate-file-refs.js
+
 # Output and temp
 temp/
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,51 @@
 # Roadmap
 
-Future work planned for Skill Forge. Items listed here are not yet scoped or scheduled.
+Future work planned for Skill Forge. Items here are directional, not scheduled. Layered items ship when their trigger conditions are met, not on a timeline.
 
-## Planned
+**North-star principle for workspace/infrastructure work:** *The workspace is an optimization, never a gate.* Every failure path degrades gracefully to the existing ephemeral behavior.
 
-- **Spec sync mechanism** — pending agentskills.io endpoint. SKF currently version-pins to an agentskills.io spec at release time; once upstream publishes a canonical spec endpoint, SKF will add a sync path (likely a maintainer-side release script, not a runtime CLI flag).
+---
+
+## Persistent Workspace (`~/.skf/workspace/`)
+
+A shared, system-level cache of git clones and their tool indexes, replacing per-forge ephemeral cloning. Designed as four layers that ship independently when real usage proves the need.
+
+### Layer 0 — Core Workspace *(current)*
+
+Persistent clones + CCC indexes preserved across forges, projects, and sessions. Zero new dependencies. Lazy creation on first remote forge. Always falls back to ephemeral on any failure.
+
+### Layer 1 — Registry Intelligence *(triggered)*
+
+Ship when real users cache 5+ repos, disk complaints arrive, concurrent forge failures surface, or users start asking "what's in my workspace?" Scope: `registry.json` with `schema_version`, staleness thresholds, disk budget + LRU eviction, PID-based locking, CLI (`skf workspace list/remove/clean/migrate`), cross-platform hardening (Windows long paths, case-sensitivity detection, file-lock retry), and recovery paths (self-healing registry, git health check, auth-failure degradation).
+
+### Layer 2 — Tool Tenants *(triggered)*
+
+Ship when Layer 1 is stable and a target tool meets the **Tool Maturity Gate**: versioned schema, 6+ months of releases, no critical security fixes in the last 3 months, deletion handling in incremental updates, and Linux/macOS/Windows support. Tools persist outputs inside repo checkouts (`.cocoindex_code/`, `graphify-out/`, etc.); the registry's extensible `tools` section tracks per-tool state without tool-specific code.
+
+### Layer 3 — Cross-Repo Intelligence *(triggered)*
+
+Ship when Layer 2 graphify (or alternative) integration is proven AND a graph-merging API exists. Scope: merge per-repo graphs into a unified stack graph, Leiden community detection across repos for architectural layers, forge intelligence prompts ("you've forged N skills from this repo, here are unexplored communities"), stack-skill drift detection at the relationship level, and workspace-level QMD collections.
+
+---
+
+## Graphify Upstream Contribution
+
+Partner with [safishamsi/graphify](https://github.com/safishamsi/graphify) (MIT, 16.6k stars) to mature it into a viable Layer 2 tenant. SKF commits to contributing upstream rather than forking.
+
+**P0 blockers for Layer 2 integration:**
+- Schema versioning for `graph.json` (currently unversioned)
+- File deletion handling in `--update` (ghost nodes persist after deletes)
+- Full Windows support across build/query/watch/MCP server
+
+**P1 blockers for Layer 3 integration:**
+- Graph merging API (CLI or Python) for cross-repo unified graphs
+- Stable, documented Python API for programmatic consumption
+- Shallow-clone compatibility validation
+
+Backup candidates if graphify stalls: GitNexus (watching for MIT relicense), CodeGraphContext (MIT, 2.2k stars), CodeGraph-Rust.
+
+---
+
+## Spec Sync Mechanism
+
+Pending an upstream agentskills.io spec endpoint. SKF currently version-pins to an agentskills.io spec at release time; once upstream publishes a canonical endpoint, SKF will add a sync path — likely a maintainer-side release script, not a runtime CLI flag.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,7 @@
+# Roadmap
+
+Future work planned for Skill Forge. Items listed here are not yet scoped or scheduled.
+
+## Planned
+
+- **Spec sync mechanism** — pending agentskills.io endpoint. SKF currently version-pins to an agentskills.io spec at release time; once upstream publishes a canonical spec endpoint, SKF will add a sync path (likely a maintainer-side release script, not a runtime CLI flag).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -523,7 +523,7 @@ Provenance maps enable verification: an `official` skill's provenance must trace
 | **Hub-and-spoke cross-knowledge** | Each skill covers one source repository. Stack skills compose cross-library integration patterns in `references/integrations/`, citing each library's own skill. |
 | **Stack skill = compositional** | SKILL.md is the integration layer. references/ contains per-library + integration pairs. Partial regeneration on dependency updates. |
 | **Snippet updates only at export** | Create/update write a draft `context-snippet.md` to `skills/`. Export regenerates the final `context-snippet.md` and publishes it to the platform context file (CLAUDE.md/AGENTS.md/.cursorrules). No managed-section updates in draft workflows. |
-| **Bundle spec with opt-in update** | Offline-capable. Run `@Ferris SF --update-spec` to fetch the latest agentskills.io spec on demand. |
+| **Bundle spec, version-pin at release** | Offline-capable. SKF ships with a vendored agentskills.io spec pinned at release time; spec drift is a maintainer concern handled at SKF release, not a runtime concern for users. |
 
 ---
 

--- a/src/forger/forge-tier.yaml
+++ b/src/forger/forge-tier.yaml
@@ -21,6 +21,8 @@ ccc_index:
   last_indexed: ~
   status: "none"
   staleness_threshold_hours: 24
+  file_count: ~
+  exclude_patterns: []
 
 # CCC index registry (tracks which source paths have been indexed for skill workflows)
 ccc_index_registry: []

--- a/src/shared/health-check.md
+++ b/src/shared/health-check.md
@@ -8,6 +8,8 @@ localFallbackFolder: '{output_folder}/improvement-queue'
 
 # Health Check: Workflow Self-Improvement
 
+> **Path convention:** This file is referenced as `shared/health-check.md` from workflow step frontmatter. All `shared/` paths resolve relative to the SKF module root (`_bmad/skf/` when installed, `src/` during development), not relative to the calling step file.
+
 ## STEP GOAL:
 
 Reflect on the workflow that just completed. If real friction, bugs, or gaps were encountered in the SKF workflow instructions, capture them as structured findings for the user to review and optionally submit as GitHub issues.

--- a/src/skf-create-skill/SKILL.md
+++ b/src/skf-create-skill/SKILL.md
@@ -53,7 +53,7 @@ These rules apply to every step in this workflow:
 ## On Activation
 
 1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
-   - `project_name`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `sidecar_path`, `skills_output_folder`, `forge_data_folder`
+   - `output_folder`, `user_name`, `communication_language`, `document_output_language`, `sidecar_path`, `skills_output_folder`, `forge_data_folder`
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 

--- a/src/skf-create-skill/assets/skill-sections.md
+++ b/src/skf-create-skill/assets/skill-sections.md
@@ -344,9 +344,19 @@ Each reference file includes:
 - Confidence: T1={n}, T1-low={n}, T2={n}, T3={n}
 
 ## Validation Results
-- Schema: {pass/fail}
+- Schema: {pass/fail} (quality score: {score}/100)
 - Frontmatter: {pass/fail}
+- Body: {pass/fail} {split-body applied if applicable}
+- Security: {pass/warn/skipped}
+- Content Quality (tessl): {pass/warn/skipped} (score: {score}%)
+- Metadata: {pass/fail}
 
-## Warnings
+## Quality Score Breakdown
+- Frontmatter (30%): {score} | Description (30%): {score} | Body (20%): {score} | Links (10%): {score} | File (10%): {score}
+
+## Auto-Fixed Issues
+- {list of issues automatically corrected by --fix}
+
+## Remaining Warnings
 - {any warnings from extraction or validation}
 ```

--- a/src/skf-create-skill/references/source-resolution-protocols.md
+++ b/src/skf-create-skill/references/source-resolution-protocols.md
@@ -32,11 +32,13 @@ Proceed with local files as-is. Set `source_ref` to `"local"`.
 
 ---
 
-## Remote Source Resolution (Forge/Deep only)
+## Remote Source Resolution
+
+**Note:** Quick-tier remote sources do not use the workspace/clone protocol described below. Quick tier accesses remote files via the `gh_bridge.read_file` path described in step-03 section 4.
 
 If `source_repo` is a local path: proceed with the tier-appropriate strategy as normal.
 
-If `source_repo` is a remote URL (GitHub URL or owner/repo format) AND tier is Forge or Deep:
+If `source_repo` is a remote URL (GitHub URL or owner/repo format) AND tier is Forge, Forge+, or Deep:
 
 1. **Check `git` availability:** Verify `git` is functional (`git --version`). If `git` is not available, skip to the fallback warning below.
 

--- a/src/skf-create-skill/steps-c/step-01-load-brief.md
+++ b/src/skf-create-skill/steps-c/step-01-load-brief.md
@@ -58,13 +58,14 @@ Check that the loaded skill-brief.yaml contains required fields:
 - `version` — source version to compile against
 - `source_repo` — GitHub owner/repo or local path (**optional when `source_type: "docs-only"`**)
 - `language` — primary source language
-- `scope` — what to extract (e.g., "all public exports", specific modules)
+- `scope` — what to extract. Accepts either a string (simple scope description, e.g., "all public exports") or an object with sub-fields: `type` (e.g., `"component-library"`), `include`, `exclude`, `notes`, and optionally `demo_patterns`, `registry_path`, `ui_variants` for component libraries
 
 **Optional fields:**
 - `source_type` — `"source"` (default) or `"docs-only"` (external documentation only)
 - `doc_urls` — array of `{url, label}` documentation URLs (required when `source_type: "docs-only"`)
 - `source_branch` — branch to use (default: main/master)
 - `source_authority` — official/community/internal (default: community; forced to `community` for docs-only)
+- `target_version` — specific version to compile against (triggers tag resolution for remote repos; see source-resolution-protocols.md)
 - `include_patterns` — file glob patterns to include
 - `exclude_patterns` — file glob patterns to exclude
 - `description` — human description of the skill
@@ -83,7 +84,7 @@ Halt with specific error: "Brief validation failed: missing required field `{fie
 **If source_repo is a GitHub URL or owner/repo format:**
 - Verify repository exists via `gh_bridge.list_tree(owner, repo, branch)` — **Tool resolution:** `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` or direct file listing if local; see `knowledge/tool-resolution.md`
 - If branch not specified, detect default branch
-- Store resolved: owner, repo, branch, file tree — note: `source_root` for remote repos is set to the workspace or ephemeral clone path during extraction (step-03)
+- Store resolved: owner, repo, branch, file tree — note: `source_root` for remote repos is initially set to the remote URL (for detection and API access purposes) and then updated to the local workspace/clone path during step-03 source resolution
 
 **If source_repo is a local path:**
 - Verify path exists and contains source files
@@ -117,7 +118,7 @@ Where tier_description follows positive capability framing:
 
 **Auto-proceed step — no user interaction.**
 
-After initialization is complete and all data is loaded, immediately load, read entire file, then execute `{nextStepFile}`.
+After initialization is complete and all data is loaded (including `target_version` if present in the brief), immediately load, read entire file, then execute `{nextStepFile}`.
 
 #### EXECUTION RULES:
 

--- a/src/skf-create-skill/steps-c/step-03-extract.md
+++ b/src/skf-create-skill/steps-c/step-03-extract.md
@@ -51,7 +51,7 @@ If ALL of these conditions are true:
 
 Then run CCC indexing and discovery on the resolved clone (workspace or ephemeral):
 
-1. **Check existing index:** If `{remote_clone_path}/.cocoindex_code/` already exists (workspace repo with a persisted CCC index), skip steps 2-3 and proceed directly to step 4 using `ccc search --refresh` instead of plain `ccc search`. The `--refresh` flag tells CCC to re-index if files have changed since the last index, then search. This is the fast path for workspace repos that have been indexed before.
+1. **Check existing index:** If `{remote_clone_path}/.cocoindex_code/` already exists (workspace repo with a persisted CCC index), skip steps 2-3 and proceed directly to step 4 using `ccc search --refresh` instead of plain `ccc search`. The `--refresh` flag tells CCC to re-index if files have changed since the last index, then search. This is the fast path for workspace repos that have been indexed before. **Note:** If `--refresh` is not supported by the installed ccc version, omit the flag — ccc will use the existing index.
 
 2. **Initialize index (first time only):** Run `cd {remote_clone_path} && ccc init`. If init fails, set `{ccc_discovery: []}` and continue — this is not an error.
 
@@ -70,7 +70,7 @@ Then run CCC indexing and discovery on the resolved clone (workspace or ephemera
 4. **Construct semantic query:** Build from brief data: `"{brief.name} {brief.scope}"`. Truncate to 80 characters — keep the full skill name and trim `brief.scope` from the end. If `brief.scope` is very short (< 10 chars), append terms from `brief.description` to fill the remaining space.
 
 5. **Execute search:** Run `ccc_bridge.search(query, remote_clone_path, top_k=20)`:
-   - **If existing index was found (step 1):** Use `cd {remote_clone_path} && ccc search --refresh --limit 20 "{query}"` — this re-indexes if files changed, then searches.
+   - **If existing index was found (step 1):** Use `cd {remote_clone_path} && ccc search --refresh --limit 20 "{query}"` — this re-indexes if files changed, then searches. If `--refresh` is not supported by the installed ccc version, omit the flag — ccc will use the existing index.
    - **Otherwise:** Use `cd {remote_clone_path} && ccc search --limit 20 "{query}"` after indexing in step 3.
    - **Tool resolution:** Use `/ccc` skill search (Claude Code), ccc MCP server (Cursor), or CLI. Note: `ccc search` operates on the index in the current working directory. See `knowledge/tool-resolution.md`.
 
@@ -90,6 +90,8 @@ If `{ccc_discovery}` is in context and non-empty (populated by step-02b or defer
 If `{ccc_discovery}` is empty or not in context: proceed with existing file ordering (no change to current behavior).
 
 ### 2b. Component Library Delegation
+
+**Skip this section if `source_type` is `"docs-only"` — docs-only skills do not use component extraction.**
 
 **If `scope.type: "component-library"` in the brief:**
 
@@ -210,6 +212,8 @@ Compile all extracted data into a structured inventory:
 - Integration point suggestions
 
 ### 6. Present Extraction Summary (Gate 2)
+
+**Docs-only note:** If `docs_only_mode` is active (`extraction_mode: "docs-only"`), display a brief note explaining that T3 content will be added by the doc-fetcher step (step-03c), then auto-proceed past this gate. Example: "Docs-only mode: extraction inventory is empty. Documentation content will be fetched from `doc_urls` in step-03c. Auto-proceeding."
 
 Display the extraction findings for user confirmation:
 

--- a/src/skf-create-skill/steps-c/step-03c-fetch-docs.md
+++ b/src/skf-create-skill/steps-c/step-03c-fetch-docs.md
@@ -109,6 +109,8 @@ Parse the successfully fetched markdown for:
 
 **Conflict rule:** T3 items NEVER override existing T1, T1-low, or T2 items for the same export. When an export already has a higher-confidence entry, the T3 item is discarded. T3 has the lowest priority.
 
+**Edge case — T1-zero supplemental mode:** If T1 extraction produced zero results and `doc_urls` are present in supplemental mode, T3 items should be used as the primary inventory since no T1 data exists to conflict with.
+
 **Aggregate totals for reporting:**
 - URLs fetched successfully vs. total
 - URLs that failed

--- a/src/skf-create-skill/steps-c/step-03d-component-extraction.md
+++ b/src/skf-create-skill/steps-c/step-03d-component-extraction.md
@@ -23,6 +23,8 @@ When `scope.type: "component-library"`, perform specialized extraction that trea
 
 Before extraction, identify and exclude demo/example files to avoid inflating export counts.
 
+**Note:** For remote sources, the file list from step-03 section 2 was built from the API tree. When scanning for demo directories, scan the local workspace/clone path (`remote_clone_path`) instead of the API-derived file list.
+
 **If `scope.demo_patterns` is specified in the brief:** Use those patterns directly.
 
 **Otherwise, auto-detect:**

--- a/src/skf-create-skill/steps-c/step-06-validate.md
+++ b/src/skf-create-skill/steps-c/step-06-validate.md
@@ -93,7 +93,7 @@ Then re-validate: `npx skill-check check <staging-skill-dir> --format json --no-
 npx skill-check check <staging-skill-dir> --format json
 ```
 
-(Security scan enabled by default when `--no-security-scan` omitted. The scan uses [Snyk Agent Scan](https://github.com/snyk/agent-scan) to check for prompt injection risks, sensitive data exposure, and unsafe tool permissions.)
+(Security scan enabled by default when `--no-security-scan` omitted. The scan uses [Snyk](https://docs.snyk.io/) to check for prompt injection risks, sensitive data exposure, and unsafe tool permissions.)
 
 Record any security warnings in evidence-report. Security findings are advisory — they do not block artifact generation. If the full validation re-run produces a different quality score than section 2, update the evidence-report with the newer score.
 

--- a/src/skf-create-skill/steps-c/step-07-generate-artifacts.md
+++ b/src/skf-create-skill/steps-c/step-07-generate-artifacts.md
@@ -76,6 +76,7 @@ Write these 3 files from the compiled content:
 
 **File 7:** `{forge_version}/extraction-rules.yaml`
 - Language and ast-grep schema used for this extraction (for reproducibility)
+- Note: This file is generated here from extraction data collected during steps 3-4, not assembled in step-05
 
 ### 4. Create Active Symlink
 

--- a/src/skf-create-skill/steps-c/step-08-report.md
+++ b/src/skf-create-skill/steps-c/step-08-report.md
@@ -101,7 +101,7 @@ completed: [{list of completed skill names}]
 last_updated: {ISO timestamp}
 ```
 
-Then loop back to step-01 for the next brief. Step-01 detects an active batch via `batch-state.yaml` and loads the brief at `current_index`.
+Then load and execute `steps-c/step-01-load-brief.md` for the next brief. Step-01 detects an active batch via `batch-state.yaml` and loads the brief at `current_index`.
 
 **If all batch briefs complete:**
 
@@ -115,7 +115,7 @@ End workflow. No further steps.
 
 **If not batch mode (or all batch briefs complete):**
 
-Write `{skill_package}/create-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`.
+Write `{forge_version}/create-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`.
 
 ### 6. Workflow Health Check
 
@@ -123,11 +123,11 @@ Write `{skill_package}/create-skill-result.json` per `shared/references/output-c
 
 Load and execute `{nextStepFile}` for workflow self-improvement check.
 
-**If batch mode with remaining briefs:** Skip health check — loop back to step-01 for the next brief. Health check runs after the final brief in the batch.
+**If batch mode with remaining briefs:** Skip health check — load and execute `steps-c/step-01-load-brief.md` for the next brief. Health check runs after the final brief in the batch.
 
 ## CRITICAL STEP COMPLETION NOTE
 
 This step chains to the shared health check (unless batch mode loops back to step-01). After the health check completes, the create-skill workflow is fully done.
 
-For batch mode: loop back to step-01 for remaining briefs via sidecar checkpoint. Health check runs only after the last brief.
+For batch mode: load and execute `steps-c/step-01-load-brief.md` for remaining briefs via sidecar checkpoint. Health check runs only after the last brief.
 

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -31,7 +31,7 @@ These rules apply to every step in this workflow:
 | 1 | Detect Tools & Set Tier | steps-c/step-01-detect-and-tier.md | Yes |
 | 1b | CCC Index | steps-c/step-01b-ccc-index.md | Yes |
 | 2 | Write Config | steps-c/step-02-write-config.md | Yes |
-| 3 | Auto Index | steps-c/step-03-auto-index.md | Yes |
+| 3 | QMD Hygiene | steps-c/step-03-auto-index.md | Yes |
 | 4 | Report | steps-c/step-04-report.md | Yes |
 
 ## Invocation Contract
@@ -39,14 +39,14 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | (none — fully autonomous) |
-| **Gates** | (none) |
+| **Gates** | One optional: orphaned QMD collection removal (step 3, Deep tier only; default: Keep) |
 | **Outputs** | forge-tier.yaml, preferences.yaml, forge-data directories |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
 
 ## On Activation
 
 1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
-   - `project_name`, `output_folder`, `user_name`, `communication_language`, `document_output_language`
+   - `project_name` (from installer-generated config.yaml, not module.yaml), `output_folder`, `user_name`, `communication_language`, `document_output_language`
    - `skills_output_folder`, `forge_data_folder`, `sidecar_path`
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -86,7 +86,7 @@ ccc availability gates the Forge+ tier and enhances Deep tier when present.
 
 **If no override, apply tier rules from {tierRulesData} in order — the first matching rule wins. Do not continue checking once a match is found:**
 - `{ast_grep}` AND `{gh_cli}` AND `{qmd}` all true → **Deep**
-- `{ast_grep}` AND `{ccc}` both true (regardless of gh/qmd) → **Forge+**
+- `{ast_grep}` AND `{ccc}` both true, but NOT (`{gh_cli}` AND `{qmd}`) → **Forge+**
 - `{ast_grep}` true (regardless of ccc/gh/qmd) → **Forge**
 - Otherwise → **Quick**
 

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -86,7 +86,7 @@ If `{settings_yml_existed}` is false: the exclusions will be applied after `ccc 
 
 ### 3. Create or Refresh CCC Index
 
-**If `{ccc_daemon}` is `"stopped"` or undefined (healthy daemon where no explicit state was recorded):**
+**If `{ccc_daemon}` is `"stopped"` or `"healthy"`:**
 
 The `ccc index` command auto-starts the daemon when needed. Proceed with indexing below.
 

--- a/src/skf-setup/steps-c/step-02-write-config.md
+++ b/src/skf-setup/steps-c/step-02-write-config.md
@@ -119,5 +119,5 @@ Check if `{forge_data_folder}` directory exists:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN forge-tier.yaml has been written successfully and preferences.yaml exists (created or pre-existing) will you load and read fully `{nextStepFile}` to execute the auto-index step.
+ONLY WHEN forge-tier.yaml has been written successfully and preferences.yaml exists (created or pre-existing) will you load and read fully `{nextStepFile}` to execute the QMD hygiene step.
 

--- a/src/skf-setup/steps-c/step-03-auto-index.md
+++ b/src/skf-setup/steps-c/step-03-auto-index.md
@@ -8,7 +8,7 @@ nextStepFile: './step-04-report.md'
 
 If the detected tier is Deep, verify the health of existing QMD collections by cross-referencing them against the `qmd_collections` registry in `forge-tier.yaml`. Identify orphaned collections (in QMD but not in registry) and stale registry entries (in registry but collection missing from QMD). Prompt the user before removing orphaned collections.
 
-For Quick and Forge tiers (without ccc), skip silently and proceed. For Forge+ tier, skip QMD hygiene but the step routes correctly to the next step.
+For Quick and Forge tiers, skip silently and proceed (QMD is not available at those tiers). For Forge+ tier, skip QMD hygiene but the step routes correctly to the next step.
 
 ## Rules
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -7,7 +7,7 @@ nextStepFile: 'shared/health-check.md'
 
 ## STEP GOAL:
 
-Display the forge status report with positive capability framing, report tier changes on re-run, and optionally fetch the latest agentskills.io spec if flagged.
+Display the forge status report with positive capability framing and report tier changes on re-run.
 
 ## Rules
 
@@ -82,18 +82,7 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 - Do NOT list unavailable tools
 - Do NOT show a "missing" column or section
 
-### 3. Handle --update-spec Flag (Reserved — Not Yet Implemented)
-
-**This flag is reserved for a future feature.** No spec URL endpoint exists yet.
-
-**If the user included `--update-spec` in their workflow invocation:**
-- Display: "The `--update-spec` flag is not yet implemented. This will be available in a future release when the agentskills.io spec endpoint is published."
-- Do NOT fail the workflow — continue to step 4
-
-**If `--update-spec` was NOT passed:**
-- Skip silently
-
-### 4. Workflow Health Check
+### 3. Workflow Health Check
 
 Load and execute `{nextStepFile}` for workflow self-improvement check.
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -82,15 +82,13 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 - Do NOT list unavailable tools
 - Do NOT show a "missing" column or section
 
-### 3. Handle --update-spec Flag (Optional)
+### 3. Handle --update-spec Flag (Reserved — Not Yet Implemented)
 
-**If the user included `--update-spec` in their workflow invocation (e.g., `@Ferris SF --update-spec`):**
-- Attempt to fetch the latest agentskills.io specification schema
-- Use `gh` or `curl` to retrieve the spec
-- Store in `{forge_data_folder}/agentskills-spec.json` (or appropriate format)
-- If fetch succeeds: display "agentskills.io spec updated."
-- If fetch fails: display "Could not fetch agentskills.io spec. Existing spec (if any) unchanged."
-- Do NOT fail the workflow over this — it is purely optional
+**This flag is reserved for a future feature.** No spec URL endpoint exists yet.
+
+**If the user included `--update-spec` in their workflow invocation:**
+- Display: "The `--update-spec` flag is not yet implemented. This will be available in a future release when the agentskills.io spec endpoint is published."
+- Do NOT fail the workflow — continue to step 4
 
 **If `--update-spec` was NOT passed:**
 - Skip silently

--- a/src/skf-test-skill/references/scoring-rules.md
+++ b/src/skf-test-skill/references/scoring-rules.md
@@ -17,7 +17,7 @@
 
 ## Naive Mode Weight Redistribution
 
-The following weights replace the default table for naive mode. The 18% coherence weight from the default table has been proportionally redistributed into these values. Do not apply a second redistribution.
+The following weights replace the default table for naive mode. The 18% coherence weight from the default table has been proportionally redistributed into these values. Do not re-redistribute for coherence (already handled in this table). Quick-tier redistribution (zeroing Signature Accuracy and Type Coverage) still applies as an additional step.
 
 When running in naive mode (no coherence category):
 - Export Coverage: 45%
@@ -42,9 +42,9 @@ tessl evaluates SKILL.md body content only — it does not read `references/*.md
 - Score based on: structural completeness only
 - Weight redistribution: skipped categories' weights (Signature Accuracy 22% + Type Coverage 14%) redistributed proportionally to remaining active categories
 
-### Docs-Only Mode (Quick tier, all [EXT:...] citations)
+### Docs-Only Mode (all [EXT:...] citations, any tier)
 
-When `docs_only_mode: true` is set by step-03 (indicating a Quick tier skill where all SKILL.md citations are `[EXT:...]` format with no local source code):
+When `docs_only_mode: true` is set by step-03 (indicating a skill where all SKILL.md citations are `[EXT:...]` format with no local source code):
 
 - **Signature Accuracy:** Not scored (no source to compare against)
 - **Type Coverage:** Not scored (no source to compare against)

--- a/src/skf-test-skill/references/source-access-protocol.md
+++ b/src/skf-test-skill/references/source-access-protocol.md
@@ -38,7 +38,7 @@ If no provenance-map.json exists (typical for quick-skill output), fall back to 
 If neither provenance-map nor metadata exports provide a usable baseline, but remote reading tools (zread, deepwiki, gh API, or similar) are available and `source_repo` is set in metadata.json, read the entry point remotely to build the export inventory from scratch. Name-matching only — no AST. Set `analysis_confidence: remote-only`.
 
 **State 5 — No source access at all:**
-If none of the above succeed, fall through to docs-only mode (as defined in step-01-init.md Section 0: pre-analysis source type detection). Set `analysis_confidence: docs-only`. Warn: "**No source access available.** Coverage check evaluates documentation self-consistency only. Re-run with local clone or remote access for source-backed verification."
+If none of the above succeed, fall through to docs-only mode (as defined in step-03-coverage-check.md Section 0: pre-analysis source type detection). Set `analysis_confidence: docs-only`. Warn: "**No source access available.** Coverage check evaluates documentation self-consistency only. Re-run with local clone or remote access for source-backed verification."
 
 Set `analysis_confidence` in context for use in Section 2 analysis depth, step-05 output, and step-05 scoring.
 

--- a/src/skf-test-skill/steps-c/step-01-init.md
+++ b/src/skf-test-skill/steps-c/step-01-init.md
@@ -5,6 +5,7 @@ templateFile: 'templates/test-report-template.md'
 sidecarFile: '{sidecar_path}/forge-tier.yaml'
 skillsOutputFolder: '{skills_output_folder}'
 frontmatterScript: 'shared/scripts/skf-validate-frontmatter.py'
+versionPathsKnowledge: 'knowledge/version-paths.md'
 ---
 
 # Step 1: Initialize Test
@@ -36,12 +37,12 @@ Provide the skill path or name. I'll search in `{skillsOutputFolder}`.
 
 ### 2. Validate Skill Exists (version-aware)
 
-Resolve the skill path using version-aware resolution (see `knowledge/version-paths.md`):
+Resolve the skill path using version-aware resolution (see `{versionPathsKnowledge}`):
 
 1. Read `{skillsOutputFolder}/.export-manifest.json` and look up the skill name in `exports` to get `active_version`
 2. If found: resolve to `{skill_package}` = `{skillsOutputFolder}/{skill_name}/{active_version}/{skill_name}/`
 3. If not in manifest: check for `active` symlink at `{skillsOutputFolder}/{skill_name}/active` — resolve to `{skill_group}/active/{skill_name}/`
-4. If neither: fall back to flat path `{skillsOutputFolder}/{skill_name}/`. If SKILL.md exists at the flat path, auto-migrate per `knowledge/version-paths.md` migration rules
+4. If neither: fall back to flat path `{skillsOutputFolder}/{skill_name}/`. If SKILL.md exists at the flat path, auto-migrate per `{versionPathsKnowledge}` migration rules
 5. Store the resolved path as `{resolved_skill_package}`
 
 Check that the skill package contains required files:

--- a/src/skf-test-skill/steps-c/step-03-coverage-check.md
+++ b/src/skf-test-skill/steps-c/step-03-coverage-check.md
@@ -23,9 +23,11 @@ Compare the exports, functions, classes, types, and interfaces documented in SKI
 
 ### 0. Check for Docs-Only Mode
 
-**If metadata.json indicates `confidence_tier: "Quick"` and all SKILL.md citations are `[EXT:...]` format (docs-only skill):**
+**If all SKILL.md citations are `[EXT:...]` format (no local source citations):**
 
-Coverage scoring adapts: instead of comparing SKILL.md against source code exports, compare SKILL.md documented items against themselves for internal completeness (every documented function has a description, parameters, and return type). Score based on documentation completeness rather than source coverage. Set `docs_only_mode: true` in context for step-05 scoring.
+Set `docs_only_mode: true` in context for step-05 scoring. Coverage scoring adapts: instead of comparing SKILL.md against source code exports, compare SKILL.md documented items against themselves for internal completeness (every documented function has a description, parameters, and return type). Score based on documentation completeness rather than source coverage.
+
+**Quick-tier weight adjustment:** If `confidence_tier` is also `"Quick"`, apply Quick-tier weight redistribution (zeroing Signature Accuracy and Type Coverage) as an additional step per `{scoringRulesFile}`.
 
 "**Docs-only skill detected.** Coverage check evaluates documentation completeness rather than source code coverage."
 

--- a/src/skf-test-skill/steps-c/step-04-coherence-check.md
+++ b/src/skf-test-skill/steps-c/step-04-coherence-check.md
@@ -2,6 +2,7 @@
 nextStepFile: './step-04b-external-validators.md'
 outputFile: '{forge_version}/test-report-{skill_name}.md'
 outputFormatsFile: 'assets/output-section-formats.md'
+scoringRulesFile: 'references/scoring-rules.md'
 ---
 
 # Step 4: Coherence Check
@@ -136,7 +137,7 @@ Build integration completeness findings:
 
 ### 5b. Migration/Deprecation Verification (Contextual Path)
 
-**This section shares logic with Section 2b.** If you are on the contextual mode path (Sections 3-5), execute the migration check here using the same rules as Section 2b:
+**This section shares logic with Section 2b.** If updating the shared logic, ensure both sections remain synchronized. If you are on the contextual mode path (Sections 3-5), execute the migration check here using the same rules as Section 2b:
 
 **Gate check:** Execute ONLY IF both conditions are met:
 1. Forge tier is **Deep** (tool-gated)

--- a/src/skf-test-skill/steps-c/step-06-report.md
+++ b/src/skf-test-skill/steps-c/step-06-report.md
@@ -4,6 +4,7 @@ nextStepFile: 'shared/health-check.md'
 outputFile: '{forge_version}/test-report-{skill_name}.md'
 scoringRulesFile: 'references/scoring-rules.md'
 outputFormatsFile: 'assets/output-section-formats.md'
+outputContractSchema: 'shared/references/output-contract-schema.md'
 ---
 
 # Step 6: Gap Report
@@ -93,7 +94,7 @@ Record discovery testing status as Info-level in the gap table. This is advisory
 
 ### 4c. Result Contract
 
-Write `{forge_version}/test-skill-result.json` per `shared/references/output-contract-schema.md`. Include the test report path in `outputs`; include `score`, `threshold`, `result` (PASS/FAIL), and `testMode` (naive/contextual) in `summary`.
+Write `{forge_version}/skf-test-skill-result.json` per `{outputContractSchema}`. Include the test report path in `outputs`; include `score`, `threshold`, `result` (PASS/FAIL), and `testMode` (naive/contextual) in `summary`.
 
 ### 5. Finalize Output Document
 


### PR DESCRIPTION
## Summary
- Resolves issues found during release audit across `skf-setup`, `skf-create-skill`, and `skf-test-skill` workflows (10 + 15 + 9 issues respectively)
- Fixes CI/release pipeline: full test suite now gates npm publish, `.npmignore` excludes reports/pycache/dev tools, manual-release and docs workflows cleaned up
- Adds missing feature request issue template and expands ROADMAP with persistent workspace layers and graphify plan
- Removes reserved `--update-spec` flag from `skf-setup`

## Test plan
- [x] `npm test` — all suites green (schemas, install, cli, workflow, python, knowledge, validate, lint, markdownlint, prettier)
- [x] `validate:skills --strict` — 1 LOW finding only (step count advisory)
- [x] `validate:refs --strict` — 0 broken references, 0 absolute path leaks
- [x] CI checks on PR pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)