### PR TITLE
fix(workflows): split health-check into dedicated terminal step across 14 workflows

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -28,7 +28,7 @@ Each workflow directory contains these files, and each has a specific job:
 | File                      | What it does                                                                                                        | When it loads                                     |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
 | `SKILL.md`                | Human-readable entry point — goals, role definition, initialization sequence, invocation contract, routes to first step | Entry point per workflow                          |
-| `steps-c/*.md`            | **Create** steps — primary execution, 5–11 sequential files per workflow                                            | One at a time (just-in-time)                      |
+| `steps-c/*.md`            | **Create** steps — primary execution, 4–10 sequential files per workflow (the last one always chains to the shared health check) | One at a time (just-in-time)                      |
 | `references/*.md`         | Workflow-specific reference data — rules, patterns, protocols                                                       | Read by steps on demand                           |
 | `assets/*.md`             | Workflow-specific output formats — schemas, templates, heuristics                                                   | Read by steps on demand                           |
 | `templates/*.md`          | Output skeletons with placeholder vars — steps fill these in to produce the final artifact                          | Read by steps when generating output              |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -341,7 +341,7 @@ You can also set `headless_mode: true` in your forge preferences (`_bmad/_memory
 
 ## Terminal Step: Health Check
 
-All 14 workflows above share the same final step — a **health check** defined in [`src/shared/health-check.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/shared/health-check.md). This isn't a workflow you invoke directly; there's no command code and no menu entry. Every workflow's last step frontmatter points `nextStepFile` at the shared file, so the health check fires automatically once the main work is done. After the main work is done, Ferris silently reflects on the execution:
+All 14 workflows above share the same final step — a **health check** defined in [`src/shared/health-check.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/shared/health-check.md). This isn't a workflow you invoke directly; there's no command code and no menu entry. Each workflow ends with a dedicated local `step-NN-health-check.md` whose `nextStepFile` points at the shared file, so the health check fires automatically once the main work is done. After the main work is done, Ferris silently reflects on the execution:
 
 - Did any step instruction lead the agent astray or cause unnecessary back-and-forth?
 - Was any step ambiguous, forcing the agent to guess?

--- a/src/skf-analyze-source/SKILL.md
+++ b/src/skf-analyze-source/SKILL.md
@@ -36,6 +36,7 @@ These rules apply to every step in this workflow:
 | 4 | Map & Detect | steps-c/step-04-map-and-detect.md | Yes |
 | 5 | Recommend | steps-c/step-05-recommend.md | No (confirm) |
 | 6 | Generate Briefs | steps-c/step-06-generate-briefs.md | Yes |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-analyze-source/steps-c/step-06-generate-briefs.md
+++ b/src/skf-analyze-source/steps-c/step-06-generate-briefs.md
@@ -1,10 +1,7 @@
 ---
 outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 schemaFile: 'assets/skill-brief-schema.md'
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 ---
 
 # Step 6: Generate Briefs
@@ -18,7 +15,7 @@ To generate a valid skill-brief.yaml file for each confirmed unit using the sche
 - Generate only for units in confirmed_units — no extras, no omissions
 - Do not modify recommendations or re-ask for confirmations
 - Every generated field must trace back to data collected in steps 02-05
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing summary is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -185,7 +182,7 @@ To refine any brief, run the recommended next workflow. To re-analyze with diffe
 
 Write `{forge_data_folder}/analyze-source-result.json` per `shared/references/output-contract-schema.md`. Include all generated `skill-brief.yaml` paths in `outputs` and brief counts in `summary`.
 
-### 10. Workflow Health Check
+### 10. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the briefs have been written (or skipped per user abort), the report updated, the summary presented, and the result contract saved will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the summary reads as final.
 

--- a/src/skf-analyze-source/steps-c/step-07-health-check.md
+++ b/src/skf-analyze-source/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of analyze-source — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-audit-skill/SKILL.md
+++ b/src/skf-audit-skill/SKILL.md
@@ -36,6 +36,7 @@ These rules apply to every step in this workflow:
 | 4 | Semantic Diff | steps-c/step-04-semantic-diff.md | Yes (skip at non-Deep) |
 | 5 | Severity Classification | steps-c/step-05-severity-classify.md | Yes |
 | 6 | Report | steps-c/step-06-report.md | Yes |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-audit-skill/steps-c/step-06-report.md
+++ b/src/skf-audit-skill/steps-c/step-06-report.md
@@ -1,9 +1,6 @@
 ---
 outputFile: '{forge_version}/drift-report-{timestamp}.md'
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 ---
 
 # Step 6: Generate Report
@@ -17,7 +14,7 @@ Finalize the drift report by completing the Audit Summary with calculated metric
 - Focus on completing the report — summary, remediation, provenance
 - Do not discover new drift items or reclassify severity
 - Remediation suggestions must be practical: what to change, where, and why
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing summary is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -165,7 +162,7 @@ Update {outputFile} frontmatter:
 
 Write `{forge_version}/audit-skill-result.json` per `shared/references/output-contract-schema.md`. Include the drift report path in `outputs`; include `drift_count` and `severity` (CLEAN/MINOR/SIGNIFICANT/CRITICAL) in `summary`.
 
-### Workflow Health Check
+### 6. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the report has been written, presented, and the result contract saved will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the user-facing summary reads as final.
 

--- a/src/skf-audit-skill/steps-c/step-07-health-check.md
+++ b/src/skf-audit-skill/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of audit-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -32,6 +32,7 @@ These rules apply to every step in this workflow:
 | 3 | Scope Definition | steps-c/step-03-scope-definition.md | No (interactive) |
 | 4 | Confirm Brief | steps-c/step-04-confirm-brief.md | No (confirm) |
 | 5 | Write Brief | steps-c/step-05-write-brief.md | Yes |
+| 6 | Workflow Health Check | steps-c/step-06-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -1,9 +1,6 @@
 ---
 briefSchemaFile: 'assets/skill-brief-schema.md'
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-06-health-check.md'
 ---
 
 # Step 5: Write Brief
@@ -17,7 +14,7 @@ To generate the complete skill-brief.yaml from the approved brief data and write
 - Focus only on writing the file — all decisions have been made
 - Do not change any field values without user request — the brief was already approved
 - Create the output directory if it doesn't exist
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing success summary is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -186,11 +183,11 @@ After compilation, you can:
 
 **Brief-skill workflow complete.**"
 
-### 7. Workflow Health Check
+### 7. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the brief file has been written and the success summary displayed will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the summary reads as final.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-This step chains to the shared health check. After the health check completes, the brief-skill workflow is fully done.
+This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the brief-skill workflow is fully done.
 

--- a/src/skf-brief-skill/steps-c/step-06-health-check.md
+++ b/src/skf-brief-skill/steps-c/step-06-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 6: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of brief-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-05
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-create-skill/SKILL.md
+++ b/src/skf-create-skill/SKILL.md
@@ -40,8 +40,9 @@ These rules apply to every step in this workflow:
 | 6 | Validate | steps-c/step-06-validate.md | Conditional |
 | 7 | Generate Artifacts | steps-c/step-07-generate-artifacts.md | Yes |
 | 8 | Report | steps-c/step-08-report.md | Yes |
+| 9 | Workflow Health Check | steps-c/step-09-health-check.md | Yes |
 
-*Sub-steps under `steps-c/sub/` are conditional branches (CCC discovery, temporal/doc enrichment) kept out of the top-level step count so main-line steps 1–8 drive the workflow. Step 3d (Component Extraction) stays top-level as an alternative main step that replaces the standard extraction path when `scope.type: "component-library"`.*
+*Sub-steps under `steps-c/sub/` are conditional branches (CCC discovery, temporal/doc enrichment) kept out of the top-level step count so main-line steps 1–9 drive the workflow. Step 3d (Component Extraction) stays top-level as an alternative main step that replaces the standard extraction path when `scope.type: "component-library"`.*
 
 ## Invocation Contract
 

--- a/src/skf-create-skill/steps-c/step-08-report.md
+++ b/src/skf-create-skill/steps-c/step-08-report.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-09-health-check.md'
 ---
 
 # Step 8: Report
@@ -15,7 +12,7 @@ To display the final compilation summary — skill name, version, source, export
 
 - Focus only on reporting compilation results — do not modify any files
 - Deliver structured report with confidence breakdown
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion (non-batch mode, or after the final batch brief) — the user-facing report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -120,17 +117,17 @@ End workflow. No further steps.
 
 Write `{forge_version}/create-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`.
 
-### 6. Workflow Health Check
+### 6. Chain to Health Check
 
 **If not batch mode (or all batch briefs complete):**
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the compilation report, warnings (if any), recommended next steps, and result contract have been handled will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
 
-**If batch mode with remaining briefs:** Skip health check — load and execute `steps-c/step-01-load-brief.md` for the next brief. Health check runs after the final brief in the batch.
+**If batch mode with remaining briefs:** Skip the health-check chain — load and execute `steps-c/step-01-load-brief.md` for the next brief instead. The health check runs only after the final brief in the batch.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-This step chains to the shared health check (unless batch mode loops back to step-01). After the health check completes, the create-skill workflow is fully done.
+This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md` (unless batch mode loops back to step-01). After the health check completes, the create-skill workflow is fully done.
 
 For batch mode: load and execute `steps-c/step-01-load-brief.md` for remaining briefs via sidecar checkpoint. Health check runs only after the last brief.
 

--- a/src/skf-create-skill/steps-c/step-09-health-check.md
+++ b/src/skf-create-skill/steps-c/step-09-health-check.md
@@ -1,0 +1,23 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 9: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of create-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-08
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- In batch mode, this step is only reached after the final brief — step-08 loops back to step-01-load-brief for remaining briefs and skips chaining here
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-create-stack-skill/SKILL.md
+++ b/src/skf-create-stack-skill/SKILL.md
@@ -38,6 +38,7 @@ These rules apply to every step in this workflow:
 | 7 | Generate Output | steps-c/step-07-generate-output.md | Yes |
 | 8 | Validate | steps-c/step-08-validate.md | Yes |
 | 9 | Report | steps-c/step-09-report.md | Yes |
+| 10 | Workflow Health Check | steps-c/step-10-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-create-stack-skill/steps-c/step-09-report.md
+++ b/src/skf-create-stack-skill/steps-c/step-09-report.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-10-health-check.md'
 ---
 
 # Step 9: Stack Skill Report
@@ -16,7 +13,7 @@ Display the final summary of the forged stack skill with confidence distribution
 - Do not write or modify any files — report is console output only
 - Lead with the positive summary, then details, then warnings
 - Recommend next workflows based on what was produced
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -93,7 +90,7 @@ Forge tier: **{tier}**"
 
 Write `{forge_version}/create-stack-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs`; include `lib_count`, `integration_count`, and confidence distribution in `summary`.
 
-### 7. Workflow Health Check
+### 7. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the forge banner, confidence distribution, output file summary, validation summary, warnings (if any), next-workflow recommendations, and result contract have all been handled will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
 

--- a/src/skf-create-stack-skill/steps-c/step-10-health-check.md
+++ b/src/skf-create-stack-skill/steps-c/step-10-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 10: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of create-stack-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-09
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-drop-skill/SKILL.md
+++ b/src/skf-drop-skill/SKILL.md
@@ -33,6 +33,7 @@ These rules apply to every step in this workflow:
 | 1 | Select Target | steps-c/step-01-select.md | No (confirm) |
 | 2 | Execute Drop | steps-c/step-02-execute.md | Yes |
 | 3 | Report | steps-c/step-03-report.md | Yes |
+| 4 | Workflow Health Check | steps-c/step-04-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-drop-skill/steps-c/step-03-report.md
+++ b/src/skf-drop-skill/steps-c/step-03-report.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-04-health-check.md'
 ---
 
 # Step 3: Report Drop Results
@@ -15,7 +12,7 @@ Present a clear, final summary of what the drop workflow changed — manifest st
 
 - Focus only on reporting results stored in context by step-02 — do not re-execute any part of the drop
 - Do not hide verification errors or failed context file rebuilds
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -76,11 +73,11 @@ These require manual review — see the error-handling guidance in step-02.
 
 Write `{skills_output_folder}/drop-skill-result.json` per `shared/references/output-contract-schema.md`. Include all purged file paths in `outputs`; include `target_skill`, `drop_mode`, and `versions_affected` in `summary`.
 
-### 3. Workflow Health Check
+### 3. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the report has been rendered and the result contract saved will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-This step chains to the shared health check. After the health check completes, the drop-skill workflow is fully done. Do not re-run any earlier step automatically — if the user wants another drop, they should re-invoke the workflow from the top.
+This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the drop-skill workflow is fully done. Do not re-run any earlier step automatically — if the user wants another drop, they should re-invoke the workflow from the top.
 

--- a/src/skf-drop-skill/steps-c/step-04-health-check.md
+++ b/src/skf-drop-skill/steps-c/step-04-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 4: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of drop-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-03
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-export-skill/SKILL.md
+++ b/src/skf-export-skill/SKILL.md
@@ -33,6 +33,7 @@ These rules apply to every step in this workflow:
 | 4 | Update Context | steps-c/step-04-update-context.md | No (confirm) |
 | 5 | Token Report | steps-c/step-05-token-report.md | Yes |
 | 6 | Summary | steps-c/step-06-summary.md | Yes |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-export-skill/steps-c/step-06-summary.md
+++ b/src/skf-export-skill/steps-c/step-06-summary.md
@@ -1,20 +1,17 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 ---
 
 # Step 6: Summary
 
 ## STEP GOAL:
 
-To present a complete export summary showing all files written, token counts, and provide distribution instructions based on the skill's source authority. This is the final step — workflow ends here.
+To present a complete export summary showing all files written, token counts, and provide distribution instructions based on the skill's source authority. Then chain to the local health-check step — it, not this summary, is the terminal step.
 
 ## Rules
 
 - Focus only on summarizing what was done and providing next steps — no additional file writes
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing summary is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -134,11 +131,11 @@ No files were written. To run the export for real:
 
 Write `{skills_output_folder}/export-skill-result.json` per `shared/references/output-contract-schema.md`. Include all context files and target managed-section files in `outputs`; include total always-on and on-trigger token counts in `summary`.
 
-### 7. Workflow Health Check
+### 7. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check. The health check is the terminal step and will display the workflow-complete marker on exit.
+ONLY WHEN the export summary, distribution instructions, and result contract are complete will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the summary reads as final.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-This step chains to the shared health check. After the health check completes, the export-skill workflow is fully done.
+This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the export-skill workflow is fully done.
 

--- a/src/skf-export-skill/steps-c/step-07-health-check.md
+++ b/src/skf-export-skill/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of export-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-quick-skill/SKILL.md
+++ b/src/skf-quick-skill/SKILL.md
@@ -34,6 +34,7 @@ These rules apply to every step in this workflow:
 | 4 | Compile | steps-c/step-04-compile.md | No (review) |
 | 5 | Validate | steps-c/step-05-validate.md | Yes |
 | 6 | Write Output | steps-c/step-06-write.md | Yes |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-quick-skill/steps-c/step-06-write.md
+++ b/src/skf-quick-skill/steps-c/step-06-write.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 ---
 
 # Step 6: Write Output
@@ -124,7 +121,7 @@ Please check:
 
 Write `{skill_package}/quick-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and export count in `summary`.
 
-### 7. Workflow Health Check
+### 7. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the skill files are written and the completion summary has been displayed will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the summary reads as final.
 

--- a/src/skf-quick-skill/steps-c/step-07-health-check.md
+++ b/src/skf-quick-skill/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of quick-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-refine-architecture/SKILL.md
+++ b/src/skf-refine-architecture/SKILL.md
@@ -35,6 +35,7 @@ These rules apply to every step in this workflow:
 | 4 | Improvements | steps-c/step-04-improvements.md | Yes |
 | 5 | Compile Refined Architecture | steps-c/step-05-compile.md | No (review) |
 | 6 | Report | steps-c/step-06-report.md | Yes |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-refine-architecture/steps-c/step-06-report.md
+++ b/src/skf-refine-architecture/steps-c/step-06-report.md
@@ -1,9 +1,6 @@
 ---
 outputFile: '{output_folder}/refined-architecture-{project_name}.md'
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 ---
 
 # Step 6: Present Report
@@ -16,7 +13,7 @@ Present the complete refinement summary to the user. Display counts of gaps fill
 
 - Focus only on presenting the completed refinement — no new analysis
 - Do not discover new gaps, issues, or improvements, and do not modify the refined document
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing summary is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -86,7 +83,7 @@ Re-run **[RA] Refine Architecture** anytime after updating your skills or archit
 
   Write `{output_folder}/refine-architecture-result.json` per `shared/references/output-contract-schema.md`. Include the refined architecture doc path in `outputs`; include `gap_count`, `issue_count`, and `improvement_count` in `summary`.
 
-  Then load and execute `{nextStepFile}` for workflow self-improvement check.
+  Then load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 
 #### EXECUTION RULES:
 
@@ -96,5 +93,5 @@ Re-run **[RA] Refine Architecture** anytime after updating your skills or archit
 
 ## CRITICAL STEP COMPLETION NOTE
 
-When the user selects X, this step chains to the shared health check. After the health check completes, the refine-architecture workflow is fully done. The refined architecture at `{outputFile}` contains the full original content plus all gap-fills, issue annotations, and improvement suggestions backed by skill API evidence.
+When the user selects X, this step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the refine-architecture workflow is fully done. The refined architecture at `{outputFile}` contains the full original content plus all gap-fills, issue annotations, and improvement suggestions backed by skill API evidence.
 

--- a/src/skf-refine-architecture/steps-c/step-07-health-check.md
+++ b/src/skf-refine-architecture/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of refine-architecture — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-rename-skill/SKILL.md
+++ b/src/skf-rename-skill/SKILL.md
@@ -34,6 +34,7 @@ These rules apply to every step in this workflow:
 | 1 | Select & Validate | steps-c/step-01-select.md | No (confirm) |
 | 2 | Execute Rename | steps-c/step-02-execute.md | No (confirm) |
 | 3 | Report | steps-c/step-03-report.md | Yes |
+| 4 | Workflow Health Check | steps-c/step-04-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-rename-skill/steps-c/step-03-report.md
+++ b/src/skf-rename-skill/steps-c/step-03-report.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-04-health-check.md'
 ---
 
 # Step 3: Report Rename Results
@@ -16,7 +13,7 @@ Present a clear, final summary of what the rename workflow changed — old and n
 - Focus only on reporting results stored in context by step-02 — do not re-execute any part of the rename
 - Do not hide verification warnings, context file rebuild failures, or deletion errors
 - Present next-steps guidance so the user knows which downstream workflows to run
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -76,11 +73,11 @@ Informational: the old name still appears in SKILL.md body text (prose only, non
 
 Write `{skills_output_folder}/{new_name}/rename-skill-result.json` per `shared/references/output-contract-schema.md`. Include all updated file paths (SKILL.md, metadata.json, context-snippet.md, provenance-map.json) in `outputs`; include `old_name`, `new_name`, and `versions_renamed` in `summary`.
 
-### 2. Workflow Health Check
+### 2. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the rename report has been rendered and the result contract saved will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-This step chains to the shared health check. After the health check completes, the rename-skill workflow is fully done. Do not re-run any earlier step automatically — if the user wants another rename, they should re-invoke the workflow from the top.
+This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the rename-skill workflow is fully done. Do not re-run any earlier step automatically — if the user wants another rename, they should re-invoke the workflow from the top.
 

--- a/src/skf-rename-skill/steps-c/step-04-health-check.md
+++ b/src/skf-rename-skill/steps-c/step-04-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 4: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of rename-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-03
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -33,6 +33,7 @@ These rules apply to every step in this workflow:
 | 2 | Write Config | steps-c/step-02-write-config.md | Yes |
 | 3 | QMD Hygiene | steps-c/step-03-auto-index.md | Yes |
 | 4 | Report | steps-c/step-04-report.md | Yes |
+| 5 | Workflow Health Check | steps-c/step-05-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -1,9 +1,6 @@
 ---
 tierRulesData: 'references/tier-rules.md'
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-05-health-check.md'
 ---
 
 # Step 4: Forge Status Report
@@ -18,7 +15,7 @@ Display the forge status report with positive capability framing and report tier
 - Do not use negative framing ("missing", "lacking", "unavailable")
 - Do not list tools that are not available
 - Use tier capability descriptions from tier-rules.md
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing status report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -85,11 +82,11 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 - Do NOT list unavailable tools
 - Do NOT show a "missing" column or section
 
-### 3. Workflow Health Check
+### 3. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check.
+ONLY WHEN the forge status report has been displayed will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-This step chains to the shared health check. After the health check completes, the setup workflow is fully done.
+This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the setup workflow is fully done.
 

--- a/src/skf-setup/steps-c/step-05-health-check.md
+++ b/src/skf-setup/steps-c/step-05-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 5: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of setup — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-04
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-test-skill/SKILL.md
+++ b/src/skf-test-skill/SKILL.md
@@ -37,6 +37,7 @@ These rules apply to every step in this workflow:
 | 4b | External Validators | steps-c/step-04b-external-validators.md | Yes |
 | 5 | Score | steps-c/step-05-score.md | Yes |
 | 6 | Report | steps-c/step-06-report.md | No (confirm) |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-test-skill/steps-c/step-06-report.md
+++ b/src/skf-test-skill/steps-c/step-06-report.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 
 outputFile: '{forge_version}/test-report-{skill_name}.md'
 scoringRulesFile: 'references/scoring-rules.md'
@@ -24,7 +21,7 @@ Generate a detailed gap report listing every issue found during coverage and coh
 - Focus on gap enumeration, severity classification, and remediation — do not recalculate scores
 - Remediation suggestions reference specific files, exports, and line numbers
 - Gaps are ordered by severity (Critical > High > Medium > Low > Info)
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -146,7 +143,7 @@ Display: "**Test complete.** [C] Finish"
 
 #### Menu Handling Logic:
 
-- IF C: Load and execute `{nextStepFile}` for workflow self-improvement check.
+- IF C: Load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:
@@ -158,5 +155,5 @@ Display: "**Test complete.** [C] Finish"
 
 ## CRITICAL STEP COMPLETION NOTE
 
-When the user selects C, this step chains to the shared health check. After the health check completes, the test-skill workflow is fully done. The test report document at `{outputFile}` contains the full analysis: Test Summary, Coverage Analysis, Coherence Analysis, Completeness Score, and Gap Report.
+When the user selects C, this step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the test-skill workflow is fully done. The test report document at `{outputFile}` contains the full analysis: Test Summary, Coverage Analysis, Coherence Analysis, Completeness Score, and Gap Report.
 

--- a/src/skf-test-skill/steps-c/step-07-health-check.md
+++ b/src/skf-test-skill/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of test-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-update-skill/SKILL.md
+++ b/src/skf-update-skill/SKILL.md
@@ -36,6 +36,7 @@ These rules apply to every step in this workflow:
 | 5 | Validate | steps-c/step-05-validate.md | Yes |
 | 6 | Write | steps-c/step-06-write.md | Yes |
 | 7 | Report | steps-c/step-07-report.md | Yes |
+| 8 | Workflow Health Check | steps-c/step-08-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-update-skill/steps-c/step-07-report.md
+++ b/src/skf-update-skill/steps-c/step-07-report.md
@@ -1,8 +1,5 @@
 ---
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-08-health-check.md'
 ---
 
 # Step 7: Report
@@ -15,7 +12,7 @@ Present a comprehensive change summary showing what was updated, [MANUAL] sectio
 
 - Focus only on reporting — all operations are complete; do not modify any files
 - Present clear, actionable summary with next step recommendations
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing summary is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -36,7 +33,7 @@ Source code matches provenance map exactly. The skill `{skill_name}` is current 
 
 **Recommendation:** No action required. Run audit-skill periodically to monitor for drift."
 
-→ Load and execute `{nextStepFile}` for workflow self-improvement check.
+→ Load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 
 ### 2. Present Change Summary
 
@@ -145,7 +142,7 @@ Based on the update results:"
 
 Write `{forge_version}/update-skill-result.json` per `shared/references/output-contract-schema.md`. Include all modified file paths in `outputs`; include `exports_affected`, `files_modified`, and `validation_status` (passed/warnings/failures) in `summary`.
 
-### 6. Workflow Health Check
+### 6. Chain to Health Check
 
-Load and execute `{nextStepFile}` for workflow self-improvement check. The health check is the terminal step and will display the workflow-complete marker on exit.
+ONLY WHEN the change summary has been presented, files-written list displayed, and result contract saved will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
 

--- a/src/skf-update-skill/steps-c/step-08-health-check.md
+++ b/src/skf-update-skill/steps-c/step-08-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 8: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of update-skill — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-07
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-verify-stack/SKILL.md
+++ b/src/skf-verify-stack/SKILL.md
@@ -36,6 +36,7 @@ These rules apply to every step in this workflow:
 | 4 | Requirements Mapping | steps-c/step-04-requirements.md | Yes |
 | 5 | Synthesize Verdict | steps-c/step-05-synthesize.md | Yes |
 | 6 | Report | steps-c/step-06-report.md | No (confirm) |
+| 7 | Workflow Health Check | steps-c/step-07-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-verify-stack/steps-c/step-06-report.md
+++ b/src/skf-verify-stack/steps-c/step-06-report.md
@@ -1,9 +1,6 @@
 ---
 outputFile: '{forge_data_folder}/feasibility-report-{project_name}.md'
-# nextStepFile `shared/health-check.md` resolves relative to the SKF module
-# root (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
-nextStepFile: 'shared/health-check.md'
+nextStepFile: './step-07-health-check.md'
 ---
 
 # Step 6: Present Report
@@ -15,7 +12,7 @@ Present the complete feasibility report to the user. Display the overall verdict
 ## Rules
 
 - Focus only on presenting the completed report — no new analysis or changes to verdicts
-- Chains to shared health check via `{nextStepFile}` after completion
+- Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing report is NOT the terminal step
 
 ## MANDATORY SEQUENCE
 
@@ -135,7 +132,7 @@ Re-run **[VS] Verify Stack** anytime after making changes to your skills or arch
 
 **Verification workflow complete.**"
 
-  Then load and execute `{nextStepFile}` for workflow self-improvement check.
+  Then load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 
 #### EXECUTION RULES:
 
@@ -146,5 +143,5 @@ Re-run **[VS] Verify Stack** anytime after making changes to your skills or arch
 
 ## CRITICAL STEP COMPLETION NOTE
 
-When the user selects X, this step chains to the shared health check. After the health check completes, the verify-stack workflow is fully done. The feasibility report at `{outputFile}` contains the full analysis: Coverage Matrix, Integration Verdicts, Requirements Coverage, and Synthesis & Recommendations.
+When the user selects X, this step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the verify-stack workflow is fully done. The feasibility report at `{outputFile}` contains the full analysis: Coverage Matrix, Integration Verdicts, Requirements Coverage, and Synthesis & Recommendations.
 

--- a/src/skf-verify-stack/steps-c/step-07-health-check.md
+++ b/src/skf-verify-stack/steps-c/step-07-health-check.md
@@ -1,0 +1,22 @@
+---
+# `shared/health-check.md` resolves relative to the SKF module root
+# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# to this step file.
+nextStepFile: 'shared/health-check.md'
+---
+
+# Step 7: Workflow Health Check
+
+## STEP GOAL:
+
+Chain to the shared workflow self-improvement health check at `{nextStepFile}`. This is the terminal step of verify-stack — after the shared health check completes, the workflow is fully done.
+
+## Rules
+
+- No user-facing reports, file writes, or result contracts in this step — those belong in step-06
+- Delegate directly to `{nextStepFile}` with no additional commentary
+- Do not attempt any other action between loading this step and executing `{nextStepFile}`
+
+## MANDATORY SEQUENCE
+
+Load `{nextStepFile}`, read it fully, then execute it.


### PR DESCRIPTION
## Summary

- Splits the shared health-check chain out of each workflow's user-facing summary step into a dedicated `step-NN-health-check.md` in every `steps-c/` — structurally identical to any other step transition the workflow already handles correctly. Applied to all 14 SKF workflows.
- Updates `docs/how-it-works.md` step-count range (4–10, previously listed as 5–11) and clarifies `docs/workflows.md` to describe the new chain shape (local relay → `shared/health-check.md`).

Fixes #152

## Why

The health-check load was buried as a trailing sub-section inside the terminal summary step. In three consecutive sessions (audit → update → export) the agent treated the summary as terminal and skipped the health check entirely — self-improvement telemetry was lost until the user prompted explicitly. The fix matches the pattern every other step transition already uses, removing the "summary reads as terminal" ambiguity.

## Test plan

- [x] `npm run validate:skills` — 15 skills pass, 0 findings
- [x] `npm run validate:refs` — 253 references, 0 broken
- [x] `npm run docs:validate-drift` — no drift vs oh-my-skills
- [x] `npm run test:workflow` — 38/38 pass
- [x] `npm run lint:md` — 188 files, 0 errors
- [x] Pre-commit hooks (full test suite: schemas, install, cli, workflow, python, knowledge, validators, lint, format) run green on both commits
- [x] Manual smoke: run one SKF workflow end-to-end and confirm the agent lands in the health-check step without the user prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)