### PR TITLE
fix(workflows): update-skill pathway fixes and shared banner removal

### DIFF
--- a/src/skf-analyze-source/steps-c/step-06-generate-briefs.md
+++ b/src/skf-analyze-source/steps-c/step-06-generate-briefs.md
@@ -154,9 +154,9 @@ lastStep: 'step-06-generate-briefs'
 nextWorkflow: '{primary recommendation}'
 ```
 
-### 8. Present Completion Summary
+### 8. Present Summary
 
-"**Analyze-Source Workflow Complete**
+"**Analyze-Source Summary**
 
 **Project:** {project_name}
 **Forge Tier:** {forge_tier}
@@ -179,7 +179,7 @@ nextWorkflow: '{primary recommendation}'
 **Stack Skill Candidates:**
 {List candidates with recommendation to run create-stack-skill after individual skills are created}
 
-**This analysis is complete.** To refine any brief, run the recommended next workflow. To re-analyze with different scope, run analyze-source again."
+To refine any brief, run the recommended next workflow. To re-analyze with different scope, run analyze-source again."
 
 ### 9. Result Contract
 

--- a/src/skf-create-stack-skill/steps-c/step-09-report.md
+++ b/src/skf-create-stack-skill/steps-c/step-09-report.md
@@ -87,9 +87,7 @@ Forge tier: **{tier}**"
 - **[TS] test-skill** — Validate the stack skill against its own assertions
 - **[EX] export-skill** — Package for distribution or agent loading
 
-- **[VS] verify-stack** — Validate the stack's integration feasibility against your architecture document{IF compose_mode:} (re-run to confirm feasibility after any architecture changes from **[RA] refine-architecture**){END IF}
-
-**Workflow complete.**"
+- **[VS] verify-stack** — Validate the stack's integration feasibility against your architecture document{IF compose_mode:} (re-run to confirm feasibility after any architecture changes from **[RA] refine-architecture**){END IF}"
 
 ### 6b. Result Contract
 

--- a/src/skf-export-skill/steps-c/step-06-summary.md
+++ b/src/skf-export-skill/steps-c/step-06-summary.md
@@ -130,19 +130,13 @@ No files were written. To run the export for real:
 - Suggest testing by invoking the skill's trigger phrase in a new conversation
 - If token budget was exceeded, note which skills were trimmed
 
-### 6. Workflow Complete
-
-"---
-
-**Skill forged and delivered.** ⚒️"
-
-### Result Contract
+### 6. Result Contract
 
 Write `{skills_output_folder}/export-skill-result.json` per `shared/references/output-contract-schema.md`. Include all context files and target managed-section files in `outputs`; include total always-on and on-trigger token counts in `summary`.
 
 ### 7. Workflow Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+Load and execute `{nextStepFile}` for workflow self-improvement check. The health check is the terminal step and will display the workflow-complete marker on exit.
 
 ## CRITICAL STEP COMPLETION NOTE
 

--- a/src/skf-update-skill/steps-c/step-03-re-extract.md
+++ b/src/skf-update-skill/steps-c/step-03-re-extract.md
@@ -22,6 +22,45 @@ Perform tier-aware extraction on only the changed files identified in step 02, p
 
 **CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
 
+### 0. Check for Gap-Driven Mode
+
+**If `update_mode == "gap-driven"` (set in step-01 via `--from-test-report`, confirmed in step-02 section 0):**
+
+Source code has not drifted — the gap-derived manifest from step-02 contains export-level findings translated from the test report, not file-level changes. Perform citation spot-checks instead of full re-extraction to verify each gap-affected export is still at its recorded location.
+
+1. Use the provenance map already loaded in step-01 (at `{forge_version}/provenance-map.json`) — do not re-read
+2. For each entry in the gap-derived change manifest from step-02:
+   - Look up the export by `name` in `provenance_map.exports` — read `source_file` and `source_line`
+   - **If export not found in provenance map:** record as new (`provenance_citation: unknown`) — no spot-check possible; flag for merge step to handle as `NEW_EXPORT`
+   - **If export found:** read the source file at `source_line ± 5` lines and verify the symbol name still appears within that window
+   - Record verification outcome: `verified` (symbol at recorded line), `moved` (symbol found elsewhere in same file — record new line), or `missing` (symbol not found in file)
+3. Build a minimal extraction results block matching section 4's shape, with `mode: gap-driven` and per-export verification records:
+
+   ```
+   Extraction Results:
+     mode: gap-driven
+     files_extracted: 0
+     exports_extracted: {gap_count}
+     confidence_breakdown:
+       T1: {verified_count + moved_count}
+       T1-low: 0
+       T2: 0
+
+     Per-export verification:
+       {export_name}:
+         provenance_citation: {source_file}:{source_line}
+         verification: verified|moved|missing|unknown
+         new_location: {source_file}:{new_line}  # only if moved
+         gap_category: NEW_EXPORT|MODIFIED_EXPORT|metadata_update
+   ```
+
+4. Set `no_reextraction: true` in workflow context — step-06 will use this flag to skip stale `source_file`/`source_line`/`confidence` field updates for verified exports (only `moved` exports get updated citations).
+5. **Skip all remaining sections of step-03** — sections 1–5 are source-drift extraction paths that do not apply. Display the summary below and load `{nextStepFile}` to proceed directly to the merge step.
+
+"**Gap-driven re-extraction.** Verified {verified_count}/{gap_count} citations against live source. Moved: {moved_count}. Missing: {missing_count}. Unknown (not in provenance map): {unknown_count}. No source re-extraction performed — proceeding to merge."
+
+**If normal mode (`update_mode` unset or not `gap-driven`):** Continue with docs-only check and source extraction below.
+
 ### 1. Check for Docs-Only Mode
 
 **If `source_type: "docs-only"` in the original brief or metadata:**

--- a/src/skf-update-skill/steps-c/step-04-merge.md
+++ b/src/skf-update-skill/steps-c/step-04-merge.md
@@ -14,7 +14,7 @@ Merge freshly extracted export data into the existing SKILL.md content while pre
 
 - Focus only on merging extractions into existing skill content
 - Never delete or modify [MANUAL] section content
-- Do not write files — merge produces an edit plan for Step 06
+- Write merged SKILL.md (and stack reference files) directly to disk at section 6b — Claude Code's Edit/Write tools commit on call, so there is no held-in-memory "edit plan" primitive; subsequent steps validate and verify against the on-disk files
 - If [MANUAL] conflicts detected: halt and present to user. If clean merge: auto-proceed
 
 ## MANDATORY SEQUENCE
@@ -132,6 +132,27 @@ Merge Results:
 
   stack_files_merged: [count] (if stack skill)
 ```
+
+### 6b. Write Merged Files to Disk
+
+Write the merged content produced by sections 3–5 directly to disk now. Later steps read from these files for validation and verification. The write must happen exactly once, here.
+
+**Write SKILL.md:**
+- Use the `Edit` or `Write` tool to write merged SKILL.md content to `{skill_package}/SKILL.md`
+- Preserve UTF-8 encoding
+- If the source version detected during step-03 differs from the previous metadata version, create the new `{skill_package}` directory (`{skill_group}/{new_version}/`) first and write there — the previous version's directory is preserved on disk. Update `{skill_package}` in context to point at the new path.
+
+**Write stack reference files (if `skill_type == "stack"`):**
+- For each affected file from section 5, use `Edit` or `Write` to write:
+  - `references/{library}.md` with merged per-library content
+  - `references/integrations/{pair}.md` with merged per-integration content
+- Preserve [MANUAL] blocks exactly as captured in section 2.
+
+**Do NOT write here:**
+- `metadata.json`, `provenance-map.json`, `evidence-report.md` — derived from merge + validation output, written by step-06 sections 2–4
+- `context-snippet.md` — regenerated from the on-disk SKILL.md + metadata.json by step-06 section 5
+
+**Halt-on-tool-failure:** If any `Edit`/`Write` call errors (permission denied, disk full, path invalid, etc.), halt and report the failure — do not proceed to step-05 validation. The skill package may be in a partial state and will need manual recovery before re-running update-skill.
 
 ### 7. Display Merge Summary
 

--- a/src/skf-update-skill/steps-c/step-05-validate.md
+++ b/src/skf-update-skill/steps-c/step-05-validate.md
@@ -27,7 +27,7 @@ Run: `npx skill-check -h`
 
 **Important:** Do not assume availability — empirical check required.
 
-**Validation timing note:** Step-04 produces an edit plan, not written files. Checks that require files on disk (skill-check Checks A, E, F) will be **deferred to post-write** — step-06 runs them after writing files. Structural checks (B, C, D) validate the planned merge content and run here.
+**Validation timing note:** Step-04 section 6b has already written SKILL.md (and stack reference files) to disk. External-tool checks against written files (skill-check Checks A, E, F) still run in **step-06 section 7** to co-locate external-tool validation with post-write verification. Structural checks (B, C, D) run here against the merged content — content on disk is byte-identical to the in-context copy.
 
 ### 2. Launch Parallel Validation Checks
 

--- a/src/skf-update-skill/steps-c/step-06-write.md
+++ b/src/skf-update-skill/steps-c/step-06-write.md
@@ -49,7 +49,14 @@ Update `{skill_package}/metadata.json`:
 
 Write to `{forge_version}/provenance-map.json`:
 
-**For each export in the updated skill:**
+**If `no_reextraction == true` (gap-driven mode from step-03 section 0):**
+No fresh extraction data exists for `verified` exports — their provenance entries stay byte-identical. Only apply targeted updates:
+- For `moved` exports: update `source_line` (and `source_file` if different) to the new location recorded by the spot-check
+- For `unknown` exports (not found in provenance map but present in gap manifest): add new entries with fields populated from step-04 merge output; `source_file`/`source_line` may be `null` if the export was undocumented and no fresh extraction was performed — leave these fields unset rather than writing stale values
+- Do NOT overwrite `confidence`, `extraction_method`, `ast_node_type`, `params[]`, or `return_type` for `verified` exports
+- Skip the "For each export in the updated skill" bullets below — they apply only to normal re-extraction mode
+
+**For each export in the updated skill (normal mode only):**
 - Update `export_name` if renamed
 - Update `params[]` array if parameters changed (add, remove, or modify individual entries)
 - Update `return_type` if changed

--- a/src/skf-update-skill/steps-c/step-06-write.md
+++ b/src/skf-update-skill/steps-c/step-06-write.md
@@ -6,26 +6,30 @@ nextStepFile: './step-07-report.md'
 
 ## STEP GOAL:
 
-Write all updated skill artifacts to disk: the merged SKILL.md, updated provenance-map.json with new timestamps and mappings, updated evidence-report.md with the update operation trail, and for stack skills, all affected reference files.
+Verify the merged SKILL.md and stack reference files that step-04 section 6b wrote to disk, then write the derived artifacts (metadata.json, provenance-map.json, evidence-report.md, context-snippet.md, and the active symlink).
 
 ## Rules
 
-- Focus only on writing files — all merge and validation is complete
-- Write exactly what was produced — do not modify merged content
+- Focus only on verifying merged files and writing derived artifacts — merge content was already written in step-04
+- Do not modify merged SKILL.md content — any mismatch detected during verification triggers HALT, not repair
 - Do not skip provenance map update — critical for future audits
+- HALT immediately on verification failure before writing any derived artifact — a partial-write skill package is worse than an unchanged one
 
 ## MANDATORY SEQUENCE
 
 **CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
 
-### 1. Write Updated SKILL.md
+### 1. Verify SKILL.md Write
 
-Write the merged SKILL.md content to `{skill_package}/SKILL.md`:
-- Overwrite the existing file with merged content
-- Preserve file encoding (UTF-8)
-- Verify write by reading back and confirming [MANUAL] section count matches expected
+SKILL.md was written in step-04 section 6b. Verify the write landed intact before proceeding to any derived-artifact writes.
 
-If the version changed (source version differs from the previous metadata version), write to the new `{skill_package}` (creating the version directory if needed). The previous version's directory is preserved on disk.
+- Read `{skill_package}/SKILL.md` from disk
+- Count `<!-- [MANUAL:*] -->` opening markers and compare against the [MANUAL] inventory captured in step-01
+- Verify the resolved `{skill_package}` path matches the version directory step-04 wrote to (if the version changed, step-04 updated `{skill_package}` in context to point at the new path)
+- If [MANUAL] count matches and path resolves: proceed to section 2
+- **If [MANUAL] count does not match: HALT immediately.** Do not write `metadata.json`, `provenance-map.json`, or any other artifact — further writes would compound the inconsistency. Alert the user:
+
+  "**[MANUAL] section count mismatch after write.** Expected {N} from step-01 inventory, found {M} on disk at `{skill_package}/SKILL.md`. The skill package is in an inconsistent state. Manual recovery required — restore the previous version from `{skill_group}/{previous_version}/` or fix the file in place, then re-run update-skill."
 
 ### 2. Write Updated metadata.json
 
@@ -119,14 +123,16 @@ Append update operation section to `{forge_version}/evidence-report.md` (create 
 - Provenance: {PASS/WARN/FAIL}
 ```
 
-### 5. Write Stack Skill Reference Files (Conditional) and Regenerate context-snippet.md
+### 5. Verify Stack Skill Reference File Writes (Conditional) and Regenerate context-snippet.md
 
 **ONLY if skill_type == "stack":**
 
-For each affected reference file from the merge:
-- Write updated `references/{library}.md` files
-- Write updated `references/integrations/{pair}.md` files
-- Verify [MANUAL] sections preserved in each reference file
+Stack reference files were written in step-04 section 6b. Verify each affected reference file that the merge produced:
+
+- Read each `references/{library}.md` back from disk
+- Read each `references/integrations/{pair}.md` back from disk
+- Verify per-file [MANUAL] section counts match the per-file inventory captured in step-01
+- **If any verification fails: HALT** using the same recovery protocol as section 1 — do not regenerate `context-snippet.md` or write any further derived artifact
 
 **For all skills (both single and stack) — regenerate `context-snippet.md`:**
 
@@ -157,23 +163,25 @@ If the version was incremented or changed in section 2 (metadata.json update):
 
 If the version did not change, the existing symlink already points to the correct version -- no action needed.
 
-### 6. Verify All Writes
+### 6. Verify Derived Artifact Writes
 
-For each file written:
+SKILL.md was verified in section 1 and stack reference files in section 5 (both written by step-04 section 6b). This section verifies the artifacts this step wrote: `metadata.json`, `provenance-map.json`, `evidence-report.md`, and `context-snippet.md`.
+
+For each derived artifact:
 - Read back the file
 - Confirm content matches expected output
-- Confirm [MANUAL] sections are intact (count comparison)
 - Report verification status
 
 "**Write Verification:**
 
 | File | Status |
 |------|--------|
-| SKILL.md | {VERIFIED/FAILED} |
+| SKILL.md | {VERIFIED in section 1} |
 | metadata.json | {VERIFIED/FAILED} |
 | provenance-map.json | {VERIFIED/FAILED} |
 | evidence-report.md | {VERIFIED/FAILED} |
-| {stack reference files...} | {VERIFIED/FAILED} |
+| context-snippet.md | {VERIFIED/FAILED} |
+| {stack reference files...} | {VERIFIED in section 5} |
 
 **All files written and verified.**"
 

--- a/src/skf-update-skill/steps-c/step-07-report.md
+++ b/src/skf-update-skill/steps-c/step-07-report.md
@@ -145,13 +145,7 @@ Based on the update results:"
 
 Write `{forge_version}/update-skill-result.json` per `shared/references/output-contract-schema.md`. Include all modified file paths in `outputs`; include `exports_affected`, `files_modified`, and `validation_status` (passed/warnings/failures) in `summary`.
 
-### 6. Workflow Complete
+### 6. Workflow Health Check
 
-"---
-
-**Update-skill workflow complete for `{skill_name}`.**"
-
-### 7. Workflow Health Check
-
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+Load and execute `{nextStepFile}` for workflow self-improvement check. The health check is the terminal step and will display the workflow-complete marker on exit.
 


### PR DESCRIPTION
## Summary

Three independent fixes in `skf-update-skill` (plus a cross-workflow banner cleanup) to resolve workflow friction and a missing gap-driven branch.

- **Premature workflow-complete banner** — removed across `update-skill`, `export-skill`, `create-stack-skill`, and `analyze-source`. `shared/health-check.md` already displays the terminal marker on all exit paths.
- **Gap-driven mode missing in step-03** — added Section 0 that spot-checks provenance-map citations against live source instead of re-extracting unchanged files, then jumps directly to step-04. Step-06 provenance writes now honor a `no_reextraction` flag.
- **"Do not write files" rule unenforceable** — reframed the step-04 ↔ step-06 write boundary. Step-04 gets a new section 6b that writes SKILL.md (and stack reference files) via `Edit`/`Write`; step-06 section 1 becomes a read-back verification with HALT-on-[MANUAL]-mismatch before any derived-artifact write.

Closes #107
Closes #108
Closes #109

## Test plan

- [x] Pre-commit hooks pass on each commit (verified locally — all three landed cleanly)
- [x] Run `skf-update-skill` end-to-end on a real source-drift scenario; confirm health check runs after the report step
- [x] Run `skf-update-skill --from-test-report` against a skill with a test report; confirm step-03 Section 0 performs citation spot-checks and jumps to merge without re-extracting
- [x] Run `skf-update-skill` with a source-version bump; confirm step-04 section 6b creates the new `{skill_package}` directory and step-06 section 1 verifies against the correct path
- [x] Run `skf-update-skill` on a stack skill; confirm reference files are written in step-04 and verified in step-06 section 5
- [x] Introduce a deliberate [MANUAL] block mismatch; confirm step-06 section 1 HALTs before writing metadata.json/provenance-map.json
- [x] Run `skf-export-skill`, `skf-create-stack-skill`, and `skf-analyze-source` report steps; confirm they no longer display terminal banners before the health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)