### PR TITLE
fix(skf-export-skill): rename manifest platforms field to ides (#148)

### DIFF
--- a/src/knowledge/version-paths.md
+++ b/src/knowledge/version-paths.md
@@ -144,12 +144,12 @@ The export manifest gains version awareness:
       "active_version": "0.6.0",
       "versions": {
         "0.5.0": {
-          "platforms": ["claude"],
+          "ides": ["claude-code"],
           "last_exported": "2026-03-15",
           "status": "archived"
         },
         "0.6.0": {
-          "platforms": ["claude", "copilot"],
+          "ides": ["claude-code", "github-copilot"],
           "last_exported": "2026-04-04",
           "status": "active"
         }
@@ -163,7 +163,7 @@ The export manifest gains version awareness:
 - `schema_version`: `"2"` — enables v1-to-v2 migration detection
 - `active_version`: The version whose `{skill_package}` supplies the context snippet for the managed section. Must match exactly one version with `status: "active"`
 - `versions.{v}.status`: `"active"` (currently exported), `"archived"` (previously exported, retained on disk), `"deprecated"` (dropped via drop-skill workflow, excluded from all exports), `"draft"` (created but never exported)
-- `versions.{v}.platforms`: Array of platforms this version was last exported to
+- `versions.{v}.ides`: Array of IDE identifiers from `config.yaml.ides` whose context file this version was last exported to (e.g. `["claude-code", "cursor"]`). NOT context file names, NOT skill root paths — the canonical IDE identifier used by the installer. Pre-rename manifests used `platforms` for this field; `skf-manifest-ops.py` silently upgrades them on read
 - `versions.{v}.last_exported`: ISO date of the last export
 
 **Only one version per skill can have `status: "active"` at any time.**

--- a/src/shared/scripts/skf-manifest-ops.py
+++ b/src/shared/scripts/skf-manifest-ops.py
@@ -33,13 +33,14 @@ def read_manifest(manifest_path):
 
     Handles both v1 (flat list) and v2 (dict) manifest formats.
     V1 manifests are migrated in-place to v2 on next write.
+    Legacy `platforms` field at the version level is renamed to `ides`.
     """
     try:
         with open(manifest_path) as f:
             data = json.load(f)
-        # Migrate v1 → v2 in memory if needed
         if data.get("schema_version") != "2":
             data = _migrate_v1_to_v2(data)
+        data = _normalize_platforms_to_ides(data)
         return data, None
     except FileNotFoundError:
         return {"schema_version": "2", "exports": {}, "updated_at": None}, None
@@ -59,13 +60,35 @@ def _migrate_v1_to_v2(data):
             for v in versions:
                 status = "active" if v == active and not deprecated else "archived"
                 new_versions[v] = {
-                    "platforms": [],
+                    "ides": [],
                     "last_exported": data.get("updated_at", ""),
                     "status": "deprecated" if deprecated and v == active else status,
                 }
             entry["versions"] = new_versions
         entry.pop("deprecated", None)
         entry.pop("deprecated_versions", None)
+    return data
+
+
+def _normalize_platforms_to_ides(data):
+    """Rename legacy `platforms` key → `ides` on each version entry.
+
+    Pre-rename v2 manifests used `platforms` for the list of IDE identifiers
+    the version was exported to. The field was ambiguous (IDE name vs context
+    file vs skill root), so it was renamed to `ides` to match
+    `config.yaml.ides`. Existing manifests are upgraded on next read.
+    """
+    for entry in data.get("exports", {}).values():
+        versions = entry.get("versions", {})
+        if not isinstance(versions, dict):
+            continue
+        for v_data in versions.values():
+            if not isinstance(v_data, dict):
+                continue
+            if "platforms" in v_data:
+                legacy = v_data.pop("platforms")
+                if "ides" not in v_data:
+                    v_data["ides"] = legacy
     return data
 
 
@@ -118,8 +141,9 @@ def cmd_set(manifest_path, skill_name, version):
         versions[old_active]["status"] = "archived"
 
     # Add or update the new active version
+    existing_version = versions.get(version, {})
     versions[version] = {
-        "platforms": versions.get(version, {}).get("platforms", []),
+        "ides": existing_version.get("ides", existing_version.get("platforms", [])),
         "last_exported": today,
         "status": "active",
     }

--- a/src/skf-drop-skill/steps-c/step-02-execute.md
+++ b/src/skf-drop-skill/steps-c/step-02-execute.md
@@ -41,7 +41,7 @@ For each version in `target_versions`:
 
 1. Navigate to `exports.{target_skill}.versions.{version}`
 2. Set `status = "deprecated"`
-3. Leave `platforms`, `last_exported`, and all other fields unchanged
+3. Leave `ides`, `last_exported`, and all other fields unchanged
 
 Do NOT change `active_version` on the skill entry in this pass — if the dropped version was the active one (only reachable when it was the sole non-deprecated version per the step-01 guard), the active_version field will still point at it, but every consumer excludes deprecated versions from exports.
 

--- a/src/skf-export-skill/steps-c/step-04-update-context.md
+++ b/src/skf-export-skill/steps-c/step-04-update-context.md
@@ -93,17 +93,17 @@ Read `{skills_output_folder}/.export-manifest.json` — see `knowledge/version-p
       "active_version": "0.6.0",
       "versions": {
         "0.1.0": {
-          "platforms": ["claude"],
+          "ides": ["claude-code"],
           "last_exported": "2026-01-15",
           "status": "deprecated"
         },
         "0.5.0": {
-          "platforms": ["claude"],
+          "ides": ["claude-code"],
           "last_exported": "2026-03-15",
           "status": "archived"
         },
         "0.6.0": {
-          "platforms": ["claude", "copilot"],
+          "ides": ["claude-code", "github-copilot"],
           "last_exported": "2026-04-04",
           "status": "active"
         }
@@ -119,10 +119,12 @@ Read `{skills_output_folder}/.export-manifest.json` — see `knowledge/version-p
 - `"deprecated"` — dropped via drop-skill workflow; excluded from all exports (files may or may not exist on disk)
 - `"draft"` — created but never exported
 
+**Legacy `platforms` → `ides` rename:** Pre-rename v2 manifests used a `platforms` array at the version level. If a version entry contains `platforms` instead of (or in addition to) `ides`, treat `platforms` as `ides` and rewrite it to `ides` on the next manifest write. This is a silent in-place upgrade — no user prompt, no v3 bump.
+
 **v1 manifest** (no `schema_version` field — migrate in-place to v2):
-1. For each entry in `exports`, read its `platforms` and `last_exported`
+1. For each entry in `exports`, read its `last_exported` (v1 had no per-version IDE list)
 2. Resolve the skill's current version from `{resolved_skill_package}/metadata.json`
-3. Wrap in v2 structure: set `active_version` to the resolved version, create a single entry in `versions` with `status: "active"`, the original `platforms`, and `last_exported`
+3. Wrap in v2 structure: set `active_version` to the resolved version, create a single entry in `versions` with `status: "active"`, `ides: []` (unknown — will be filled on next successful export), and `last_exported`
 4. Set `schema_version: "2"` at root
 5. Hold the migrated structure in context (it will be written in section 9b)
 
@@ -250,9 +252,9 @@ Auto-proceed to {nextStepFile}.
 
 Display: "**Select:** [C] Continue — write changes to {target-file}"
 
-**Multi-platform behavior:** When processing multiple platforms, present all platforms' previews together before asking for a single confirmation. After confirmation, write all target files sequentially, verifying each one.
+**Multi-target behavior:** When processing multiple context files, present all previews together before asking for a single confirmation. After confirmation, write all target files sequentially, verifying each one.
 
-"**Targets:** {list all platform → target-file pairs}
+"**Targets:** {list all context-file → target-file pairs}
 **Ready to write changes to all targets?**"
 
 Display: "**Select:** [C] Continue — write changes to all targets"
@@ -284,17 +286,20 @@ After user confirms with 'C':
 
 ### 9b. Update Export Manifest (Non-Dry-Run Only)
 
-**This section executes ONCE after all platform iterations complete** (outside the per-platform loop defined in section 3). Only platforms whose writes succeeded in section 9 are recorded.
+**This section executes ONCE after all context-file iterations complete** (outside the per-context-file loop defined in section 3). Only IDEs whose target context files were successfully written and verified in section 9 are recorded.
+
+**`ides` field definition:** `ides` is the list of IDE identifiers from `config.yaml.ides` (e.g. `claude-code`, `cursor`, `github-copilot`) whose context files were successfully written and verified in section 9. It is NOT the context file name (`CLAUDE.md`) and NOT the skill root path (`.claude/skills/`). Each IDE → context file → skill root mapping is defined in `skf-export-skill/assets/managed-section-format.md`.
 
 1. Read `{skills_output_folder}/.export-manifest.json` (or start with `{"schema_version": "2", "exports": {}}` if it does not exist)
-2. Ensure `schema_version` is `"2"` (if v1 was migrated in section 4a, the migrated structure is already in context)
-3. Add or update the current skill's entry in v2 format:
+2. Ensure `schema_version` is `"2"` (if v1 was migrated in section 4a, the migrated structure is already in context). If any version entry still has a legacy `platforms` key, rename it to `ides` in place (see §4a).
+3. Compute `ides_written` — the set of IDE identifiers from `config.yaml.ides` whose mapped context file was successfully written in section 9 (deduplicated, sorted). When `--context-file` was passed explicitly, `ides_written` contains only the IDEs that map to that single context file.
+4. Add or update the current skill's entry in v2 format:
    ```json
    "{skill-name}": {
      "active_version": "{version}",
      "versions": {
        "{version}": {
-         "platforms": ["{successfully-written platforms}"],
+         "ides": ["{ides_written}"],
          "last_exported": "{current-date}",
          "status": "active"
        }
@@ -302,15 +307,14 @@ After user confirms with 'C':
    }
    ```
    - `{version}` is the version from `{resolved_skill_package}/metadata.json`
-   - Set `platforms` to only the platforms that were successfully written and verified in section 9
    - If the skill already has a manifest entry:
      - Set `active_version` to the current version
-     - If the version already exists in `versions`, update its `platforms` (merge, deduplicate), `last_exported`, and set `status: "active"`
+     - If the version already exists in `versions`, union its existing `ides` with `ides_written` (deduplicate, keep sorted), refresh `last_exported`, and set `status: "active"`
      - If this is a new version, add it to `versions` with `status: "active"` and set any previously-active version's status to `"archived"`
      - Preserve all other version entries in `versions` (do not delete archived versions)
-4. Write the updated manifest to `{skills_output_folder}/.export-manifest.json`
+5. Write the updated manifest to `{skills_output_folder}/.export-manifest.json`
 
-**Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name} on platform(s) {platform-list}.**"
+**Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name} — ides: {ides_written}.**"
 
 **Error handling:** If manifest write fails, warn but do not fail the workflow — the managed section was already written successfully.
 

--- a/test/test-skf-manifest-ops.py
+++ b/test/test-skf-manifest-ops.py
@@ -130,3 +130,78 @@ class TestManifestOps:
         assert isinstance(r["entry"]["versions"], dict)
         assert "1.0.0" in r["entry"]["versions"]
         assert r["entry"]["versions"]["1.0.0"]["status"] == "active"
+        assert "ides" in r["entry"]["versions"]["1.0.0"]
+        assert "platforms" not in r["entry"]["versions"]["1.0.0"]
+
+    def test_platforms_to_ides_normalization(self, manifest_path):
+        """S12: Legacy `platforms` field is renamed to `ides` on read (issue #148)."""
+        legacy_v2 = {
+            "schema_version": "2",
+            "exports": {
+                "cocoindex": {
+                    "active_version": "2.0.0",
+                    "versions": {
+                        "2.0.0": {
+                            "platforms": ["claude-code", "cursor"],
+                            "last_exported": "2026-04-01",
+                            "status": "active",
+                        }
+                    },
+                }
+            },
+        }
+        manifest_path.write_text(json.dumps(legacy_v2))
+        r = mod.cmd_get(manifest_path, "cocoindex")
+        assert r["status"] == "ok"
+        entry = r["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["claude-code", "cursor"]
+        assert "platforms" not in entry
+
+    def test_platforms_to_ides_preserved_on_set(self, manifest_path):
+        """S13: cmd_set preserves legacy `platforms` as `ides` when touching a version."""
+        legacy_v2 = {
+            "schema_version": "2",
+            "exports": {
+                "cocoindex": {
+                    "active_version": "2.0.0",
+                    "versions": {
+                        "2.0.0": {
+                            "platforms": ["claude-code"],
+                            "last_exported": "2026-04-01",
+                            "status": "active",
+                        }
+                    },
+                }
+            },
+        }
+        manifest_path.write_text(json.dumps(legacy_v2))
+        # Re-set the same version — should keep the IDE list, rewritten under `ides`
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
+        r = mod.cmd_get(manifest_path, "cocoindex")
+        entry = r["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["claude-code"]
+        assert "platforms" not in entry
+
+    def test_ides_and_platforms_both_present_prefers_ides(self, manifest_path):
+        """S14: When both keys exist (shouldn't happen, but be safe), `ides` wins."""
+        data = {
+            "schema_version": "2",
+            "exports": {
+                "cocoindex": {
+                    "active_version": "2.0.0",
+                    "versions": {
+                        "2.0.0": {
+                            "ides": ["cursor"],
+                            "platforms": ["claude-code"],
+                            "last_exported": "2026-04-01",
+                            "status": "active",
+                        }
+                    },
+                }
+            },
+        }
+        manifest_path.write_text(json.dumps(data))
+        r = mod.cmd_get(manifest_path, "cocoindex")
+        entry = r["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["cursor"]
+        assert "platforms" not in entry


### PR DESCRIPTION
## Summary

- Renames the `.export-manifest.json` version-level `platforms` field to `ides` throughout the v2 schema, resolving the ambiguity flagged in #148 (IDE identifier vs. context file vs. skill root path).
- Adds a silent soft-migration in `skf-manifest-ops.py` so existing manifests with the legacy `platforms` key are normalized on next read — no schema-version bump, no user prompt.
- Adds an explicit field definition at the top of step-04 §9b pointing `ides` at `config.yaml.ides` and the canonical IDE → context file → skill root table in `managed-section-format.md`.

## Changes

- `src/shared/scripts/skf-manifest-ops.py` — new `_normalize_platforms_to_ides()` helper runs on every `read_manifest()`; `_migrate_v1_to_v2()` now seeds `ides: []`; `cmd_set()` preserves the version's IDE list across the rename.
- `src/skf-export-skill/steps-c/step-04-update-context.md` — §4a schema examples + migration steps updated, §9b gains the `ides` definition sentence and merge-union semantics, §8 prose drift ("Multi-platform" → "Multi-target") cleaned up.
- `src/knowledge/version-paths.md` — v2 schema example + field description with explicit domain clarification and rename note.
- `src/skf-drop-skill/steps-c/step-02-execute.md` — "leave fields unchanged" bullet renamed.
- `test/test-skf-manifest-ops.py` — v1 migration assertion extended; three new tests cover soft-migration on read, `cmd_set` preservation across the rename, and `ides`-wins tiebreaker when both keys coexist.

## Breaking-change review

- **Existing v2 manifests with `platforms`:** normalized silently on read via `_normalize_platforms_to_ides()` — covered by tests S12–S14.
- **v1 manifests:** `_migrate_v1_to_v2` creates `ides: []` (v1 had no equivalent field; empty list fills on next export).
- **rename-skill:** deep-copies manifest entries wholesale — shape-agnostic, safe.
- **drop-skill:** "leave fields unchanged" semantic preserves whatever shape exists, so safe even against un-normalized manifests.
- **CLI `tools/cli/lib/platform-codes.yaml` / `ide-skills.js`:** a different `platforms:` root key (installer catalog) — unrelated, not touched.
- **No JSON schema file** exists for `.export-manifest.json`.

## Test plan

- [x] `uv run pytest test/test-skf-manifest-ops.py -v` — 14/14 pass (11 existing + 3 new).
- [x] Full Python suite (`test:python`) — 140/140 pass.
- [x] Pre-commit hook full `npm test` — passed.
- [x] Manual: run `[EX] Export Skill` against a fresh skill on a v2 manifest that still contains `platforms` and confirm it's rewritten to `ides` on next write.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)