### PR TITLE
docs(skf-test-skill): clarify Section 4b scope in coherence gate

### DIFF
--- a/src/skf-test-skill/steps-c/step-04-coherence-check.md
+++ b/src/skf-test-skill/steps-c/step-04-coherence-check.md
@@ -70,6 +70,8 @@ If either condition fails, skip silently and proceed to Section 6.
 
 Check whether SKILL.md contains a "Migration & Deprecation Warnings" section (Section 4b). Then check the skill's `evidence-report.md` (at `{forge_data_folder}/{skill_name}/evidence-report.md`) for T2-future annotation counts.
 
+**Scope of Section 4b (authoring rule this gate enforces):** Section 4b is scoped to *forward-looking* breaking changes only — what T2-future annotations capture. Historical deprecations (e.g. `@deprecated` decorators in current source) belong inline in Key API Summary or Full API Reference, and current-state signature gotchas (e.g. "this function is sync not async") belong alongside the function in Full API Reference. They do **not** belong in Section 4b. This scoping is authoritative per `skf-create-skill/assets/skill-sections.md` ("Section 4b (Migration & Deprecation Warnings) is conditional: only emitted for Deep tier when T2-future annotations exist"). If a skill has a legitimate exception where Section 4b was manually populated with non-migration content, downgrade this gap to Low with inline justification — do not relax the gate, which would desync the test workflow from the authoring rule.
+
 - **If T2-future annotations > 0 AND Section 4b is absent:** Flag as Medium severity gap: "Migration section missing — T2-future annotations exist but Section 4b is not present in SKILL.md Tier 1."
 - **If T2-future annotations = 0 AND Section 4b is present:** Flag as Medium severity gap: "Migration section unexpected — Section 4b is present but no T2-future annotations were produced."
 - **If evidence-report.md is unavailable:** Skip this check silently. Note: "Section 4b verification skipped — evidence-report.md not found."
@@ -146,6 +148,8 @@ Build integration completeness findings:
 If either condition fails, skip silently.
 
 Check whether SKILL.md contains a "Migration & Deprecation Warnings" section (Section 4b). Then check the skill's `evidence-report.md` for T2-future annotation counts.
+
+**Scope of Section 4b (authoring rule this gate enforces):** Section 4b is scoped to *forward-looking* breaking changes only — what T2-future annotations capture. Historical deprecations (e.g. `@deprecated` decorators in current source) belong inline in Key API Summary or Full API Reference, and current-state signature gotchas (e.g. "this function is sync not async") belong alongside the function in Full API Reference. They do **not** belong in Section 4b. This scoping is authoritative per `skf-create-skill/assets/skill-sections.md` ("Section 4b (Migration & Deprecation Warnings) is conditional: only emitted for Deep tier when T2-future annotations exist"). If a skill has a legitimate exception where Section 4b was manually populated with non-migration content, downgrade this gap to Low with inline justification — do not relax the gate, which would desync the test workflow from the authoring rule.
 
 - **If T2-future annotations > 0 AND Section 4b is absent:** Flag as Medium severity gap: "Migration section missing — T2-future annotations exist but Section 4b is not present in SKILL.md Tier 1."
 - **If T2-future annotations = 0 AND Section 4b is present:** Flag as Medium severity gap: "Migration section unexpected — Section 4b is present but no T2-future annotations were produced."


### PR DESCRIPTION
## Summary

- Added identical "Scope of Section 4b" clarification notes to §2b (naive mode) and §5b (contextual mode) of `src/skf-test-skill/steps-c/step-04-coherence-check.md`, explaining what the gate is checking and why.
- The gate was previously terse enough that a health-check session mistakenly re-filed it as a false-positive finding, believing the gate was too strict when it was in fact faithfully mirroring the canonical authoring rule in `src/skf-create-skill/assets/skill-sections.md` (lines 37, 59: "Section 4b … only emitted for Deep tier when T2-future annotations exist").
- The new notes document three things:
  1. Section 4b is scoped to **forward-looking breaking changes only** — what T2-future annotations capture.
  2. Historical deprecations (e.g. `@deprecated` decorators) belong inline in Key API Summary or Full API Reference; current-state signature gotchas belong alongside the function in Full API Reference. Neither belongs in Section 4b.
  3. The correct escape hatch for exceptional cases is manual gap downgrade to Low with inline justification — **not** gate relaxation, which would desync `skf-test-skill` from the `skf-create-skill` authoring rule.
- Pure documentation addition (+4 lines). No gate logic change, no new source authority, zero functional risk.

## Test plan

- [x] Pre-commit hook — full `npm test` suite green (schemas, install, cli, workflow, python, knowledge, validate, lint, lint:md, format:check)
- [x] `scan-path-standards.py` and `scan-scripts.py` — no new findings introduced by the edit (3 pre-existing high findings in unrelated lines remain, out of scope)
- [x] Edge-case review of the updated sections — no new edge cases introduced by the scoping note itself
- [x] Quality analysis of the full `skf-test-skill` workflow — overall health rated Good; top follow-up (separate PR) is to extract the duplicated §2b/§5b migration gate to a shared include to eliminate drift
- [x] Manual diff review — both additions identical, localized to §2b and §5b only

🤖 Generated with [Claude Code](https://claude.com/claude-code)