### PR TITLE
docs: rephrase BMad intro and swap lodash for cocoindex in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You'll be prompted for project name, output folders, and IDE configuration. See 
 1. **Set up your environment:** `@Ferris SF` — detects your tools and sets your capability tier
 2. **Generate your first skill:** `@Ferris QS <package-name>` — creates a verified skill in under a minute
 3. **Full quality path:** `@Ferris BS` → clear session → `@Ferris CS` — brief first, then compile for maximum accuracy
-4. **Pipeline mode:** `@Ferris forge lodash` — chains Brief → Create → Test → Export in one command
+4. **Pipeline mode:** `@Ferris forge cocoindex` — chains Brief → Create → Test → Export in one command
 
 > **Tip:** Start a fresh conversation before each workflow (or use pipeline mode to chain them automatically). SKF workflows load significant context — clearing between them prevents interference.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -113,7 +113,7 @@ Or one workflow per session:
 Sarah prepares v3.0.0 with breaking changes.
 
 ```
-@Ferris maintain lodash
+@Ferris maintain cocoindex
 ```
 
 Or one workflow per session:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ Ferris reads the repository, extracts the public API, and generates a skill in u
 
 **Full quality path (pipeline mode):**
 ```
-@Ferris forge https://github.com/lodash/lodash lodash
+@Ferris forge https://github.com/cocoindex-io/cocoindex cocoindex
 ```
 
 `forge` chains Brief → Create → Test → Export. It needs an explicit repo URL **and** a skill name because it starts with Brief Skill (BS), which doesn't guess targets. If you just want a fast skill from a package name, use `@Ferris forge-quick cognee` instead — that starts with Quick Skill (QS), which resolves packages via the registry.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -11,7 +11,7 @@ This page is for people who want to understand how SKF works under the hood. It 
 
 ## How BMad Works
 
-[BMad](https://docs.bmad-method.org/) works because it turns big, fuzzy work into **repeatable workflows**. Each workflow is broken into small steps with clear instructions, so the AI follows the same path every time. It also uses a **shared knowledge base** (standards and patterns) so outputs are consistent, not random. In short: **structured steps + shared standards = reliable results**.
+[BMad](https://docs.bmad-method.org/) tackles complex, open-ended work by decomposing it into **repeatable workflows**. Every workflow is a sequence of small, explicit steps, so the AI takes the same route on every run. A **shared knowledge base** of standards and patterns backs those steps, keeping outputs consistent instead of improvised. The formula is simple: **structured steps + shared standards = reliable results**.
 
 ## How SKF Fits In
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -290,7 +290,7 @@ Instead of running one workflow per session, you can chain multiple workflows in
 
 ```
 @Ferris BS CS TS EX                    — space-separated codes
-@Ferris QS[lodash] TS EX               — with target argument in brackets
+@Ferris QS[cocoindex] TS EX            — with target argument in brackets
 @Ferris CS TS[min:80] EX               — with circuit breaker threshold override
 @Ferris forge-quick cognee             — named alias with target
 ```
@@ -321,7 +321,7 @@ Instead of running one workflow per session, you can chain multiple workflows in
 @Ferris forge-quick @tanstack/query                                  — QS + TS + EX for TanStack Query
 @Ferris forge https://github.com/topoteretes/cognee cognee           — BS + CS + TS + EX, explicit URL + name
 @Ferris forge https://github.com/topoteretes/cognee cognee "public API only"   — with scope hint
-@Ferris maintain lodash                                              — AS + US + TS + EX for an existing lodash skill
+@Ferris maintain cocoindex                                           — AS + US + TS + EX for an existing cocoindex skill
 @Ferris onboard                                                      — AN + CS + TS + EX on the current project
 ```
 
@@ -332,7 +332,7 @@ Instead of running one workflow per session, you can chain multiple workflows in
 Add `--headless` or `-H` to any workflow command to skip all confirmation gates. Ferris auto-proceeds with default actions (typically "Continue") and logs each auto-decision. Progress output is still shown — headless skips interaction, not reporting.
 
 ```
-@Ferris QS lodash --headless     — quick skill with no interaction gates
+@Ferris QS cocoindex --headless  — quick skill with no interaction gates
 @Ferris TS --headless             — test a skill without the review pause
 @Ferris EX -H                    — export with auto-approved context update
 ```

--- a/src/knowledge/skill-lifecycle.md
+++ b/src/knowledge/skill-lifecycle.md
@@ -177,7 +177,7 @@ forge                 — alias for BS CS TS EX
 forge-quick           — alias for QS TS EX
 onboard               — alias for AN CS TS EX
 maintain              — alias for AS US TS EX
-CS[lodash] TS[min:80] EX  — with arguments and circuit breakers
+CS[cocoindex] TS[min:80] EX  — with arguments and circuit breakers
 ```
 
 Pipelines automatically activate headless mode. The forger passes data between workflows using the artifact flow described above. Circuit breakers halt the pipeline when output quality falls below a threshold (e.g., TS score < 60 blocks EX). See `shared/references/pipeline-contracts.md` for the full specification.

--- a/src/shared/references/headless-gate-convention.md
+++ b/src/shared/references/headless-gate-convention.md
@@ -53,7 +53,7 @@ Presents a menu with multiple options (P/I/A, etc.).
 
 For skills that require user input (skill name, target path, etc.), headless mode accepts arguments via the invocation. Each skill's Invocation Contract documents its required headless args.
 
-Example: `@Ferris QS lodash --headless` passes `lodash` as the target and skips all gates.
+Example: `@Ferris QS cocoindex --headless` passes `cocoindex` as the target and skips all gates.
 
 ## What Headless Does NOT Skip
 

--- a/src/shared/references/pipeline-contracts.md
+++ b/src/shared/references/pipeline-contracts.md
@@ -11,7 +11,7 @@ The forger recognizes pipeline invocations when the user provides multiple workf
 ```
 AN CS TS EX              — space-separated codes
 AN -> CS -> TS -> EX     — arrow-separated (equivalent)
-BS CS[lodash] TS EX      — with target argument in brackets
+BS CS[cocoindex] TS EX   — with target argument in brackets
 CS TS[min:80] EX         — with circuit breaker threshold
 ```
 
@@ -68,7 +68,7 @@ Override syntax: `TS[min:80]` sets the test-skill threshold to 80 for this pipel
 Brackets after a workflow code (`CODE[value]`) are parsed as follows:
 
 - **Circuit breaker override**: `min:N` where N is a number — e.g., `TS[min:80]` sets the threshold for that workflow
-- **Target argument**: any other value — e.g., `CS[lodash]` passes "lodash" as the target to CS
+- **Target argument**: any other value — e.g., `CS[cocoindex]` passes "cocoindex" as the target to CS
 
 Only workflows with a circuit breaker entry (AN, CS, TS, AS, VS) accept `min:N` overrides. All other workflows ignore `min:N` brackets. Target arguments are valid for any workflow that accepts a named input (CS, QS, BS, US, etc.).
 
@@ -84,9 +84,9 @@ pipeline:
     - {code: AN, status: ok, output: {units: 3, briefs: [...]}}
   pending: [CS, TS, EX]
   data:
-    skill_name: "lodash"
+    skill_name: "cocoindex"
     brief_path: "/path/to/skill-brief.yaml"
-    target: "lodash"
+    target: "cocoindex"
 ```
 
 ## Anti-Patterns

--- a/src/skf-forger/SKILL.md
+++ b/src/skf-forger/SKILL.md
@@ -84,7 +84,7 @@ When the user provides multiple workflow codes (e.g., `BS CS TS EX`, `QS TS EX`,
 
 **Pipeline activation:**
 
-1. **Parse the sequence** — split codes, expand aliases (`forge` → `BS CS TS EX`, `forge-quick` → `QS TS EX`, `onboard` → `AN CS TS EX`, `maintain` → `AS US TS EX`), extract any bracket arguments (`CS[lodash]`, `TS[min:80]`)
+1. **Parse the sequence** — split codes, expand aliases (`forge` → `BS CS TS EX`, `forge-quick` → `QS TS EX`, `onboard` → `AN CS TS EX`, `maintain` → `AS US TS EX`), extract any bracket arguments (`CS[cocoindex]`, `TS[min:80]`)
 2. **Validate the sequence** — check for anti-patterns (EX before TS, CS without BS, duplicates). If found, warn the user and ask to confirm or adjust. In `{headless_mode}`, warn but proceed.
 3. **Set `{headless_mode}` = true** — pipelines auto-activate headless mode for all workflows in the chain. The user committed to the sequence by providing it.
 4. **Execute left to right** — for each workflow in the sequence:

--- a/src/skf-quick-skill/steps-c/step-01-resolve-target.md
+++ b/src/skf-quick-skill/steps-c/step-01-resolve-target.md
@@ -26,7 +26,7 @@ Provide a **GitHub URL** or **package name** and I'll resolve it to source and c
 
 **Target:** (GitHub URL or package name)
 
-Examples: `lodash`, `@tanstack/query`, `https://github.com/tursodatabase/limbo`, `cognee@0.5.0`
+Examples: `cocoindex`, `@tanstack/query`, `https://github.com/tursodatabase/limbo`, `cognee@0.5.0`
 
 **Optional:**
 - **Language hint:** (if the repo is multi-language)

--- a/test/test-skf-manifest-ops.py
+++ b/test/test-skf-manifest-ops.py
@@ -36,11 +36,11 @@ class TestManifestOps:
 
     def test_set_and_get_skill(self, manifest_path):
         """S2: Set a skill and verify v2 persistence."""
-        r = mod.cmd_set(manifest_path, "lodash", "2.0.0")
+        r = mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
         assert r["status"] == "ok"
         assert r["version"] == "2.0.0"
         # Verify written in v2 format
-        r = mod.cmd_get(manifest_path, "lodash")
+        r = mod.cmd_get(manifest_path, "cocoindex")
         assert r["entry"]["active_version"] == "2.0.0"
         assert isinstance(r["entry"]["versions"], dict)
         assert "2.0.0" in r["entry"]["versions"]
@@ -48,9 +48,9 @@ class TestManifestOps:
 
     def test_update_version(self, manifest_path):
         """S3: Update version archives old, activates new."""
-        mod.cmd_set(manifest_path, "lodash", "2.0.0")
-        mod.cmd_set(manifest_path, "lodash", "2.1.0")
-        r = mod.cmd_get(manifest_path, "lodash")
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
+        mod.cmd_set(manifest_path, "cocoindex", "2.1.0")
+        r = mod.cmd_get(manifest_path, "cocoindex")
         assert r["entry"]["active_version"] == "2.1.0"
         assert "2.0.0" in r["entry"]["versions"]
         assert "2.1.0" in r["entry"]["versions"]
@@ -59,17 +59,17 @@ class TestManifestOps:
 
     def test_get_nonexistent(self, manifest_path):
         """S4: Get nonexistent."""
-        mod.cmd_set(manifest_path, "lodash", "2.0.0")
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
         r = mod.cmd_get(manifest_path, "react")
         assert r["status"] == "not_found"
-        assert "lodash" in r["available"]
+        assert "cocoindex" in r["available"]
 
     def test_deprecate_skill(self, manifest_path):
         """S5: Deprecate all versions via v2 status field."""
-        mod.cmd_set(manifest_path, "lodash", "2.0.0")
-        r = mod.cmd_deprecate(manifest_path, "lodash")
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
+        r = mod.cmd_deprecate(manifest_path, "cocoindex")
         assert r["status"] == "ok"
-        r = mod.cmd_get(manifest_path, "lodash")
+        r = mod.cmd_get(manifest_path, "cocoindex")
         assert r["entry"]["versions"]["2.0.0"]["status"] == "deprecated"
 
     def test_deprecate_specific_version(self, manifest_path):
@@ -92,23 +92,23 @@ class TestManifestOps:
 
     def test_rename_collision(self, manifest_path):
         """S8: Rename collision."""
-        mod.cmd_set(manifest_path, "lodash", "2.0.0")
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
         mod.cmd_set(manifest_path, "react-dom", "18.0.0")
-        r = mod.cmd_rename(manifest_path, "lodash", "react-dom")
+        r = mod.cmd_rename(manifest_path, "cocoindex", "react-dom")
         assert r["status"] == "error"
         assert "already exists" in r["error"]
 
     def test_remove_skill(self, manifest_path):
         """S9: Remove."""
-        mod.cmd_set(manifest_path, "lodash", "2.0.0")
-        r = mod.cmd_remove(manifest_path, "lodash")
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
+        r = mod.cmd_remove(manifest_path, "cocoindex")
         assert r["status"] == "ok"
-        r = mod.cmd_get(manifest_path, "lodash")
+        r = mod.cmd_get(manifest_path, "cocoindex")
         assert r["status"] == "not_found"
 
     def test_schema_version_written(self, manifest_path):
         """S10: Manifest includes schema_version 2."""
-        mod.cmd_set(manifest_path, "lodash", "2.0.0")
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
         r = mod.cmd_read(manifest_path)
         assert r["manifest"]["schema_version"] == "2"
 
@@ -116,7 +116,7 @@ class TestManifestOps:
         """S11: V1 manifest is migrated to v2 on read."""
         v1_data = {
             "exports": {
-                "lodash": {
+                "cocoindex": {
                     "active_version": "1.0.0",
                     "versions": ["1.0.0"],
                     "deprecated": False,
@@ -125,7 +125,7 @@ class TestManifestOps:
             "updated_at": "2026-04-01T00:00:00+00:00",
         }
         manifest_path.write_text(json.dumps(v1_data))
-        r = mod.cmd_get(manifest_path, "lodash")
+        r = mod.cmd_get(manifest_path, "cocoindex")
         assert r["status"] == "ok"
         assert isinstance(r["entry"]["versions"], dict)
         assert "1.0.0" in r["entry"]["versions"]

--- a/test/test-skf-skill-inventory.py
+++ b/test/test-skf-skill-inventory.py
@@ -70,12 +70,12 @@ class TestSkfSkillInventory:
         assert result["summary"]["total_skills"] == 0
 
     def test_single_versioned_skill(self, skills_dir):
-        make_skill(skills_dir, "lodash", "2.1.0", with_provenance=True)
+        make_skill(skills_dir, "cocoindex", "2.1.0", with_provenance=True)
         result = scan_inventory(str(skills_dir))
         assert result["status"] == "ok"
         assert result["summary"]["total_skills"] == 1
         s = result["skills"][0]
-        assert s["name"] == "lodash"
+        assert s["name"] == "cocoindex"
         assert s["active_version"] == "2.1.0"
         assert s["has_skill_md"] is True
         assert s["has_provenance_map"] is True
@@ -110,9 +110,9 @@ class TestSkfSkillInventory:
         assert result["code"] == "DIR_NOT_FOUND"
 
     def test_with_export_manifest(self, skills_dir):
-        make_skill(skills_dir, "lodash", "2.0.0")
-        manifest = {"exports": {"lodash": {"active_version": "2.0.0"}}}
+        make_skill(skills_dir, "cocoindex", "2.0.0")
+        manifest = {"exports": {"cocoindex": {"active_version": "2.0.0"}}}
         (skills_dir / ".export-manifest.json").write_text(json.dumps(manifest))
         result = scan_inventory(str(skills_dir))
         assert result["manifest"] is not None
-        assert "lodash" in result["manifest"]["exports"]
+        assert "cocoindex" in result["manifest"]["exports"]


### PR DESCRIPTION
## Summary
- Rephrase the "How BMad Works" intro in `docs/how-it-works.md` for tighter, more active phrasing while keeping the structured steps + shared standards takeaway
- Replace the `lodash` placeholder package with `cocoindex` across README, docs, workflow references, and test fixtures so example commands point at a repo relevant to the SKF ecosystem
- Real `lodash` entries in `package-lock.json` (actual npm deps) were intentionally left alone

## Test plan
- [x] Pre-commit hooks passed on both commits (markdownlint, schemas, install, CLI, workflow, python, knowledge, validate, lint, format)
- [x] 137 Python tests pass after `lodash` → `cocoindex` rename in test fixtures
- [x] Spot-check rendered docs on the preview site

🤖 Generated with [Claude Code](https://claude.com/claude-code)