### PR TITLE
fix(workflows): preserve audit trail in result contracts, guard against workspace drift

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -586,7 +586,7 @@ The `provenance-map.json` includes per-export `entries` with a `source_library` 
 
 ### Pipeline Result Contracts
 
-Pipeline-facing workflows write a machine-readable result JSON file (`{skill-name}-result.json`) alongside their human-readable output. This enables reliable CI integration and pipeline chaining — downstream workflows or scripts can verify what the prior step produced without parsing markdown. The schema follows a consistent format: `skill`, `status` (success/failed/partial), `timestamp`, `outputs` (array of produced artifacts with type and path), and a skill-specific `summary` object.
+Pipeline-facing workflows write a machine-readable result JSON file alongside their human-readable output. This enables reliable CI integration and pipeline chaining — downstream workflows or scripts can verify what the prior step produced without parsing markdown. Each run writes two files: a timestamped per-run record (`{skill-name}-result-{YYYYMMDD-HHmmss}.json`) that preserves the full audit trail across retries and aborts, and a stable `{skill-name}-result-latest.json` copy that pipeline consumers read without enumerating timestamps. The schema follows a consistent format: `skill`, `status` (success/failed/partial), `timestamp`, `outputs` (array of produced artifacts with type and path), and a skill-specific `summary` object.
 
 `skills/` and `forge-data/` are committed. Agent memory (`_bmad/_memory/forger-sidecar/`) is gitignored.
 

--- a/docs/verifying-a-skill.md
+++ b/docs/verifying-a-skill.md
@@ -45,6 +45,10 @@ Open `{source_repo}` at `{source_commit}`, jump to `{source_file}` line `{source
 
 If it doesn't, **that's a bug**. [Open an issue](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/new/choose). SKF will republish the skill with a new commit SHA and a new provenance map. Falsifiability isn't a feature — it's the whole deal.
 
+### Workflow-time enforcement
+
+The same anchor is enforced automatically by `skf-test-skill` and by gap-driven `skf-update-skill`. Before either workflow reads source at a recorded `source_line`, it runs `git rev-parse HEAD` on the local workspace and compares it to `metadata.source_commit`. If the workspace has drifted, the workflow halts with a `halted-for-workspace-drift` status and tells you the exact `git checkout {source_ref}` to re-sync — so spot-checks can never silently verify against the wrong tree. Pass `--allow-workspace-drift` to opt in to reading the current HEAD anyway; the override is recorded in the final report rather than hidden.
+
 ---
 
 ## Where to look for what

--- a/src/shared/references/output-contract-schema.md
+++ b/src/shared/references/output-contract-schema.md
@@ -18,4 +18,18 @@ Every pipeline-capable skill writes a result JSON file at its final step. This e
 }
 ```
 
-Write to: `{output_dir}/{skill-name}-result.json`
+## Filenames
+
+Each run writes **two files** to `{output_dir}`:
+
+1. **Per-run record** (audit trail): `{skill-name}-result-{YYYYMMDD-HHmmss}.json`
+   - Timestamp is UTC, resolution to seconds — e.g., `update-skill-result-20260413-145230.json`
+   - Never overwritten by subsequent runs — preserves a durable audit trail across retries, aborts, and re-runs
+2. **Stable latest pointer** (pipeline consumption): `{skill-name}-result-latest.json`
+   - A **copy** (not a symlink) of the per-run record just written
+   - Always present at a deterministic path so CI / pipelines / the forger can read `summary.*` without enumerating timestamps
+   - Overwritten on every successful write
+
+Write the per-run record first, then copy it to the `-latest.json` path. If the copy fails, the per-run record still exists — the run is not lost.
+
+**Consumers (forger, CI, chained workflows):** read from `{skill-name}-result-latest.json`. Do not enumerate timestamped files unless inspecting prior-run history.

--- a/src/shared/references/pipeline-contracts.md
+++ b/src/shared/references/pipeline-contracts.md
@@ -46,7 +46,7 @@ How outputs from one workflow become inputs to the next:
 | TS | EX | skill name + test result | Forger checks `result` field in test report; if FAIL and circuit breaker active, halts |
 | QS | TS | skill name (from `repo_name`) | Forger passes the quick-skill's output name to TS |
 | QS | EX | skill name | Same |
-| AS | US | skill name + drift severity | Forger checks `summary.severity` in audit-skill-result.json; if CLEAN, skips US |
+| AS | US | skill name + drift severity | Forger checks `summary.severity` in `audit-skill-result-latest.json`; if CLEAN, skips US |
 | VS | RA | architecture doc path | Already known from VS invocation |
 
 ## Circuit Breakers

--- a/src/skf-analyze-source/steps-c/step-06-generate-briefs.md
+++ b/src/skf-analyze-source/steps-c/step-06-generate-briefs.md
@@ -180,7 +180,7 @@ To refine any brief, run the recommended next workflow. To re-analyze with diffe
 
 ### 9. Result Contract
 
-Write `{forge_data_folder}/analyze-source-result.json` per `shared/references/output-contract-schema.md`. Include all generated `skill-brief.yaml` paths in `outputs` and brief counts in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_data_folder}/analyze-source-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_data_folder}/analyze-source-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all generated `skill-brief.yaml` paths in `outputs` and brief counts in `summary`.
 
 ### 10. Chain to Health Check
 

--- a/src/skf-audit-skill/steps-c/step-06-report.md
+++ b/src/skf-audit-skill/steps-c/step-06-report.md
@@ -160,7 +160,7 @@ Update {outputFile} frontmatter:
 
 ### Result Contract
 
-Write `{forge_version}/audit-skill-result.json` per `shared/references/output-contract-schema.md`. Include the drift report path in `outputs`; include `drift_count` and `severity` (CLEAN/MINOR/SIGNIFICANT/CRITICAL) in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_version}/audit-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/audit-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the drift report path in `outputs`; include `drift_count` and `severity` (CLEAN/MINOR/SIGNIFICANT/CRITICAL) in `summary`.
 
 ### 6. Chain to Health Check
 

--- a/src/skf-create-skill/steps-c/step-08-report.md
+++ b/src/skf-create-skill/steps-c/step-08-report.md
@@ -115,7 +115,7 @@ End workflow. No further steps.
 
 **If not batch mode (or all batch briefs complete):**
 
-Write `{forge_version}/create-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_version}/create-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/create-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`.
 
 ### 6. Chain to Health Check
 

--- a/src/skf-create-stack-skill/steps-c/step-09-report.md
+++ b/src/skf-create-stack-skill/steps-c/step-09-report.md
@@ -88,7 +88,7 @@ Forge tier: **{tier}**"
 
 ### 6b. Result Contract
 
-Write `{forge_version}/create-stack-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs`; include `lib_count`, `integration_count`, and confidence distribution in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_version}/create-stack-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/create-stack-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs`; include `lib_count`, `integration_count`, and confidence distribution in `summary`.
 
 ### 7. Chain to Health Check
 

--- a/src/skf-drop-skill/steps-c/step-03-report.md
+++ b/src/skf-drop-skill/steps-c/step-03-report.md
@@ -71,7 +71,7 @@ These require manual review — see the error-handling guidance in step-02.
 
 ### Result Contract
 
-Write `{skills_output_folder}/drop-skill-result.json` per `shared/references/output-contract-schema.md`. Include all purged file paths in `outputs`; include `target_skill`, `drop_mode`, and `versions_affected` in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/drop-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skills_output_folder}/drop-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all purged file paths in `outputs`; include `target_skill`, `drop_mode`, and `versions_affected` in `summary`.
 
 ### 3. Chain to Health Check
 

--- a/src/skf-export-skill/steps-c/step-06-summary.md
+++ b/src/skf-export-skill/steps-c/step-06-summary.md
@@ -129,7 +129,7 @@ No files were written. To run the export for real:
 
 ### 6. Result Contract
 
-Write `{skills_output_folder}/export-skill-result.json` per `shared/references/output-contract-schema.md`. Include all context files and target managed-section files in `outputs`; include total always-on and on-trigger token counts in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/export-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skills_output_folder}/export-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all context files and target managed-section files in `outputs`; include total always-on and on-trigger token counts in `summary`.
 
 ### 7. Chain to Health Check
 

--- a/src/skf-forger/SKILL.md
+++ b/src/skf-forger/SKILL.md
@@ -98,11 +98,11 @@ When the user provides multiple workflow codes (e.g., `BS CS TS EX`, `QS TS EX`,
    - Failed/halted workflow (if any) with the halt reason
    - Remaining workflows that were not executed
    - Next steps recommendation
-6. **Result Contract** — write `{sidecar_path}/pipeline-result.json` per `shared/references/output-contract-schema.md`. Include one entry per completed workflow in `outputs` (referencing each workflow's own result JSON); include per-step status and the overall pipeline status in `summary`.
+6. **Result Contract** — write the pipeline result contract per `shared/references/output-contract-schema.md`: the per-run record at `{sidecar_path}/pipeline-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{sidecar_path}/pipeline-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include one entry per completed workflow in `outputs` (referencing each workflow's own `-latest.json` result record); include per-step status and the overall pipeline status in `summary`.
 
 **Special pipeline behaviors:**
 - `AN` in a pipeline with `CS`: if AN produces multiple recommended briefs, auto-select all and process sequentially in batch mode. If only one unit found, auto-select it.
-- `AS` followed by `US`: if `summary.severity` in audit-skill-result.json is CLEAN, skip US and report "No drift detected — skipping update."
+- `AS` followed by `US`: if `summary.severity` in `audit-skill-result-latest.json` is CLEAN, skip US and report "No drift detected — skipping update."
 - `TS` followed by `EX`: if test result is FAIL and score is below the circuit breaker threshold, halt before EX.
 
 **Inline action handling:**

--- a/src/skf-quick-skill/steps-c/step-06-write.md
+++ b/src/skf-quick-skill/steps-c/step-06-write.md
@@ -119,7 +119,7 @@ Please check:
 
 ### Result Contract
 
-Write `{skill_package}/quick-skill-result.json` per `shared/references/output-contract-schema.md`. Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and export count in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skill_package}/quick-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skill_package}/quick-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and export count in `summary`.
 
 ### 7. Chain to Health Check
 

--- a/src/skf-refine-architecture/steps-c/step-06-report.md
+++ b/src/skf-refine-architecture/steps-c/step-06-report.md
@@ -81,7 +81,7 @@ Re-run **[RA] Refine Architecture** anytime after updating your skills or archit
 
   ### Result Contract
 
-  Write `{output_folder}/refine-architecture-result.json` per `shared/references/output-contract-schema.md`. Include the refined architecture doc path in `outputs`; include `gap_count`, `issue_count`, and `improvement_count` in `summary`.
+  Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{output_folder}/refine-architecture-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{output_folder}/refine-architecture-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the refined architecture doc path in `outputs`; include `gap_count`, `issue_count`, and `improvement_count` in `summary`.
 
   Then load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 

--- a/src/skf-rename-skill/steps-c/step-03-report.md
+++ b/src/skf-rename-skill/steps-c/step-03-report.md
@@ -71,7 +71,7 @@ Informational: the old name still appears in SKILL.md body text (prose only, non
 
 ### Result Contract
 
-Write `{skills_output_folder}/{new_name}/rename-skill-result.json` per `shared/references/output-contract-schema.md`. Include all updated file paths (SKILL.md, metadata.json, context-snippet.md, provenance-map.json) in `outputs`; include `old_name`, `new_name`, and `versions_renamed` in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/{new_name}/rename-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skills_output_folder}/{new_name}/rename-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all updated file paths (SKILL.md, metadata.json, context-snippet.md, provenance-map.json) in `outputs`; include `old_name`, `new_name`, and `versions_renamed` in `summary`.
 
 ### 2. Chain to Health Check
 

--- a/src/skf-test-skill/steps-c/step-01-init.md
+++ b/src/skf-test-skill/steps-c/step-01-init.md
@@ -30,6 +30,9 @@ Discover and validate the target skill, load forge tier state to determine analy
 
 If skill path was provided as workflow argument, use it directly.
 
+**Recognized flags on the invocation:**
+- `--allow-workspace-drift` — bypass the section 5b pre-flight guard that halts when local workspace HEAD does not match `metadata.source_commit`. Store `allow_workspace_drift: true` in workflow context when present. No effect when `source_commit` is unpinned or the source is not a git working tree.
+
 If no path provided, ask:
 
 "**Which skill would you like to test?**
@@ -109,10 +112,42 @@ Read `metadata.json` to extract:
 - `name` — display name
 - `skill_type` — single or stack (needed for mode detection)
 - `source_path` — path to source code (if present)
+- `source_commit` — pinned commit the skill was extracted against (may be null for docs-only skills, `"local"` for non-git sources, or a per-repo map for stack skills)
+- `source_ref` — pinned ref (tag/branch/`HEAD`) used at extraction time
 - `generation_date` — when skill was generated
 - `confidence_tier` — tier used during creation
 
 If source path override was provided as optional input, use that instead.
+
+### 5b. Verify Workspace HEAD Matches Pinned Commit
+
+Test-skill reads `source_path` during coverage and coherence analysis. If the local workspace has drifted from `metadata.source_commit`, gap and signature-mismatch findings will silently reflect the drifted tree, not the skill's pinned source — producing false positives that downstream update-skill runs may then "repair" by corrupting correct documentation.
+
+- Resolve `pinned_commit` from `metadata.source_commit`.
+- **If `pinned_commit` is null, empty, `"local"`, or a per-repo map (stack skills):** skip the guard; log `workspace_drift_check: skipped (no single pinned commit)` and continue to section 6.
+- **If `source_path` is not a git working tree** (bare checkout, tarball extract, docs-only source) — detect by `git -C {source_path} rev-parse --is-inside-work-tree`, non-zero exit means skip: log `workspace_drift_check: skipped (not a git working tree)` and continue to section 6.
+- **Otherwise** run `git -C {source_path} rev-parse HEAD` and compare to `pinned_commit`. Accept full-SHA or short-SHA-prefix match (stored pins are often 8-char short hashes — see `src/knowledge/provenance-tracking.md`).
+  - **On match:** log `workspace_drift_check: ok ({short_sha})` and continue.
+  - **On mismatch, AND the user did not pass `--allow-workspace-drift`:** HALT with exit status `halted-for-workspace-drift`. Display:
+
+    ```
+    Workspace HEAD does not match the commit this skill was pinned against.
+
+      pinned (metadata.source_commit): {pinned_commit}
+      pinned ref (metadata.source_ref): {source_ref or "unset"}
+      workspace HEAD ({source_path}):  {head_sha}
+
+    Test-skill verifies against the source the skill was extracted from.
+    Testing against a drifted tree produces false gaps/mismatches. Re-sync:
+
+      git -C {source_path} checkout {source_ref or pinned_commit}
+
+    Or re-run test-skill with `--allow-workspace-drift` to test against the
+    current workspace (accepts that findings reflect HEAD, not the pin).
+    ```
+
+    Do not proceed. The test report has not been created; no partial writes.
+  - **On mismatch WITH `--allow-workspace-drift`:** log `workspace_drift_check: overridden (pinned={pinned_commit}, head={head_sha})` and carry the warning into the final report frontmatter (`workspaceDrift: overridden`) so downstream readers know the findings reflect HEAD rather than the pinned tree. Continue.
 
 ### 6. Create Output Document
 

--- a/src/skf-test-skill/steps-c/step-06-report.md
+++ b/src/skf-test-skill/steps-c/step-06-report.md
@@ -97,7 +97,7 @@ Record discovery testing status as Info-level in the gap table. This is advisory
 
 ### 4c. Result Contract
 
-Write `{forge_version}/skf-test-skill-result.json` per `{outputContractSchema}`. Include the test report path in `outputs`; include `score`, `threshold`, `result` (PASS/FAIL), and `testMode` (naive/contextual) in `summary`.
+Write the result contract per `{outputContractSchema}`: the per-run record at `{forge_version}/skf-test-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/skf-test-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the test report path in `outputs`; include `score`, `threshold`, `result` (PASS/FAIL), and `testMode` (naive/contextual) in `summary`.
 
 ### 5. Finalize Output Document
 

--- a/src/skf-update-skill/steps-c/step-01-init.md
+++ b/src/skf-update-skill/steps-c/step-01-init.md
@@ -26,6 +26,7 @@ Provide either:
 - A skill name (resolves via version-aware path resolution — see `knowledge/version-paths.md`)
 - A full path to the skill folder
 - A skill name with `--from-test-report` to use the test report's gap findings instead of source drift detection
+- `--allow-workspace-drift` (gap-driven mode only) to intentionally bypass the step-03 §0.a guard that halts when the local workspace HEAD does not match `metadata.source_commit`. Only use this if you know the spot-checks should read the current workspace instead of the pinned tree — step-06 will NOT automatically re-pin
 
 **Skill:** {user provides path or name}"
 
@@ -40,6 +41,8 @@ Resolve the path to an absolute skill folder location.
 
 **If `--from-test-report` was provided (or user references a test report):**
 Search for the test report at `{forge_data_folder}/{skill_name}/{active_version}/test-report-{skill_name}.md` (i.e., `{forge_version}/test-report-{skill_name}.md`). If not found at the versioned path, fall back to `{forge_data_folder}/{skill_name}/test-report-{skill_name}.md`. If found, set `test_report_path` in context and `update_mode: gap-driven`. If not found at either path, warn and continue with normal source drift mode.
+
+**If `--allow-workspace-drift` was provided:** set `allow_workspace_drift: true` in workflow context. This flag is consumed by step-03 §0.a's pre-flight drift guard (gap-driven mode only) and has no effect in normal source-drift mode.
 
 ### 2. Validate Required Artifacts
 

--- a/src/skf-update-skill/steps-c/step-03-re-extract.md
+++ b/src/skf-update-skill/steps-c/step-03-re-extract.md
@@ -28,6 +28,36 @@ Perform tier-aware extraction on only the changed files identified in step 02, p
 
 Source code has not drifted — the gap-derived manifest from step-02 contains export-level findings translated from the test report, not file-level changes. Perform citation spot-checks instead of full re-extraction to verify each gap-affected export is still at its recorded location.
 
+**0.a Pre-flight: verify workspace HEAD matches pinned commit.** Gap-driven spot-checks read source at recorded `source_line` positions and must see the exact bytes the skill was pinned against. A drifted workspace silently verifies against the wrong tree — moved/renamed symbols appear "verified" because the recorded line now points at different code. Before reading any source, run this guard:
+
+- Resolve `pinned_commit` from `metadata.source_commit` (loaded in step-01).
+- **If `pinned_commit` is null, empty, `"local"`, or a per-repo map (stack skills) with no single commit:** skip the guard and log `workspace_drift_check: skipped (no pinned commit)`. Continue to bullet 1.
+- **If `source_root` is not a git working tree** (e.g., bare checkout, tarball extract) — detect by running `git -C {source_root} rev-parse --is-inside-work-tree`; non-zero exit means skip: log `workspace_drift_check: skipped (not a git working tree)`. Continue to bullet 1.
+- **Otherwise** run `git -C {source_root} rev-parse HEAD` and compare to `pinned_commit`. Accept either a full SHA match or a short-SHA prefix match (the pinned commit is often stored as an 8-char short hash — see `src/knowledge/provenance-tracking.md`).
+  - **On match:** log `workspace_drift_check: ok ({short_sha})` and continue.
+  - **On mismatch, AND the user did not pass `--allow-workspace-drift`:** HALT immediately with exit status `halted-for-workspace-drift`. Display:
+
+    ```
+    Workspace HEAD does not match the commit this skill was pinned against.
+
+      pinned (metadata.source_commit): {pinned_commit}
+      pinned ref (metadata.source_ref): {source_ref or "unset"}
+      workspace HEAD ({source_root}):  {head_sha}
+
+    Gap-driven spot-checks read source at pinned line numbers — verifying
+    against a drifted tree silently produces wrong results (symbols appear at
+    unintended locations). Re-sync the workspace before re-running:
+
+      git -C {source_root} checkout {source_ref or pinned_commit}
+
+    Or, to intentionally proceed against the current workspace HEAD (accepting
+    that spot-checks will read bytes that differ from the pinned commit),
+    re-run update-skill with `--allow-workspace-drift`.
+    ```
+
+    Do not proceed to bullet 1. Step-04 merge has not run; no partial writes.
+  - **On mismatch WITH `--allow-workspace-drift`:** log `workspace_drift_check: overridden (pinned={pinned_commit}, head={head_sha})` and surface a visible warning in the final report ("**Workspace drift accepted via --allow-workspace-drift** — spot-checks read HEAD {head_sha}, not pinned {pinned_commit}"). Continue to bullet 1. The override does not automatically re-pin `metadata.source_commit`; re-pinning is explicit user work (run the normal-mode update-skill flow against the same HEAD, or re-create the skill).
+
 1. Use the provenance map already loaded in step-01 (at `{forge_version}/provenance-map.json`) — do not re-read
 2. For each entry in the gap-derived change manifest from step-02:
    - Look up the export by `name` in `provenance_map.exports` — read `source_file` and `source_line`

--- a/src/skf-update-skill/steps-c/step-07-report.md
+++ b/src/skf-update-skill/steps-c/step-07-report.md
@@ -140,7 +140,7 @@ Based on the update results:"
 
 ### 5b. Result Contract
 
-Write `{forge_version}/update-skill-result.json` per `shared/references/output-contract-schema.md`. Include all modified file paths in `outputs`; include `exports_affected`, `files_modified`, and `validation_status` (passed/warnings/failures) in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_version}/update-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/update-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all modified file paths in `outputs`; include `exports_affected`, `files_modified`, and `validation_status` (passed/warnings/failures) in `summary`.
 
 ### 6. Chain to Health Check
 

--- a/src/skf-verify-stack/steps-c/step-06-report.md
+++ b/src/skf-verify-stack/steps-c/step-06-report.md
@@ -117,7 +117,7 @@ Based on the overall verdict, present the appropriate recommendation:
 
 ### 4b. Result Contract
 
-Write `{forge_data_folder}/verify-stack-result.json` per `shared/references/output-contract-schema.md`. Include the feasibility report path in `outputs`; include `overall_verdict` (FEASIBLE/CONDITIONALLY FEASIBLE/NOT FEASIBLE), `coverage_percentage`, and `recommendation_count` in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_data_folder}/verify-stack-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_data_folder}/verify-stack-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the feasibility report path in `outputs`; include `overall_verdict` (FEASIBLE/CONDITIONALLY FEASIBLE/NOT FEASIBLE), `coverage_percentage`, and `recommendation_count` in `summary`.
 
 ### 5. Present Menu
 


### PR DESCRIPTION
## Summary

- **#155** — timestamped result JSON filenames (`-{YYYYMMDD-HHmmss}.json`) preserve audit history across re-runs; stable `-latest.json` copy gives pipeline consumers a deterministic read path.
- **#154** — pre-flight HEAD-drift guard in `skf-test-skill` step-01 and gap-driven `skf-update-skill` step-03 §0; halts with `halted-for-workspace-drift` when the local workspace has moved past `metadata.source_commit`, with an `--allow-workspace-drift` opt-out.
- Docs: `how-it-works.md` reflects the dual-file contract; `verifying-a-skill.md` gains a "Workflow-time enforcement" subsection covering the drift guard.

## Commits

- `e4f392d` fix(workflows): timestamped result JSON filenames to preserve audit trail (#155)
- `7328452` fix(workflows): guard against workspace HEAD drift before spot-checking pinned source (#154)
- `b6862bd` docs: document workflow-time HEAD-drift enforcement in verifying-a-skill

## Breaking change notes

- External CI consumers reading `{skill-name}-result.json` must switch to `{skill-name}-result-latest.json`. All internal consumers (forger AS→US circuit breaker, pipeline-contracts data-flow table, how-it-works docs) updated in the same commit.
- `skf-audit-skill` intentionally **not** modified for #154 — drift detection is its purpose, so halting on HEAD ≠ source_commit would break every legitimate audit.

## Test plan

- [x] `npm run lint:md` — clean
- [x] `npm run validate:refs` — 253 refs, 0 broken
- [x] `npm run validate:skills` — 15 skills, 0 findings
- [x] Pre-commit hook ran full `npm test` on each commit — all passed
- [x] Manual: run `skf-update-skill` twice against the same skill+version, confirm both per-run records survive and `-latest.json` reflects the most recent
- [x] Manual: in a drifted workspace, invoke gap-driven `skf-update-skill` — confirm halt with actionable `git checkout` hint; re-run with `--allow-workspace-drift` confirms override warning surfaces in report

Fixes #155
Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)