### PR TITLE
polish(cli): per-IDE forger invocation + banner refresh

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,10 +33,20 @@ Installs SKF on its own. You'll be prompted for project name, output folders, an
 npx bmad-method install
 ```
 
-When prompted **"Add custom modules from your computer?"**, select Yes and provide the path to the SKF `src/` folder (clone this repo first):
+Step through the installer prompts:
+
+- **"Would you like to browse community modules?"** — No (SKF isn't in the community catalog yet)
+- **"Would you like to install from a custom source (Git URL or local path)?"** — Yes
+- **"Git URL or local path:"** — paste the SKF repo URL:
 
 ```
-Path to custom module folder: /path/to/bmad-module-skill-forge/src/
+https://github.com/armelhbobdad/bmad-module-skill-forge
+```
+
+Or, if you've already cloned the repo locally, provide the path to the repo root instead:
+
+```
+/path/to/bmad-module-skill-forge
 ```
 
 This installs BMad core + SKF together with full IDE integration, manifests, and help catalog. Best when you want the complete BMad development workflow.
@@ -67,17 +77,17 @@ The installer reads the installed version from your manifest and shows the delta
 
 ## Prerequisites
 
-| Tool                                                                   | Required For                                     | Install                                                |
-|------------------------------------------------------------------------|--------------------------------------------------|--------------------------------------------------------|
-| [Node.js](https://nodejs.org/) >= 22                                   | Installation, npx commands                       | <https://nodejs.org>                                   |
-| [Python](https://www.python.org/) >= 3.10                              | Deterministic scoring, validation, and utility scripts | <https://www.python.org>                               |
-| [uv](https://docs.astral.sh/uv/) (Python package runner)              | Running Python scripts with automatic dependency management | <https://docs.astral.sh/uv/getting-started/installation/> |
-| `gh` (GitHub CLI)                                                      | Required for Deep mode. Optional convenience in Quick/Forge/Forge+ for source access. | <https://cli.github.com>                               |
-| `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes                               | <https://ast-grep.github.io>                           |
-| `ast-grep` MCP server (recommended alongside CLI)                      | Forge + Deep modes                               | <https://github.com/ast-grep/ast-grep-mcp>             |
-| `ccc` (cocoindex-code semantic code search)                            | Forge+ mode                                      | <https://github.com/cocoindex-io/cocoindex-code>       |
-| `qmd` (local hybrid search engine for project files)                   | Deep mode                                        | <https://github.com/tobi/qmd>                          |
-| `SNYK_TOKEN` (Snyk API token — **Enterprise plan required**)           | Optional security scan                           | <https://docs.snyk.io/snyk-api/authentication-for-api> |
+| Tool                                                                   | Required For                                                                          | Install                                                   |
+|------------------------------------------------------------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| Node.js >= 22                                                          | Installation, npx commands                                                            | <https://nodejs.org>                                      |
+| Python >= 3.10                                                         | Deterministic scoring, validation, and utility scripts                                | <https://www.python.org>                                  |
+| uv (Python package runner)                                             | Running Python scripts with automatic dependency management                           | <https://docs.astral.sh/uv/getting-started/installation/> |
+| `gh` (GitHub CLI)                                                      | Required for Deep mode. Optional convenience in Quick/Forge/Forge+ for source access. | <https://cli.github.com>                                  |
+| `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes                                                                    | <https://ast-grep.github.io>                              |
+| `ast-grep` MCP server (recommended alongside CLI)                      | Forge + Deep modes                                                                    | <https://github.com/ast-grep/ast-grep-mcp>                |
+| `ccc` (cocoindex-code semantic code search)                            | Forge+ mode                                                                           | <https://github.com/cocoindex-io/cocoindex-code>          |
+| `qmd` (local hybrid search engine for project files)                   | Deep mode                                                                             | <https://github.com/tobi/qmd>                             |
+| `SNYK_TOKEN` (Snyk API token — **Enterprise plan required**)           | Optional security scan                                                                | <https://docs.snyk.io/snyk-api/authentication-for-api>    |
 
 Node.js, Python, and uv are required for all tiers. Don't worry about the rest — SKF detects what's available and sets your tier automatically. Security scanning via Snyk is optional and requires an Enterprise plan; it does not affect your tier level.
 
@@ -87,13 +97,13 @@ Node.js, Python, and uv are required for all tiers. Don't worry about the rest �
 
 SKF has two install-time variables (defined in `src/module.yaml`), one Core Config variable inherited from BMad, and one runtime preference:
 
-| Variable               | Purpose                                                                                              | Default                     |
-|------------------------|------------------------------------------------------------------------------------------------------|-----------------------------|
-| `skills_output_folder` | Where generated skills are saved                                                                     | `{project-root}/skills`     |
-| `forge_data_folder`    | Where workspace artifacts are stored (VS reports, evidence)                                          | `{project-root}/forge-data` |
+| Variable               | Purpose                                                                                                  | Default                     |
+|------------------------|----------------------------------------------------------------------------------------------------------|-----------------------------|
+| `skills_output_folder` | Where generated skills are saved                                                                         | `{project-root}/skills`     |
+| `forge_data_folder`    | Where workspace artifacts are stored (VS reports, evidence)                                              | `{project-root}/forge-data` |
 | `output_folder`        | Where refined architecture documents are saved (used by RA workflow). *Inherited from BMad Core Config.* | Defined by BMad Core Config |
-| `tier_override`        | Force a specific tier for comparison or testing (in `_bmad/_memory/forger-sidecar/preferences.yaml`) | `~` (auto-detect)           |
-| `headless_mode`        | Skip confirmation gates in all workflows (in `_bmad/_memory/forger-sidecar/preferences.yaml`)        | `false`                     |
+| `tier_override`        | Force a specific tier for comparison or testing (in `_bmad/_memory/forger-sidecar/preferences.yaml`)     | `~` (auto-detect)           |
+| `headless_mode`        | Skip confirmation gates in all workflows (in `_bmad/_memory/forger-sidecar/preferences.yaml`)            | `false`                     |
 
 Runtime configuration (tool detection, tier, and collection state) is managed by the `setup` workflow and persisted in `forge-tier.yaml`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,9 +79,9 @@ The installer reads the installed version from your manifest and shows the delta
 
 | Tool                                                                   | Required For                                                                          | Install                                                   |
 |------------------------------------------------------------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| Node.js >= 22                                                          | Installation, npx commands                                                            | <https://nodejs.org>                                      |
-| Python >= 3.10                                                         | Deterministic scoring, validation, and utility scripts                                | <https://www.python.org>                                  |
-| uv (Python package runner)                                             | Running Python scripts with automatic dependency management                           | <https://docs.astral.sh/uv/getting-started/installation/> |
+| `Node.js` >= 22                                                        | Installation, npx commands                                                            | <https://nodejs.org>                                      |
+| `Python` >= 3.10                                                       | Deterministic scoring, validation, and utility scripts                                | <https://www.python.org>                                  |
+| `uv` (Python package runner)                                           | Running Python scripts with automatic dependency management                           | <https://docs.astral.sh/uv/getting-started/installation/> |
 | `gh` (GitHub CLI)                                                      | Required for Deep mode. Optional convenience in Quick/Forge/Forge+ for source access. | <https://cli.github.com>                                  |
 | `ast-grep`  (CLI tool for code structural search, lint, and rewriting) | Forge + Deep modes                                                                    | <https://ast-grep.github.io>                              |
 | `ast-grep` MCP server (recommended alongside CLI)                      | Forge + Deep modes                                                                    | <https://github.com/ast-grep/ast-grep-mcp>                |

--- a/tools/cli/lib/ide-skills.js
+++ b/tools/cli/lib/ide-skills.js
@@ -28,7 +28,8 @@ function loadPlatforms() {
 
 /**
  * Get available platforms for UI display.
- * Returns array of { value: 'claude-code', label: 'Claude Code', preferred: true }
+ * Returns array of { value, label, preferred, skillInvocationPrefix }.
+ * skillInvocationPrefix is null when the IDE only auto-invokes skills.
  */
 function getAvailablePlatforms() {
   const config = loadPlatforms();
@@ -38,6 +39,7 @@ function getAvailablePlatforms() {
       value: code,
       label: p.name,
       preferred: p.preferred || false,
+      skillInvocationPrefix: p.skill_invocation_prefix ?? null,
     }))
     .sort((a, b) => {
       // Preferred first, then alphabetical

--- a/tools/cli/lib/installer.js
+++ b/tools/cli/lib/installer.js
@@ -114,7 +114,7 @@ class Installer {
     // Step 6: Install skills to selected IDEs
     let ideDirectories = [];
     const selectedIdes = config.ides || [];
-    if (selectedIdes.length > 0 && !selectedIdes.every((ide) => ide === 'other')) {
+    if (selectedIdes.length > 0) {
       s.start('Installing skills to IDEs...');
       try {
         const ideResult = await installSkillsToIdes(projectDir, skfDir, selectedIdes);

--- a/tools/cli/lib/platform-codes.yaml
+++ b/tools/cli/lib/platform-codes.yaml
@@ -4,6 +4,13 @@
 #   name: Display name shown to users
 #   preferred: Whether shown as a recommended option on install
 #   suspended: (optional) Message explaining why install is blocked
+#   skill_invocation_prefix: (optional) Prefix users type to invoke a named
+#     skill in this IDE's chat. Examples:
+#       "/"        — slash command, e.g. /skf-forger (most IDEs)
+#       "$"        — dollar mention, e.g. $skf-forger (Codex)
+#       "/skill:"  — namespaced slash, e.g. /skill:skf-forger (Pi)
+#     Omit when the IDE only auto-invokes skills from descriptions and has
+#     no manual invocation form (Cline, GitHub Copilot, Junie, etc.).
 #   installer:
 #     target_dir: Directory where skill directories are installed
 #     legacy_targets: (optional) Old target dirs to clean up on reinstall
@@ -11,6 +18,7 @@ platforms:
   antigravity:
     name: "Google Antigravity"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       detection_marker: .agent/antigravity
       legacy_targets:
@@ -20,6 +28,7 @@ platforms:
   auggie:
     name: "Auggie"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .augment/commands
@@ -28,6 +37,7 @@ platforms:
   claude-code:
     name: "Claude Code"
     preferred: true
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .claude/commands
@@ -36,6 +46,7 @@ platforms:
   cline:
     name: "Cline"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       detection_marker: .clinerules
       legacy_targets:
@@ -45,6 +56,7 @@ platforms:
   codex:
     name: "Codex"
     preferred: false
+    skill_invocation_prefix: "$"
     installer:
       detection_marker: .codex
       legacy_targets:
@@ -54,6 +66,7 @@ platforms:
   codebuddy:
     name: "CodeBuddy"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .codebuddy/commands
@@ -62,6 +75,7 @@ platforms:
   crush:
     name: "Crush"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       legacy_targets:
         - .crush/commands
@@ -70,6 +84,7 @@ platforms:
   cursor:
     name: "Cursor"
     preferred: true
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .cursor/commands
@@ -78,6 +93,7 @@ platforms:
   gemini:
     name: "Gemini CLI"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .gemini/commands
@@ -86,6 +102,7 @@ platforms:
   github-copilot:
     name: "GitHub Copilot"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       detection_marker: .github/copilot-instructions.md
       legacy_targets:
@@ -96,6 +113,7 @@ platforms:
   iflow:
     name: "iFlow"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .iflow/commands
@@ -104,12 +122,14 @@ platforms:
   junie:
     name: "Junie"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       target_dir: .junie/skills
 
   kilo:
     name: "KiloCoder"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       legacy_targets:
         - .kilocode/workflows
@@ -118,6 +138,7 @@ platforms:
   kiro:
     name: "Kiro"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       legacy_targets:
         - .kiro/steering
@@ -126,12 +147,14 @@ platforms:
   ona:
     name: "Ona"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       target_dir: .ona/skills
 
   opencode:
     name: "OpenCode"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .opencode/agents
@@ -143,18 +166,21 @@ platforms:
   pi:
     name: "Pi"
     preferred: false
+    skill_invocation_prefix: "/skill:"
     installer:
       target_dir: .pi/skills
 
   qoder:
     name: "Qoder"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       target_dir: .qoder/skills
 
   qwen:
     name: "QwenCoder"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .qwen/commands
@@ -163,6 +189,7 @@ platforms:
   roo:
     name: "Roo Code"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .roo/commands
@@ -171,6 +198,7 @@ platforms:
   rovo-dev:
     name: "Rovo Dev"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       legacy_targets:
         - .rovodev/workflows
@@ -179,6 +207,7 @@ platforms:
   trae:
     name: "Trae"
     preferred: false
+    # Auto-invoked from descriptions; no manual prefix
     installer:
       legacy_targets:
         - .trae/rules
@@ -187,6 +216,7 @@ platforms:
   windsurf:
     name: "Windsurf"
     preferred: false
+    skill_invocation_prefix: "/"
     installer:
       legacy_targets:
         - .windsurf/workflows

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -43,29 +43,43 @@ class UI {
       logoLines = ['  S K F'];
     }
 
-    const w = 54;
+    const w = 72;
     const frame = brand.dark;
     const top = frame('  ╔' + '═'.repeat(w) + '╗');
     const mid = frame('  ╟' + '─'.repeat(w) + '╢');
     const bottom = frame('  ╚' + '═'.repeat(w) + '╝');
+    const rule = frame('  ' + '━'.repeat(w));
     const row = (content) => {
       // eslint-disable-next-line no-control-regex -- stripping ANSI escape codes for visual width calculation
       const stripped = content.replaceAll(/\u001B\[\d+(?:;\d+)*m/g, '');
       const pad = Math.max(0, w - stripped.length - 2);
       return frame('  ║ ') + content + ' '.repeat(pad) + frame(' ║');
     };
+    const empty = row('');
+    const indent = '  ';
 
     console.log();
     console.log(top);
+    console.log(empty);
     for (const line of logoLines) {
-      console.log(row(brand.amber.bold(line.replace(/\s+$/, ''))));
+      console.log(row(indent + brand.amber.bold(line.replace(/\s+$/, ''))));
     }
+    console.log(empty);
     console.log(mid);
-    console.log(row(chalk.white.bold('Skill Forge') + chalk.dim(` v${version}`)));
-    console.log(row(chalk.dim('Agent Skill Compiler') + ' '.repeat(15) + brand.spark('⚒')));
-    console.log(mid);
-    console.log(row(chalk.dim('Code · Docs · Discourse → Verified agent skills')));
+    console.log(row(indent + chalk.white.bold('Skill Forge') + '  ' + brand.spark('⚒') + '  ' + chalk.dim('Agent Skill Compiler')));
+    console.log(row(indent + chalk.dim('Turn code and docs into instructions AI agents can actually follow.')));
+    console.log(row(indent + chalk.dim(`v${version}  ·  MIT License  ·  Open Source`)));
     console.log(bottom);
+    console.log();
+    console.log(rule);
+    console.log();
+    const resource = (label, url) => '  ' + chalk.dim(label.padEnd(10)) + brand.amber(url);
+    console.log(resource('Docs', 'https://armelhbobdad.github.io/bmad-module-skill-forge'));
+    console.log(resource('GitHub', 'https://github.com/armelhbobdad/bmad-module-skill-forge'));
+    console.log(resource('Discord', 'https://discord.gg/gk8jAdXWmj'));
+    console.log(resource('Support', 'https://buymeacoffee.com/armelhbobdad'));
+    console.log();
+    console.log(rule);
     console.log();
 
     intro(brand.amber('Skill Forge Installer'));

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -170,13 +170,10 @@ class UI {
 
     // Build IDE options from platform-codes.yaml
     const platforms = getAvailablePlatforms();
-    const ideOptions = [
-      ...platforms.map((p) => ({
-        label: p.preferred ? `${p.label} (Recommended)` : p.label,
-        value: p.value,
-      })),
-      { label: 'Other', value: 'other' },
-    ];
+    const ideOptions = platforms.map((p) => ({
+      label: p.preferred ? `${p.label} (Recommended)` : p.label,
+      value: p.value,
+    }));
 
     // Pre-check IDEs: saved config takes priority, then auto-detect from directories
     const savedIdes = savedConfig?.ides || [];
@@ -290,25 +287,57 @@ class UI {
   }
 
   displaySuccess(skfFolder, ides = [], action = 'fresh') {
-    // Build IDE name map from platform-codes.yaml
-    const ideNames = { other: 'your IDE' };
+    // Build per-platform lookup tables from platform-codes.yaml
+    const ideNames = {};
+    const idePrefixes = {};
     for (const p of getAvailablePlatforms()) {
       ideNames[p.value] = p.label;
+      idePrefixes[p.value] = p.skillInvocationPrefix; // null = auto-invoke only
     }
 
+    const selectedIdes = Array.isArray(ides) && ides.length > 0 ? ides : [];
+
     let ideDisplay;
-    if (!ides || ides.length === 0) {
+    if (selectedIdes.length === 0) {
       ideDisplay = 'your IDE';
-    } else if (ides.length === 1) {
-      ideDisplay = ideNames[ides[0]] || 'your IDE';
+    } else if (selectedIdes.length === 1) {
+      ideDisplay = ideNames[selectedIdes[0]] || 'your IDE';
     } else {
-      ideDisplay = ides.map((ide) => ideNames[ide] || ide).join(' or ');
+      ideDisplay = selectedIdes.map((ide) => ideNames[ide] || ide).join(' or ');
+    }
+
+    // Build per-IDE invocation hints. Skills with a prefix get a literal
+    // command; auto-invoke IDEs get a chat-based instruction.
+    const invocations = selectedIdes.map((ide) => {
+      const name = ideNames[ide] || ide;
+      const prefix = idePrefixes[ide];
+      if (prefix) {
+        return { ide: name, command: `${prefix}skf-forger`, auto: false };
+      }
+      return { ide: name, command: null, auto: true };
+    });
+
+    // Compose the activate line shown in steps and outro.
+    let activateLine;
+    if (invocations.length === 0) {
+      // Update flow with no IDE list — show both common forms
+      activateLine = `${brand.gold('/skf-forger')} ${chalk.dim('(Claude Code)')}  ${chalk.dim('·')}  ${brand.gold('$skf-forger')} ${chalk.dim('(Codex)')}`;
+    } else if (invocations.length === 1) {
+      const inv = invocations[0];
+      activateLine = inv.auto ? chalk.dim(`${inv.ide} auto-loads skf-forger`) : brand.gold(inv.command);
+    } else {
+      // Mixed: show one segment per IDE
+      activateLine = invocations
+        .map((inv) =>
+          inv.auto
+            ? `${chalk.dim('auto')} ${chalk.dim('(' + inv.ide + ')')}`
+            : `${brand.gold(inv.command)} ${chalk.dim('(' + inv.ide + ')')}`,
+        )
+        .join('  ');
     }
 
     let noteTitle;
     let noteBody;
-
-    const activateCmd = brand.gold('@Ferris SF');
 
     if (action === 'update') {
       noteTitle = brand.amber.bold('Update complete!');
@@ -318,15 +347,15 @@ class UI {
         'Your config.yaml and sidecar state are preserved.',
         '',
         `${chalk.white.bold('Next Steps')}`,
-        `1. Reload the agent in ${ideDisplay}:  ${activateCmd}`,
-        '2. Run @Ferris SF to re-detect tools if needed',
+        `1. Reload the agent in ${ideDisplay}:  ${activateLine}`,
+        `2. Then ask Ferris to ${chalk.white('"setup the forge"')} to re-detect tools`,
       ].join('\n');
     } else {
       noteTitle = brand.amber.bold('Installation complete!');
       noteBody = [
         `${chalk.white.bold('Get Started')}`,
         `1. Open this folder in ${ideDisplay}`,
-        `2. Activate Ferris:  ${activateCmd}`,
+        `2. Activate Ferris:  ${activateLine}`,
         '3. Ferris (your Skill Architect) will guide you through',
         '   setting up and forging your first agent skill',
       ].join('\n');
@@ -335,7 +364,7 @@ class UI {
     note(noteBody, noteTitle);
 
     outro(
-      `${brand.spark('⚒')}  Agent: ${chalk.white('Ferris')} ${chalk.dim('(Skill Architect & Integrity Guardian)')}\n${brand.dark('⚡')} Docs: ${brand.amber('https://armelhbobdad.github.io/bmad-module-skill-forge')}`,
+      `${brand.spark('⚒')}  Agent: ${chalk.white('Ferris')} ${chalk.dim('(Skill Architect & Integrity Guardian)')}\n${brand.dark('⚡')} Docs: ${brand.amber('https://armelhbobdad.github.io/bmad-module-skill-forge')}\n${brand.gold('▶')}  Call the forger:  ${activateLine}`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- Refresh installer banner (wider frame, resource links, tagline).
- Per-IDE forger invocation in the success message: slash (`/skf-forger`), dollar (`$skf-forger`), namespaced (`/skill:skf-forger`), or auto-invoke hint — driven by a new `skill_invocation_prefix` field in `platform-codes.yaml`.
- Drop the synthetic "Other" IDE option; `installer.js` now installs skills whenever any IDE is selected.
- Update `docs/getting-started.md` with the current BMad Method install prompts and reformat the Prerequisites/Variables tables.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run lint:md`
- [x] `npm run test:cli` (83 passed)
- [x] `npm run test:install` (165 passed)
- [x] Visual smoke test of `displayBanner` and `displaySuccess` across single IDE, multi IDE, auto-invoke-only IDE, mixed prefix+auto, and the update flow.