### PR TITLE
docs(skf-test-skill): shared/ path resolution + empty-barrel package branch

### DIFF
--- a/src/skf-test-skill/references/source-access-protocol.md
+++ b/src/skf-test-skill/references/source-access-protocol.md
@@ -8,6 +8,7 @@
 - **TypeScript/JavaScript:** named exports from `index.ts` / `index.js` — exclude unexported locals
 - **Go:** exported identifiers (capitalized) from the package's public-facing files
 - **Rust:** items in `pub use` from `lib.rs` or `mod.rs`
+- **Empty-barrel packages (copy-paste / subpath-only distribution):** If the primary entry point is empty or re-exports nothing (e.g., `export {};` in `index.ts`, an empty `__init__.py`, `lib.rs` with no `pub use`), the package does not expose a barrel API. Do **not** compute coverage against the empty barrel — the denominator would be zero and the score meaningless. Instead, consult the skill brief's `scope.include` globs (`forge-data/{skill_name}/skill-brief.yaml`) to identify the authorized entry points, and build the public API surface from the **union of named exports across those files**. The skill brief's `scope.notes` field should document this distribution model explicitly; if present, treat it as confirmation that the empty barrel is by design rather than a bug. If no skill brief is available and the barrel is empty, set `analysis_confidence: docs-only` and report that the source API surface could not be determined.
 
 Internal module symbols are **excluded** from the coverage denominator unless they are explicitly documented in SKILL.md (in which case they count as documented extras, not missing coverage).
 

--- a/src/skf-test-skill/steps-c/step-01-init.md
+++ b/src/skf-test-skill/steps-c/step-01-init.md
@@ -4,6 +4,9 @@ outputFile: '{forge_version}/test-report-{skill_name}.md'
 templateFile: 'templates/test-report-template.md'
 sidecarFile: '{sidecar_path}/forge-tier.yaml'
 skillsOutputFolder: '{skills_output_folder}'
+# frontmatterScript `shared/scripts/skf-validate-frontmatter.py` resolves
+# relative to the SKF module root (`_bmad/skf/` when installed, `src/` during
+# development), NOT relative to this step file.
 frontmatterScript: 'shared/scripts/skf-validate-frontmatter.py'
 versionPathsKnowledge: 'knowledge/version-paths.md'
 ---

--- a/src/skf-test-skill/steps-c/step-06-report.md
+++ b/src/skf-test-skill/steps-c/step-06-report.md
@@ -7,6 +7,9 @@ nextStepFile: 'shared/health-check.md'
 outputFile: '{forge_version}/test-report-{skill_name}.md'
 scoringRulesFile: 'references/scoring-rules.md'
 outputFormatsFile: 'assets/output-section-formats.md'
+# outputContractSchema `shared/references/output-contract-schema.md` resolves
+# relative to the SKF module root (`_bmad/skf/` when installed, `src/` during
+# development), NOT relative to this step file.
 outputContractSchema: 'shared/references/output-contract-schema.md'
 ---
 


### PR DESCRIPTION
## Summary

- **Fixes #119** — add per-key `shared/` path resolution comments above `outputContractSchema` (`step-06-report.md`) and `frontmatterScript` (`step-01-init.md`). The existing comment was scoped to `nextStepFile` only, so readers hitting the other keys had to guess (or fail a `Read`) before learning that `shared/` resolves from the SKF module root.
- **Fixes #118** — add a fifth bullet to the "Source API Surface Definition" section of `source-access-protocol.md` covering empty-barrel packages (copy-paste / subpath-only distribution). Following the protocol literally on such a package yields a zero-export denominator and a meaningless coverage score; the new bullet points the reader at the skill brief's `scope.include` globs and defines how to build the public API surface from their union.

Documentation-only. No code, no schema changes.

## Regression review

- YAML frontmatter parsers tolerate the per-key comment style (verified); `skf-validate-frontmatter.py` targets SKILL.md files only, so step files are unaffected either way.
- `Source API Surface Definition` is referenced by section heading only (`step-03-coverage-check.md:39`), not by bullet count or specific language — the additional bullet is backwards-compatible.
- `scoring-rules.md` references the protocol's State 2 rules, not the surface definition.
- The full pre-commit test suite (schemas, install, CLI, workflow, python, knowledge, validators, lint, markdownlint, format) passed on both commits.

## Test plan

- [x] `shared/` path resolution comments render correctly in the source and do not break frontmatter loading on a live `skf-test-skill` run
- [x] `source-access-protocol.md` renders the new bullet under "Source API Surface Definition" without breaking section anchors referenced by `step-03-coverage-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)