### PR TITLE
docs: audit unverified assertions + installer UX polish

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -85,14 +85,14 @@ MANAGE:
 
 **Pipeline Aliases:**
 
-| Alias | Expands To | Use Case |
-|-------|-----------|----------|
-| `forge` | BS CS TS EX | Full skill creation |
-| `forge-quick` | QS TS EX | Quick skill pipeline |
-| `onboard` | AN CS TS EX | Brownfield onboarding |
-| `maintain` | AS US TS EX | Maintenance cycle |
+| Alias | Expands To | First Workflow | Required Target |
+|-------|-----------|----------------|-----------------|
+| `forge` | BS CS TS EX | BS | GitHub URL or local path **+** skill name |
+| `forge-quick` | QS TS EX | QS | GitHub URL **or** package name |
+| `onboard` | AN CS TS EX | AN | Project path (defaults to current directory) |
+| `maintain` | AS US TS EX | AS | Existing skill name |
 
-Example: `@Ferris forge lodash` chains Brief → Create → Test → Export with automatic data forwarding.
+Example: `@Ferris forge-quick cognee` chains Quick → Test → Export with automatic data forwarding — QS resolves the package to its GitHub repo. For the full brief-driven pipeline, use `@Ferris forge <repo-url> <skill-name>`. See [Workflows → Pipeline Mode](../workflows/#pipeline-mode) for the full specification.
 
 **Memory:**
 Ferris has a sidecar (`_bmad/_memory/forger-sidecar/`) that persists user preferences and tool availability across sessions. Set `headless_mode: true` in preferences to make headless the default.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -71,7 +71,7 @@ Skills are stored per-version — updating cognee to v0.6.0 creates a new versio
 
 ## Example Workflows
 
-### Quick Skill — 47 Seconds
+### Quick Skill — Under a minute
 
 Developer adds [cognee](https://github.com/topoteretes/cognee) to a Python project for AI memory management. Agent keeps hallucinating method signatures and config options.
 
@@ -79,7 +79,7 @@ Developer adds [cognee](https://github.com/topoteretes/cognee) to a Python proje
 @Ferris QS https://github.com/topoteretes/cognee
 ```
 
-Ferris reads the repository, extracts the public API via source reading, validates against spec. Skill appears in `skills/cognee/0.5.5/cognee/`. Agent stops hallucinating. Forty-seven seconds. Done.
+Ferris reads the repository, extracts the public API, and validates against the agentskills.io spec. The skill is written to `skills/cognee/<version>/cognee/` (auto-detected from the source manifest). Agent stops hallucinating.
 
 Need a specific version? Append `@version`:
 
@@ -87,7 +87,7 @@ Need a specific version? Append `@version`:
 @Ferris QS cognee@0.5.0
 ```
 
-### Brownfield Platform — 8 Minutes
+### Brownfield Platform — Pipeline or per-workflow
 
 Alex's team adopts BMAD for 10 microservices (TypeScript, Go, Rust).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,8 +135,10 @@ Ferris reads the repository, extracts the public API, and generates a skill in u
 
 **Full quality path (pipeline mode):**
 ```
-@Ferris forge lodash
+@Ferris forge https://github.com/lodash/lodash lodash
 ```
+
+`forge` chains Brief → Create → Test → Export. It needs an explicit repo URL **and** a skill name because it starts with Brief Skill (BS), which doesn't guess targets. If you just want a fast skill from a package name, use `@Ferris forge-quick cognee` instead — that starts with Quick Skill (QS), which resolves packages via the registry.
 
 Or one workflow per session:
 ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -114,7 +114,51 @@ Setup detects your installed tools and sets your tier automatically:
 ```
 
 ```
-Forge initialized. Tools: gh, ast-grep, ccc, QMD. Tier: Deep. Ready.
+┌─────────────────────────────┐
+│ FORGE STATUS                │
+└─────────────────────────────┘
+
+  Tier:  Deep
+
+  Deep tier active. Full capability unlocked — AST-backed code
+  analysis, GitHub repository exploration, and QMD knowledge search
+  with cross-repository synthesis. Maximum provenance and intelligence.
+
+  Tools Detected:
+    ast-grep  — 0.42.0
+    gh        — 2.89.0
+    qmd       — operational (104 docs indexed globally)
+    ccc       — 0.2.10 (daemon healthy)
+
+  QMD Registry:
+    0 collection(s) healthy
+    39 orphaned collection(s) removed
+    (empty — collections are created automatically when you run [CS] Create Skill)
+
+  CCC Index:
+    indexed this run — semantic discovery ready (2 files, 14 chunks)
+    SKF infrastructure excluded: _bmad, _bmad-output, .claude,
+    _skf-learn, skills, forge-data
+
+┌────────────────────────────────┐
+│ Forge ready. Deep tier active. │
+└────────────────────────────────┘
+
+Health Check: Clean run. No workflow issues to report.
+
+Workflow complete.
+
+---
+Forge is live at Deep tier, armel. All four core tools are available, the CCC semantic index is built, and the QMD registry is clean.
+
+What would you like to forge next? Common starting points:
+
+- QS — fast skill from a GitHub URL or package name
+- BS → CS — brief, then compile a skill from source
+- AN — analyze a large repo to discover what's worth skilling
+- WS — show current lifecycle status
+
+Or chain them: forge (BS CS TS EX), forge-quick (QS TS EX), onboard (AN CS TS EX).
 ```
 
 Don't have ast-grep, cocoindex-code, or QMD yet? No problem — Quick mode works with no additional tools. Optional GitHub CLI improves source access. Install tools later; your tier upgrades automatically.
@@ -470,12 +514,22 @@ When tools disagree, higher priority wins for instructions. Lower priority is pr
 | 3 | Source reading (non-AST) | `gh_bridge` |
 | 4 | External documentation | `doc_fetcher` |
 
-### Internal Utility
+### Manifest Detection
 
-**`manifest_reader`** detects and parses dependency files across ecosystems:
+Stack skill workflows detect project dependencies by scanning for manifest files. This isn't a tool — it's a reference pattern ([`skf-create-stack-skill/references/manifest-patterns.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-create-stack-skill/references/manifest-patterns.md)) consulted by workflow steps:
 
-- **Full support:** `package.json`, `pyproject.toml`, `requirements.txt`, `Cargo.toml`, `go.mod`
-- **Basic support:** `build.gradle`, `pom.xml`, `Gemfile`, `composer.json`
+| Ecosystem | Manifest Files |
+|-----------|----------------|
+| JavaScript / TypeScript | `package.json` |
+| Python | `requirements.txt`, `setup.py`, `pyproject.toml`, `Pipfile` |
+| Rust | `Cargo.toml` |
+| Go | `go.mod` |
+| Java | `pom.xml`, `build.gradle` |
+| Ruby | `Gemfile` |
+| PHP | `composer.json` |
+| .NET | `*.csproj` |
+
+Detection runs at depth 0-1 from project root, excluding dependency trees (`node_modules/`, `.venv/`, `vendor/`), build output (`dist/`, `target/`, `__pycache__/`), and VCS directories.
 
 ---
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -284,40 +284,45 @@ flowchart TD
 
 ## Pipeline Mode
 
-Instead of running one workflow per session, you can chain multiple workflows in a single command. Ferris executes them left to right, passing data between each workflow automatically.
+Instead of running one workflow per session, you can chain multiple workflows in a single command. Ferris executes them left to right, passing data (brief path, skill name) between each workflow automatically.
 
 ### Syntax
 
 ```
-@Ferris BS CS TS EX              — space-separated codes
-@Ferris QS[lodash] TS EX         — with target argument
-@Ferris CS TS[min:80] EX         — with circuit breaker threshold
-@Ferris forge lodash             — named alias
+@Ferris BS CS TS EX                    — space-separated codes
+@Ferris QS[lodash] TS EX               — with target argument in brackets
+@Ferris CS TS[min:80] EX               — with circuit breaker threshold override
+@Ferris forge-quick cognee             — named alias with target
 ```
 
 ### Pipeline Aliases
 
-| Alias | Expands To | Description |
-|-------|-----------|-------------|
-| `forge` | `BS CS TS EX` | Full skill creation pipeline |
-| `forge-quick` | `QS TS EX` | Quick skill pipeline |
-| `onboard` | `AN CS TS EX` | Full brownfield onboarding |
-| `maintain` | `AS US TS EX` | Maintenance cycle |
+| Alias | Expands To | First Workflow | Required Target |
+|-------|-----------|----------------|-----------------|
+| `forge` | `BS CS TS EX` | BS | GitHub URL or local path **+** skill name |
+| `forge-quick` | `QS TS EX` | QS | GitHub URL **or** package name |
+| `onboard` | `AN CS TS EX` | AN | Project path (defaults to current directory) |
+| `maintain` | `AS US TS EX` | AS | Existing skill name |
+
+**The first workflow's input contract defines what arguments the pipeline needs.** A bare package name works for `forge-quick` (QS resolves packages via the registry) but **not** for `forge` — BS requires both an unambiguous target (URL or path) and a skill name.
 
 ### How It Works
 
 - Pipelines **automatically activate headless mode** — all confirmation gates auto-proceed with their default action
-- **Data flows automatically** — the skill name or brief path from one workflow becomes the input for the next
+- **Data flows automatically** — once the first workflow completes, the brief path or skill name becomes the input for downstream workflows
 - **Circuit breakers** halt the pipeline if quality drops below a threshold (e.g., test score < 60 blocks export)
 - **Anti-pattern warnings** — Ferris warns if you chain workflows in a problematic order (e.g., exporting before testing)
 - **Progress reporting** — Ferris reports completion of each workflow before starting the next
+- **Safe halt on ambiguity** — headless mode won't guess. If the initial target doesn't satisfy the first workflow's contract (e.g., `forge cognee` — ambiguous, not a URL or path), the pipeline halts at step 1 before any work happens and suggests concrete next steps.
 
 ### Examples
 
 ```
-@Ferris forge-quick @tanstack/query    — quick skill + test + export for TanStack Query
-@Ferris maintain lodash                — audit + update + test + export for lodash
-@Ferris AN onboard                     — analyze the project, then forge each recommended unit
+@Ferris forge-quick @tanstack/query                                  — QS + TS + EX for TanStack Query
+@Ferris forge https://github.com/topoteretes/cognee cognee           — BS + CS + TS + EX, explicit URL + name
+@Ferris forge https://github.com/topoteretes/cognee cognee "public API only"   — with scope hint
+@Ferris maintain lodash                                              — AS + US + TS + EX for an existing lodash skill
+@Ferris onboard                                                      — AN + CS + TS + EX on the current project
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **docs audit** — systematic review of `docs/` against source of truth in `src/` to remove or correct claims that don't match the actual implementation (pipeline aliases, manifest detection, SF output, unverifiable timing claims)
- **installer UX polish** — refreshed banner, per-IDE forger invocation in success message, expanded platform-codes.yaml

## Docs corrections

- `how-it-works.md` — replaced SF output placeholder with the real forge status banner; rewrote "Internal Utility" to remove the fictional `manifest_reader` tool and fabricated Full/Basic support split
- `workflows.md` — rewrote Pipeline Mode so the aliases table shows each alias's first workflow and required target; documented safe-halt on ambiguous targets; fixed invalid examples (`forge lodash`, duplicate `AN onboard`)
- `agents.md` / `getting-started.md` — replaced wrong `@Ferris forge lodash` examples with the correct forms (`forge-quick cognee` or `forge <repo-url> <skill-name>`)
- `examples.md` — removed unverifiable specific timing claims ("47 Seconds", "8 Minutes"); use `<version>` placeholder instead of a hardcoded cognee version

## Test plan

- [x] Preview docs site renders the updated Pipeline Mode table and forge status code block correctly
- [x] Run `@Ferris SF` in a fresh project and confirm the banner matches the one now documented
- [x] Run `@Ferris forge-quick cognee` and confirm the pipeline resolves via QS
- [x] Run `@Ferris forge cognee` and confirm the documented safe-halt fires
- [x] Verify the installer banner and per-IDE success message render on a fresh install