### PR TITLE
fix(skf-update-skill): resolve 3 gap-driven health-check findings

### DIFF
--- a/src/skf-update-skill/steps-c/step-02-detect-changes.md
+++ b/src/skf-update-skill/steps-c/step-02-detect-changes.md
@@ -36,7 +36,7 @@ Load the test report at `{test_report_path}` and extract findings:
 | Medium | Stale documentation | MODIFIED_EXPORT (docs reference removed export) |
 | Low | Missing metadata/examples | metadata update |
 
-4. Build the change manifest from translated gaps — no file-level timestamp comparison needed since source hasn't changed
+4. Build the change manifest from translated gaps — no file-level timestamp comparison needed since source hasn't changed. **For each manifest entry, if the corresponding test report finding includes a source citation (`file:line` — e.g., a Gap Report row that cites `packages/utils/src/builder-utils.ts:33`), preserve it on the entry as `source_citation: {file, line}`.** Step-03 §0 uses this field to perform a live spot-check against source rather than flagging the export as `unknown`. If the test report lacks a citation for a finding, omit the field — step-03 will record the entry as `unknown` with no spot-check attempted.
 5. Set `gap_count` from the total number of translated entries
 6. **Skip to section 5** (Display Change Summary) with the gap-derived manifest
 

--- a/src/skf-update-skill/steps-c/step-03-re-extract.md
+++ b/src/skf-update-skill/steps-c/step-03-re-extract.md
@@ -31,7 +31,9 @@ Source code has not drifted — the gap-derived manifest from step-02 contains e
 1. Use the provenance map already loaded in step-01 (at `{forge_version}/provenance-map.json`) — do not re-read
 2. For each entry in the gap-derived change manifest from step-02:
    - Look up the export by `name` in `provenance_map.exports` — read `source_file` and `source_line`
-   - **If export not found in provenance map:** record as new (`provenance_citation: unknown`) — no spot-check possible; flag for merge step to handle as `NEW_EXPORT`
+   - **If export not found in provenance map:**
+     - **If the manifest entry has a `source_citation` (propagated from the test report by step-02 §0 bullet 4):** read the file at that citation's `file:line ± 5` lines and verify the symbol name still appears within that window. Record a full `verified` / `moved` / `missing` entry using the citation as the starting location — same spot-check logic as the "export found" branch below, keyed on the manifest-supplied citation instead of the provenance map. The export is still flagged `NEW_EXPORT` for the merge step; this branch only upgrades the provenance entry from `unknown` to a live spot-check result so step-06 writes `source_file` / `source_line` instead of `null`.
+     - **If the manifest entry has no `source_citation`:** record as new (`provenance_citation: unknown`) — no spot-check possible; flag for merge step to handle as `NEW_EXPORT`.
    - **If export found:** read the source file at `source_line ± 5` lines and verify the symbol name still appears within that window
    - Record verification outcome: `verified` (symbol at recorded line), `moved` (symbol found elsewhere in same file — record new line), or `missing` (symbol not found in file)
 3. Build a minimal extraction results block matching section 4's shape, with `mode: gap-driven` and per-export verification records:

--- a/src/skf-update-skill/steps-c/step-06-write.md
+++ b/src/skf-update-skill/steps-c/step-06-write.md
@@ -58,7 +58,7 @@ SKILL.md was written in step-04 section 6b. Verify the write landed intact befor
 ### 2. Write Updated metadata.json
 
 Update `{skill_package}/metadata.json`:
-- Update `version`: if a source version was detected during re-extraction and differs from the current metadata version, use the source version; otherwise increment patch version
+- Update `version`: **if `update_mode == "gap-driven"`, do not bump — the skill is being repaired against the same source commit, so leave `version` unchanged and update only `generation_date` / `last_update` below.** This keeps metadata `version` consistent with the on-disk `{skill_package}` path, which step-04 §6b also leaves unchanged in gap-driven mode (see step-04 §6b's "If the source version detected during step-03 differs..." carve-out — in gap-driven mode no source version is detected, so step-04 writes into the existing version directory). Otherwise, if a source version was detected during re-extraction and differs from the current metadata version, use the source version; otherwise increment patch version
 - Update `generation_date` timestamp to current ISO-8601 date
 - Update `exports` array to reflect current export list
 - Update `stats` from re-extraction results:

--- a/src/skf-update-skill/steps-c/step-06-write.md
+++ b/src/skf-update-skill/steps-c/step-06-write.md
@@ -151,9 +151,16 @@ Append update operation section to `{forge_version}/evidence-report.md` (create 
 - Triggering tool: {tool_name or —}
 - Original description preserved: {true/false}
 - Notes: {one-sentence detail or —}
+
+### Context Snippet
+- Regenerated: {true/false}
+- Triggers fired: {list or —}
+- Notes: {one-sentence detail or —}
 ```
 
 **Description Guard population** (used by §7 Post-Write Validation when the §0 protocol fires): fill all four fields from context when `description_guard_restored == true` (triggering tool, whether restore succeeded, what changed). When `Restored: false`, the other three fields are `—` — this is the clean-run expected state. Same field semantics and populator logic as create-skill step-06 §8.
+
+**Context Snippet population** (used by §5 after the staleness check runs): §4 writes the sub-block with placeholders; §5 updates the on-disk evidence report in place after deciding whether to regenerate. Set `Regenerated: true` and populate `Triggers fired` with any combination of `headline-exports`, `version`, `gotchas` when at least one trigger fired. Set `Regenerated: false` and `Triggers fired: —` when none fired (the gap-driven / internals-only outcome). Always fill `Notes` with a one-sentence reason (e.g., `"Gap-driven repair — no snippet surface changed"`, `"Version bumped 0.1.0 → 0.2.0; headline exports re-ranked"`).
 
 ### 5. Verify Stack Skill Reference File Writes (Conditional) and Regenerate context-snippet.md
 
@@ -166,11 +173,21 @@ Stack reference files were written in step-04 section 6b. Verify each affected r
 - Verify per-file [MANUAL] section counts match the per-file inventory captured in step-01
 - **If any verification fails: HALT** using the same recovery protocol as section 1 — do not regenerate `context-snippet.md` or write any further derived artifact
 
-**For all skills (both single and stack) — regenerate `context-snippet.md`:**
+**For all skills (both single and stack) — regenerate `context-snippet.md` if stale:**
 
-Per `knowledge/version-paths.md` "Writing Workflows (CS, QS, SS, US)", update-skill is a writing workflow that MUST write all deliverables to `{skill_package}`. `context-snippet.md` is one of those deliverables and goes stale whenever exports, version, or gotchas change.
+`context-snippet.md` is a `{skill_package}` deliverable that goes stale whenever **headline exports**, **version**, or **gotchas** change in this run. Regenerate it only when at least one of these triggers fired; otherwise skip — a skip is the correct outcome for gap-driven repairs and other runs that touch internals below the snippet's surface, where regenerating would produce byte-identical content.
 
-Regenerate the snippet using the format from the matching template file:
+**Staleness triggers:**
+
+- **Headline exports changed** — the top-K exports surfaced in the snippet differ from the prior snippet (a `NEW_EXPORT` was promoted into a headline slot, or a `MODIFIED_EXPORT` changed the signature/shape of a surfaced export).
+- **Version changed** — §2 bumped `version` (normal mode with detected source drift; never fires in gap-driven mode per §2's carve-out).
+- **Gotchas changed** — new gotchas surfaced from this run's evidence that were not in the prior snippet, or a prior gotcha was invalidated and removed.
+
+**Record the decision on the on-disk evidence report:** open `{forge_version}/evidence-report.md` (written by §4 with placeholder values in the `### Context Snippet` sub-block) and update that sub-block under the Update Operation section just written. Set `Regenerated: true|false`, fill `Triggers fired:` with the list of triggers that fired (or `—` when none), and write a one-sentence `Notes:` entry. See §4's "Context Snippet population" note for field semantics.
+
+**If no trigger fired:** skip regeneration — do not touch `context-snippet.md` on disk. The snippet remains valid against the prior run's surface. Continue to §5b.
+
+**If at least one trigger fired:** regenerate the snippet using the format from the matching template file:
 
 - For single skills: `skf-create-skill/assets/skill-sections.md` (pipe-delimited indexed format)
 - For stack skills: `skf-create-stack-skill/assets/stack-skill-template.md`


### PR DESCRIPTION
## Summary

Fixes three open health-check findings on `skf-update-skill` that surfaced during a real gap-driven repair run of `oms-uitripled` v0.1.0. All three are surgical step-file edits — no behavior change outside `update_mode == "gap-driven"` paths.

- **Fixes #122** — step-02 §0 now preserves `source_citation` (`file:line`) from the test report Gap Report onto each gap-driven manifest entry, and step-03 §0 consumes it to perform a live spot-check against source instead of flagging the export as `unknown`. Previously, exports not in the provenance map forced `provenance_citation: unknown` even when the test report had already cited a precise location — which then made step-06 §3 write `source_file` / `source_line` as `null`, tripping the next audit-skill run.
- **Fixes #121** — step-06 §2 now has a gap-driven carve-out on the version-bump bullet. When `update_mode == "gap-driven"`, `version` stays unchanged (only `generation_date` / `last_update` move forward). This keeps metadata `version` in lockstep with the on-disk `{skill_package}` path, which step-04 §6b already leaves unchanged in gap-driven mode. Previously a gap-driven repair produced metadata `version: 0.1.1` with files still under `skills/{skill}/0.1.0/{skill}/` — an inconsistency that broke subsequent audit / export runs.
- **Fixes #123** — step-06 §5 no longer carries the contradictory "MUST write all deliverables" / "goes stale whenever X changes" pair. The rule is now explicit: regenerate `context-snippet.md` only when at least one of `{headline-exports, version, gotchas}` changed in this run; otherwise skip regeneration (the correct outcome for gap-driven repairs that touch internals below the snippet's surface). The outcome is recorded via a new `### Context Snippet` sub-block in §4's Update Operation evidence-report template, populated by §5 in place — mirroring the existing `### Description Guard` sub-block pattern.

## Regression review

All edits scoped to `src/skf-update-skill/steps-c/step-{02,03,06}-*.md`. Downstream impact checks:

- `source_citation` is consumed only by step-03 §0. Step-04 merge iterates the manifest via its declared schema (`{export_name, change_type, old_line, new_line}`) and ignores additive fields. Step-06 §3 reads step-03's extraction records (which are now richer), not the manifest.
- `update_mode == "gap-driven"` is already referenced in step-01/02/03; the step-06 §2 addition aligns with step-04 §6b's existing "source version detected" gate — gap-driven runs reach "don't bump version" through both paths.
- No parser exists for evidence-report sub-blocks. Grepped: zero Python consumers; `Description Guard` (the template the new sub-block mirrors) only appears in prose. `skf-audit-skill` does not reference `context_snippet`. Step-07 report treats `evidence-report.md` as "Appended" without peeking inside.
- `tools/validate-file-refs.js`: 225 references checked, 0 broken, 0 absolute path leaks (before and after every commit).
- Full test suite (`npm test`) ran via pre-commit hook on all three commits: schemas / install / CLI / workflow / python / knowledge / validate-schemas / validate-skills / validate-refs / lint / lint:md / format:check — all passing.

## Out-of-scope observation (not fixed in this PR)

Commit B's gap-driven carve-out does not cover `source_type == "docs-only"`. In docs-only mode step-03 re-fetches documentation rather than re-extracting source, so no source version is detected — and step-06 §2 without a docs-only carve-out would fall through to "increment patch version", producing the same metadata/path mismatch that #121 flagged for gap-driven mode. This is pre-existing (not introduced by this PR) and strictly outside #121's scope. Worth a separate health-check issue if confirmed in a real docs-only update run.

## Test plan

- [x] Run a gap-driven repair on a test skill whose test report Gap Report cites exports not in the provenance map; confirm step-03 §0 spot-checks them and step-06 §3 writes `source_file` / `source_line` instead of `null`.
- [x] Run a gap-driven repair on a skill at version `0.1.0`; confirm metadata `version` stays `0.1.0` and `{skill_package}` path is unchanged after the run.
- [x] Run a gap-driven repair that touches internals without changing headline exports / version / gotchas; confirm `context-snippet.md` is NOT rewritten and the evidence report's `### Context Snippet` sub-block reads `Regenerated: false`, `Triggers fired: —`.
- [x] Run a normal-mode update with a headline-export change; confirm `### Context Snippet` reads `Regenerated: true`, `Triggers fired: headline-exports`.
- [x] Run `skf-audit-skill` on a skill updated via gap-driven repair; confirm no null-provenance findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)