### PR TITLE
feat(health-check): announce arrival on entry for all chaining workflows

### DIFF
--- a/src/shared/health-check.md
+++ b/src/shared/health-check.md
@@ -38,6 +38,16 @@ Reflect on the workflow that just completed. If real friction, bugs, or gaps wer
 
 ## MANDATORY SEQUENCE
 
+### 0. Announce Arrival
+
+**Display in `{communication_language}`:**
+
+"**Running a quick self-improvement check on this workflow.** If nothing rough came up, I'll close out immediately."
+
+**GATE [default: skip]** — If `{headless_mode}`: skip the display entirely, log: "headless: skipped health-check arrival announcement".
+
+**If interactive:** display the line above, then proceed to step 1 (Read Workflow Context) without waiting. The line is informational, not a commitment gate — the user's commitment to continuing was already captured upstream (either via an explicit menu in the calling step or by auto-chain). This announcement just tells them what is about to happen.
+
 ### 1. Read Workflow Context
 
 From the current session context, identify:


### PR DESCRIPTION
## Summary

- Adds a `### 0. Announce Arrival` section at the start of `src/shared/health-check.md`'s mandatory sequence that displays a single descriptive line — *"Running a quick self-improvement check on this workflow. If nothing rough came up, I'll close out immediately."* — before the reflective-auditor logic runs.
- The announcement is suppressed under `{headless_mode}` (log-only), so `skf-forger` pipelines and other non-interactive runs see zero friction.
- Single source of truth — the hint lives in one file and reaches all 14 workflows that chain into the shared health check. No per-caller edits, no new files, no new variables, no two-hop path resolution, no documentation drift.

## Why

All 14 SKF workflows chain to `shared/health-check.md` as their terminal step. Before this change, 13 of them auto-chained silently — users had no visible signal about what the next step was doing. This change makes the terminal step's purpose visible to users in all 14 workflows via a single edit in the one file every workflow already passes through.

The approach was selected after a long planning session that explored two more elaborate designs (per-file inline menus in 14 files, and a new `shared/finish-menu.md` intermediate step with frontmatter redirects). Both were rejected in favor of this minimal shape:

- The inline-per-file design shipped the hint sentence as 14 duplicated copies with guaranteed drift.
- The `shared/finish-menu.md` design depended on a `{finish_gate}` variable that has no resolution mechanism in the current SKF variable system, and introduced a two-hop path-resolution pattern the codebase has no precedent for.

The full reasoning trail is preserved in `_bmad-output/todo/plan-health-check-finish-hint.md` (not part of this PR) for future reference.

## Test plan

- [x] `npm run validate:skills` (strict) — 0 errors on `src/shared/health-check.md`
- [x] `npm run lint:md` — 0 errors across 173 markdown files
- [x] Pre-commit hook (full test suite via `npm test`) — passed
- [x] Manual interactive smoke: run `skf-test-skill` against a fixture; confirm the announcement line appears after pressing `[C] Finish` at the report menu
- [x] Manual auto-chain smoke: run `skf-drop-skill` against a fixture; confirm the announcement line appears on chain-in with no caller menu
- [x] Manual headless smoke: run `skf-forger` against a fixture with `{headless_mode}=true`; confirm the announcement is suppressed (log-only) and no stalls occur
- [x] Manual language smoke: run one workflow with `{communication_language}` set to a non-English value; confirm the announcement is translated (no menu keys to preserve, so no mixed-mode concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)