### PR TITLE
fix(skf): align tessl parse label with actual CLI output

### DIFF
--- a/src/skf-create-skill/steps-c/step-06-validate.md
+++ b/src/skf-create-skill/steps-c/step-06-validate.md
@@ -110,7 +110,7 @@ Record: "Security scan skipped — SNYK_TOKEN not configured"
 
 **If tessl available**, run: `npx -y tessl skill review <staging-skill-dir>`
 
-Parse output for: `description_score`, `content_score`, `average_score`, `validation_result`, `judge_suggestions[]`.
+Parse output for: `description_score`, `content_score`, `review_score`, `validation_result`, `judge_suggestions[]`.
 
 - **Content score < 70%:** Record warning: "Content quality warning: tessl scored content at {score}%."
 - **Unavailable:** Skip with note: "Content quality review skipped — tessl tool unavailable"

--- a/src/skf-test-skill/steps-c/step-04b-external-validators.md
+++ b/src/skf-test-skill/steps-c/step-04b-external-validators.md
@@ -94,13 +94,13 @@ npx -y tessl skill review {skillDir}
 **Parse the output** to extract:
 - `description_score` — percentage (e.g., 100%)
 - `content_score` — percentage (e.g., 45%)
-- `average_score` — percentage (e.g., 73%)
+- `review_score` — percentage (e.g., 73%)
 - `validation_result` — PASSED/FAILED
 - `judge_suggestions[]` — list of improvement suggestions
 
-The tessl output is human-readable text, not JSON. Parse the percentage values from lines like "Description: 100%", "Content: 45%", "Average Score: 73%".
+The tessl output is human-readable text, not JSON. Parse the percentage values from lines like "Description: 100%", "Content: 45%", "Review Score: 73%".
 
-Store in context: `tessl_description_score`, `tessl_content_score`, `tessl_average_score`, `tessl_suggestions`
+Store in context: `tessl_description_score`, `tessl_content_score`, `tessl_review_score`, `tessl_suggestions`
 
 **If tessl content score < 70%:** Flag a warning:
 
@@ -113,10 +113,10 @@ Store in context: `tessl_description_score`, `tessl_content_score`, `tessl_avera
 **If both tools ran:**
 
 ```
-external_score = (skill_check_score + tessl_average_score) / 2
+external_score = (skill_check_score + tessl_review_score) / 2
 ```
 
-Note: `skill_check_score` is 0-100, `tessl_average_score` is 0-100%. Both are on the same scale.
+Note: `skill_check_score` is 0-100, `tessl_review_score` is 0-100%. Both are on the same scale.
 
 **If only one tool ran:** Use that tool's score as the external score.
 
@@ -141,7 +141,7 @@ Append to `{outputFile}`:
 - **Validation:** {PASSED/FAILED}
 - **Description Score:** {score}%
 - **Content Score:** {score}%
-- **Average Score:** {score}%
+- **Review Score:** {score}%
 - **Suggestions:**
 {bulleted list of judge suggestions}
 


### PR DESCRIPTION
## Summary
- tessl CLI prints `Review Score: NN%`, not `Average Score: NN%` — rename the parse label, example, and `tessl_average_score` variable so the agent extracts the score deterministically instead of inferring which line is the intended target.
- Fixes the same stale label in `skf-create-skill/step-06-validate.md` (not mentioned in the issue, but same root cause).

Fixes #111

## Test plan
- [x] `grep -r "Average Score\|average_score\|tessl_average"` returns no matches
- [x] Pre-commit test suite passes (schemas, install, CLI, workflow, python, knowledge, validate, lint, format)
- [x] Next `skf-test-skill` run parses `Review Score` from tessl output without friction

🤖 Generated with [Claude Code](https://claude.com/claude-code)