### PR TITLE
docs(cognee): refresh to v1.0.0 + accept short-SHA in drift validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ results = await cognee.search(
 )
 ```
 
-The skill told the agent the real function name, the real parameters, and that the call requires `await` — all traced to the exact source line. This example is from the real [`oms-cognee`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/0.5.8/oms-cognee/SKILL.md) skill in [**oh-my-skills**](https://github.com/armelhbobdad/oh-my-skills) — SKF's reference output. Want to walk the citation chain yourself? The section below shows how.
+The skill told the agent the real function name, the real parameters, and that the call requires `await` — all traced to the exact source line. This example is from the real [`oms-cognee`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/1.0.0/oms-cognee/SKILL.md) skill in [**oh-my-skills**](https://github.com/armelhbobdad/oh-my-skills) — SKF's reference output. Want to walk the citation chain yourself? The section below shows how.
 
 ## Verifying a Skill
 

--- a/docs/_data/pinned.yaml
+++ b/docs/_data/pinned.yaml
@@ -36,12 +36,12 @@ oh_my_skills_path: "../oh-my-skills"
 skills:
   oms-cognee:
     library: cognee
-    version: "0.5.8"
+    version: "1.0.0"
     source_repo: "https://github.com/topoteretes/cognee"
-    source_commit: "b51dcce1d273d47ce864cd6c5e44a7a82f7f8dce"
-    source_ref: "v0.5.8"
-    upstream_commit_date: "2026-04-08"
-    test_score: 99.45
+    source_commit: "3c048aa4147776f14d4546704f986242554a9ef3"
+    source_ref: "v1.0.0"
+    upstream_commit_date: "2026-04-11"
+    test_score: 99.00
     test_mode: "naive"
     confidence_tier: "Deep"
     source_authority: "community"

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,7 +9,7 @@ An agent skill is an instruction file that tells an AI agent how to use your cod
 
 Skills follow the [agentskills.io](https://agentskills.io) open standard, so they work across Claude, Cursor, Copilot, and other AI tools.
 
-**Example:** A skill for [cognee](https://github.com/topoteretes/cognee) tells your agent: "The function is `cognee.search()`, it takes `query_text`, `query_type`, `top_k`, and `session_id`, and it's defined at `cognee/api/v1/search/search.py:L27`." Every parameter and location is AST-verified from the actual source code.
+**Example:** A skill for [cognee](https://github.com/topoteretes/cognee) tells your agent: "The function is `cognee.search()`, its first parameters are `query_text`, `query_type`, `user`, `datasets`, and `dataset_ids`, and it's defined at `cognee/api/v1/search/search.py:L26` (v1.0.0, commit `3c048aa4`)." Every parameter and location is AST-verified from the actual source code.
 
 ---
 
@@ -18,8 +18,8 @@ Skills follow the [agentskills.io](https://agentskills.io) open standard, so the
 Provenance means every instruction in a skill traces back to where it came from. For code, that's a file and line number. For documentation, it's a URL. For developer discourse, it's an issue or PR reference. If SKF can't point to a source, it doesn't include the instruction.
 
 **Examples** (from a [real generated skill](https://github.com/armelhbobdad/oh-my-skills)):
-- `[AST:cognee/api/v1/search/search.py:L27]` — extracted from source code via AST parsing (T1)
-- `[SRC:cognee/api/v1/session/__init__.py:L8]` — read from source code without AST verification (T1-low)
+- `[AST:cognee/api/v1/search/search.py:L26]` — extracted from source code via AST parsing (T1)
+- `[SRC:cognee/api/v1/session/__init__.py:L7]` — read from source code without AST verification (T1-low)
 - `[QMD:cognee-temporal:issues.md]` — surfaced from indexed developer discourse (T2)
 - `[EXT:docs.cognee.ai/getting-started/quickstart]` — sourced from external documentation (T3)
 
@@ -81,7 +81,7 @@ Your forge tier determines which categories are scored. Quick-tier skills skip s
 
 Every skill records the exact version (or commit) of the source code it was built from. This means you always know which version of the library the instructions apply to.
 
-By default, the version is auto-detected from the source (package.json, pyproject.toml, etc.). You can also target a specific version — either by specifying it during `@Ferris BS` (brief-skill) or by appending `@version` to a quick skill command (`@Ferris QS cognee@0.5.8`). This is especially useful for docs-only skills where no source code is available for auto-detection. When targeting a specific version on a remote repository, SKF resolves the matching git tag and clones from it — so the extracted API signatures actually reflect the target version's code, not just the label applied to whatever happens to be on the default branch.
+By default, the version is auto-detected from the source (package.json, pyproject.toml, etc.). You can also target a specific version — either by specifying it during `@Ferris BS` (brief-skill) or by appending `@version` to a quick skill command (`@Ferris QS cognee@1.0.0`). This is especially useful for docs-only skills where no source code is available for auto-detection. When targeting a specific version on a remote repository, SKF resolves the matching git tag and clones from it — so the extracted API signatures actually reflect the target version's code, not just the label applied to whatever happens to be on the default branch.
 
 When the source updates, you can re-run `@Ferris US` (update-skill) to regenerate the skill for the new version while preserving any manual additions you've made.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,25 +5,25 @@ description: Real-world scenarios, tips, and troubleshooting for Skill Forge
 
 ## What the Output Looks Like
 
-When SKF generates a skill, you get a `SKILL.md` file with machine-readable frontmatter and provenance-backed instructions. Here's a trimmed example from the real [`oms-cognee` SKILL.md](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/0.5.8/oms-cognee/SKILL.md) generated for [cognee](https://github.com/topoteretes/cognee) (full portfolio at [oh-my-skills](https://github.com/armelhbobdad/oh-my-skills)):
+When SKF generates a skill, you get a `SKILL.md` file with machine-readable frontmatter and provenance-backed instructions. Here's a trimmed example from the real [`oms-cognee` SKILL.md](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/1.0.0/oms-cognee/SKILL.md) generated for [cognee](https://github.com/topoteretes/cognee) (full portfolio at [oh-my-skills](https://github.com/armelhbobdad/oh-my-skills)):
 
 **Frontmatter (tells AI agents when to load this skill):**
 
 ```yaml
-name: cognee
+name: oms-cognee
 description: >
-  Builds apps on top of cognee v0.5.8, the knowledge-graph memory engine for AI agents.
-  Use when ingesting text/files/URLs into persistent agent memory, building knowledge
-  graphs with entities and relationships, searching graph-backed memory with multiple
-  search modes (GRAPH_COMPLETION, CHUNKS, SUMMARIES, TEMPORAL, CYPHER, CODING_RULES),
-  enriching existing graphs with memify, scoping memory with datasets and node_sets,
-  configuring LLM/embedding/graph/vector backends, running custom task pipelines,
-  tracing cognee operations, or visualizing the resulting graph. Covers the top-level
-  exports from cognee/__init__.py: add, cognify, search, memify, datasets, prune,
-  update, run_custom_pipeline, config, SearchType, visualize_graph, and the tracing
-  API. Do NOT use for: cognee internals (cognify task implementation, graph adapters),
-  the HTTP REST API (use cognee-mcp or the FastAPI server instead), non-cognee memory
-  or RAG libraries.
+  Builds apps on top of cognee v1.0.0, the knowledge-graph memory engine for AI agents.
+  Use when ingesting text/files/URLs into persistent memory, building knowledge graphs,
+  searching graph-backed memory with multiple SearchType modes, enriching graphs with
+  memify/improve, scoping memory with datasets and node_sets, configuring LLM/embedding/
+  graph/vector backends, running custom task pipelines, tracing operations, decorating
+  agent entrypoints with `agent_memory`, connecting to Cognee Cloud with `serve`, or
+  visualizing the graph. Covers cognee/__init__.py exports: the V1 API (add, cognify,
+  search, memify, datasets, prune, update, run_custom_pipeline, config, SearchType,
+  visualize_graph, pipelines, Drop, run_startup_migrations, tracing) and the V2
+  memory-oriented API (remember, RememberResult, recall, improve, forget, serve,
+  disconnect, visualize, agent_memory). Do NOT use for: cognee internals, the HTTP
+  REST API (use cognee-mcp or the FastAPI server), non-cognee memory/RAG libraries.
 ```
 
 **Body (what your AI agent reads):**
@@ -33,15 +33,15 @@ description: >
 
 | Function | Purpose | Key Params | Source |
 |----------|---------|------------|--------|
-| add() | Ingest text, files, binary data | data, dataset_name | [AST:cognee/api/v1/add/add.py:L21] |
+| add() | Ingest text, files, binary data | data, dataset_name | [AST:cognee/api/v1/add/add.py:L22] |
 | cognify() | Build knowledge graph | datasets, graph_model | [AST:cognee/api/v1/cognify/cognify.py:L44] |
-| search() | Query knowledge graph | query_text, query_type | [AST:cognee/api/v1/search/search.py:L27] |
+| search() | Query knowledge graph | query_text, query_type | [AST:cognee/api/v1/search/search.py:L26] |
 | memify() | Enrich graph with custom tasks | extraction_tasks, data | [AST:cognee/modules/memify/memify.py:L25] |
-| session | Session module | session.py module | [SRC:cognee/api/v1/session/session.py:L16] |
+| remember() | V2 one-shot memory ingest | data, dataset_name | [AST:cognee/api/v1/remember/remember.py:L339] |
 | DataPoint | Base class for custom graph nodes | inherit and add fields | [EXT:docs.cognee.ai/guides/custom-data-models] |
 ```
 
-Every line number above is verbatim from the real [`forge-data/oms-cognee/0.5.8/provenance-map.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cognee/0.5.8/provenance-map.json) shipped with oh-my-skills — not illustrative.
+Every line number above is verbatim from the real [`forge-data/oms-cognee/1.0.0/provenance-map.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cognee/1.0.0/provenance-map.json) shipped with oh-my-skills — not illustrative.
 
 Provenance tags trace each instruction to its source:
 - `[AST:file:line]` — extracted from code via AST parsing (highest confidence)
@@ -55,10 +55,16 @@ See [How It Works](../how-it-works/) for the full output structure.
 
 ```
 skills/oms-cognee/
-├── active -> 0.5.8
-└── 0.5.8/
+├── active -> 1.0.0
+├── 0.5.8/
+│   └── oms-cognee/
+│       ├── SKILL.md              # Archived: v0.5.8, pinned to b51dcce1
+│       ├── context-snippet.md
+│       ├── metadata.json
+│       └── references/
+└── 1.0.0/
     └── oms-cognee/
-        ├── SKILL.md              # What your agent reads
+        ├── SKILL.md              # Active: pinned to cognee v1.0.0 (3c048aa4)
         ├── context-snippet.md    # Compressed index for platform context files
         ├── metadata.json         # Machine-readable provenance
         └── references/           # Progressive disclosure detail
@@ -68,7 +74,7 @@ skills/oms-cognee/
             └── pipelines-and-datapoints.md
 ```
 
-This is the real directory listing from [`oh-my-skills/skills/oms-cognee/`](https://github.com/armelhbobdad/oh-my-skills/tree/main/skills/oms-cognee). Skills are stored per-version — updating cognee to v1.0.0 creates a new version directory without overwriting v0.5.8. The `active` symlink always points to the current version. Some skills also include `scripts/` and `assets/` directories when the source repository contains executable scripts or static assets — oms-cognee doesn't have either, but see [How It Works → Per-Skill Output](../how-it-works/#per-skill-output) for the full schema.
+This is the real directory listing from [`oh-my-skills/skills/oms-cognee/`](https://github.com/armelhbobdad/oh-my-skills/tree/main/skills/oms-cognee) after cognee shipped v1.0.0 upstream. SKF recompiled the skill from the v1.0.0 commit and wrote it next to the existing 0.5.8 tree — the older version stays pinned to its original commit (`b51dcce1`) and is still installable by any project that hasn't bumped its `CLAUDE.md` pin yet. The `active` symlink and the [`.export-manifest.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/.export-manifest.json) both point at the current version. Some skills also include `scripts/` and `assets/` directories when the source repository contains executable scripts or static assets — oms-cognee doesn't have either, but see [How It Works → Per-Skill Output](../how-it-works/#per-skill-output) for the full schema.
 
 ---
 
@@ -87,7 +93,7 @@ Ferris reads the repository, extracts the public API, and validates against the 
 Need a specific version? Append `@version`:
 
 ```
-@Ferris QS cognee@0.5.8
+@Ferris QS cognee@1.0.0
 ```
 
 ### Brownfield Platform — Pipeline or per-workflow

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,7 +124,7 @@ Ferris reads the repository, extracts the public API, and generates a skill in u
 
 **Targeting a specific version:** Append `@version` to pin the skill to a library version:
 ```
-@Ferris QS cognee@0.5.8
+@Ferris QS cognee@1.0.0
 ```
 
 **Full quality path (pipeline mode):**

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -392,27 +392,27 @@ Skills follow the [agentskills.io specification](https://agentskills.io/specific
 
 ```yaml
 ---
-name: cognee
+name: oms-cognee
 description: >
-  Builds apps on top of cognee v0.5.8, the knowledge-graph memory engine for AI agents.
-  Use when ingesting text/files/URLs into persistent agent memory, building knowledge
-  graphs with entities and relationships, searching graph-backed memory with multiple
-  search modes (GRAPH_COMPLETION, CHUNKS, SUMMARIES, TEMPORAL, CYPHER, CODING_RULES),
-  enriching existing graphs with memify, scoping memory with datasets and node_sets,
-  configuring LLM/embedding/graph/vector backends, running custom task pipelines,
-  tracing cognee operations, or visualizing the resulting graph. Covers the top-level
-  exports from cognee/__init__.py: add, cognify, search, memify, datasets, prune,
-  update, run_custom_pipeline, config, SearchType, visualize_graph, and the tracing
-  API. Do NOT use for: cognee internals (cognify task implementation, graph adapters),
-  the HTTP REST API (use cognee-mcp or the FastAPI server instead), non-cognee memory
-  or RAG libraries.
+  Builds apps on top of cognee v1.0.0, the knowledge-graph memory engine for AI agents.
+  Use when ingesting text/files/URLs into persistent memory, building knowledge graphs,
+  searching graph-backed memory with multiple SearchType modes, enriching graphs with
+  memify/improve, scoping memory with datasets and node_sets, configuring LLM/embedding/
+  graph/vector backends, running custom task pipelines, tracing operations, decorating
+  agent entrypoints with `agent_memory`, connecting to Cognee Cloud with `serve`, or
+  visualizing the graph. Covers cognee/__init__.py exports: the V1 API (add, cognify,
+  search, memify, datasets, prune, update, run_custom_pipeline, config, SearchType,
+  visualize_graph, pipelines, Drop, run_startup_migrations, tracing) and the V2
+  memory-oriented API (remember, RememberResult, recall, improve, forget, serve,
+  disconnect, visualize, agent_memory). Do NOT use for: cognee internals, the HTTP
+  REST API (use cognee-mcp or the FastAPI server), non-cognee memory/RAG libraries.
 ---
 ```
 
 Every instruction in the body traces to source:
 
 ```python
-await cognee.search(  # [AST:cognee/api/v1/search/search.py:L27]
+await cognee.search(  # [AST:cognee/api/v1/search/search.py:L26]
     query_text="What does Cognee do?"
 )
 ```
@@ -421,40 +421,40 @@ await cognee.search(  # [AST:cognee/api/v1/search/search.py:L27]
 
 Machine-readable provenance for every skill:
 
-This is a trimmed excerpt from the real [`oms-cognee/0.5.8/metadata.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/0.5.8/oms-cognee/metadata.json) shipped with the oh-my-skills canonical output. Every value below is verbatim from the file — not illustrative.
+This is a trimmed excerpt from the real [`oms-cognee/1.0.0/metadata.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/1.0.0/oms-cognee/metadata.json) shipped with the oh-my-skills canonical output. Every value below is verbatim from the file — not illustrative.
 
 ```json
 {
   "name": "oms-cognee",
-  "version": "0.5.8",
+  "version": "1.0.0",
   "skill_type": "single",
   "source_authority": "community",
   "source_repo": "https://github.com/topoteretes/cognee",
-  "source_commit": "b51dcce1d273d47ce864cd6c5e44a7a82f7f8dce",
-  "source_ref": "v0.5.8",
+  "source_commit": "3c048aa4147776f14d4546704f986242554a9ef3",
+  "source_ref": "v1.0.0",
   "confidence_tier": "Deep",
   "spec_version": "1.3",
-  "generation_date": "2026-04-10T21:18:00Z",
+  "generation_date": "2026-04-13T00:00:00Z",
   "language": "python",
-  "ast_node_count": 25,
+  "ast_node_count": 34,
   "confidence_distribution": {
-    "t1": 25,
+    "t1": 34,
     "t1_low": 0,
-    "t2": 4,
+    "t2": 11,
     "t3": 15
   },
   "stats": {
-    "exports_documented": 25,
-    "exports_public_api": 25,
+    "exports_documented": 34,
+    "exports_public_api": 34,
     "exports_internal": 0,
-    "exports_total": 25,
+    "exports_total": 34,
     "public_api_coverage": 1.0,
     "total_coverage": 1.0
   }
 }
 ```
 
-Fields omitted from this excerpt for brevity: `description`, `exports[]`, `tool_versions`, `dependencies`, `compatibility`, `last_update`, `generated_by`. The full 83-line file lives at [`oh-my-skills/skills/oms-cognee/0.5.8/oms-cognee/metadata.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/0.5.8/oms-cognee/metadata.json).
+Fields omitted from this excerpt for brevity: `description`, `exports[]`, `tool_versions`, `dependencies`, `compatibility`, `last_update`, `generated_by`. The full 93-line file lives at [`oh-my-skills/skills/oms-cognee/1.0.0/oms-cognee/metadata.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/skills/oms-cognee/1.0.0/oms-cognee/metadata.json).
 
 `scripts` and `assets` arrays are optional — omitted entirely (not empty) when the source has no scripts or assets.
 
@@ -502,17 +502,18 @@ Export injects a managed section between markers:
 The block below is the real managed section currently in [`oh-my-skills/CLAUDE.md`](https://github.com/armelhbobdad/oh-my-skills/blob/main/CLAUDE.md), showing one of its four compiled skills. Every line is verbatim from the file:
 
 ```markdown
-<!-- SKF:BEGIN updated:2026-04-12 -->
+<!-- SKF:BEGIN updated:2026-04-13 -->
 [SKF Skills]|4 skills|0 stack
 |IMPORTANT: Prefer documented APIs over training data.
 |When using a listed library, read its SKILL.md before writing code.
 |
-|[oms-cognee v0.5.8]|root: .claude/skills/oms-cognee/
-|IMPORTANT: oms-cognee v0.5.8 — read SKILL.md before writing cognee code. Do NOT rely on training data.
+|[oms-cognee v1.0.0]|root: .claude/skills/oms-cognee/
+|IMPORTANT: oms-cognee v1.0.0 — read SKILL.md before writing cognee code. Do NOT rely on training data.
 |quick-start:SKILL.md#quick-start
-|api: add(), cognify(), search(), memify(), update(), run_custom_pipeline(), visualize_graph(), datasets, prune, SearchType
-|key-types:SKILL.md#key-types — SearchType: GRAPH_COMPLETION (default), RAG_COMPLETION, CHUNKS, CHUNKS_LEXICAL, SUMMARIES, TEMPORAL, CODING_RULES, CYPHER, FEELING_LUCKY (+5 more); Task, DataPoint, 5 Cognee* exceptions
-|gotchas: cognee.delete is DEPRECATED since v0.3.9 (use cognee.datasets.delete_data); cognee.start_ui is sync (not async) and needs pid_callback arg; cognee.start_visualization_server is a module, call .visualization_server(port) on it; all add/cognify/search/memify are async — always await.
+|api-v1: add(), cognify(), search(), memify(), update(), run_custom_pipeline(), visualize_graph(), datasets, prune, config, SearchType, pipelines, Drop, run_startup_migrations(), session, tracing
+|api-v2: remember()→RememberResult, recall(), improve(), forget(), serve()/disconnect(), visualize(), @agent_memory
+|key-types:SKILL.md#key-types — SearchType: GRAPH_COMPLETION (default), RAG_COMPLETION, CHUNKS, CHUNKS_LEXICAL, SUMMARIES, TEMPORAL, CODING_RULES, CYPHER, FEELING_LUCKY, GRAPH_COMPLETION_DECOMPOSITION (+5 more); Task, Drop, RememberResult, DataPoint, 5 Cognee* exceptions
+|gotchas: cognee.low_level REMOVED from public API in v1.0.0 (import from cognee.infrastructure.engine directly); cognee.run_migrations REPLACED by cognee.run_startup_migrations (relational + vector); cognee.delete is DEPRECATED since v0.3.9 (use cognee.datasets.delete_data or cognee.forget); cognee.pipelines restructured in v1.0.0 (package with Drop + lazy re-exports); cognee.agent_memory requires async function; cognee.serve() without url triggers Auth0 Device Code Flow; cognee.start_ui is sync and needs pid_callback arg; all add/cognify/search/memify/remember/recall/improve/forget/serve are async — always await.
 |
 |(three more skills — oms-cocoindex, oms-storybook-react-vite, oms-uitripled — omitted here for brevity; see the full file)
 <!-- SKF:END -->

--- a/docs/verifying-a-skill.md
+++ b/docs/verifying-a-skill.md
@@ -37,7 +37,7 @@ Provenance maps live in `forge-data/{skill}/{version}/provenance-map.json` along
 }
 ```
 
-The snippet above is a real entry from [`forge-data/oms-cognee/0.5.8/provenance-map.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cognee/0.5.8/provenance-map.json). Line number is not rounded. Confidence tier is explicit. Extraction method is named. Nothing is paraphrased.
+The snippet above is a real entry from [`forge-data/oms-cognee/1.0.0/provenance-map.json`](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cognee/1.0.0/provenance-map.json). Line number is not rounded. Confidence tier is explicit. Extraction method is named. Nothing is paraphrased.
 
 ### 3. Visit the upstream repo at the pinned commit
 
@@ -77,7 +77,7 @@ Take oh-my-skills' four reference skills as an example. Their scores range from 
 | Skill | Score | What the report discloses |
 |---|---|---|
 | [oms-cocoindex](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cocoindex/0.3.37/test-report-oms-cocoindex.md) | **99.0%** | 114/114 provenance entries; 55 public-API denominator from `__init__.py` `__all__`; 20/20 sampled signatures matched. Two denominators (barrel vs. full surface) both disclosed with rationale. |
-| [oms-cognee](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cognee/0.5.8/test-report-oms-cognee.md) | **99.45%** | 25/25 exports documented; denominator pinned to `cognee/__init__.py` lines 18–47. |
+| [oms-cognee](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-cognee/1.0.0/test-report-oms-cognee.md) | **99.0%** | 34/34 exports documented; denominator is the `cognee/__init__.py` barrel (61 lines, 34 public re-exports) at pinned commit `3c048aa4` (v1.0.0). |
 | [oms-storybook-react-vite](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-storybook-react-vite/10.3.5/test-report-oms-storybook-react-vite.md) | **99.49%** | 215/216 documented — the missing 1 entry is logged openly as **GAP-004**, a canonical surface count drift from the stated denominator. |
 | [oms-uitripled](https://github.com/armelhbobdad/oh-my-skills/blob/main/forge-data/oms-uitripled/0.1.0/test-report-oms-uitripled.md) | **99.45%** | 34-entry denominator (not 11, not 25) with the full reconciliation reasoning in the report. |
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -75,7 +75,7 @@ Trigger workflows by typing commands to [Ferris](../agents/). See [Concepts](../
 
 **Purpose:** Brief-less fast skill with package-to-repo resolution.
 
-**When to Use:** When you need a skill quickly — no brief needed. Accepts package names or GitHub URLs. Append `@version` to target a specific version (e.g., `@Ferris QS cognee@0.5.8`).
+**When to Use:** When you need a skill quickly — no brief needed. Accepts package names or GitHub URLs. Append `@version` to target a specific version (e.g., `@Ferris QS cognee@1.0.0`).
 
 **Key Steps:** Resolve target → Ecosystem check → Quick extract → Compile → Validate → Write
 

--- a/tools/validate-docs-drift.js
+++ b/tools/validate-docs-drift.js
@@ -53,6 +53,17 @@ function resolveOmsPath(anchors) {
   return path.resolve(SKF_ROOT, anchors.oh_my_skills_path);
 }
 
+// Accept either a full SHA match or a short-SHA prefix match, per
+// src/skf-update-skill/steps-c/step-03-re-extract.md:36 — the pinned commit
+// is often stored as an 8-char short hash. Both anchors and metadata are
+// lowercased before comparison; blank / null values never match.
+function commitsMatch(anchorCommit, metadataCommit) {
+  if (!anchorCommit || !metadataCommit) return false;
+  const a = String(anchorCommit).toLowerCase();
+  const b = String(metadataCommit).toLowerCase();
+  return a === b || a.startsWith(b) || b.startsWith(a);
+}
+
 function checkCanonicalFiles(anchors, omsPath) {
   const errors = [];
   if (!fs.existsSync(omsPath) || !fs.statSync(omsPath).isDirectory()) {
@@ -83,7 +94,7 @@ function checkCanonicalFiles(anchors, omsPath) {
       errors.push(`VERSION_DRIFT: ${skillName} — anchors say ${spec.version}, ` + `metadata.json says ${metadata.version}`);
     }
 
-    if (metadata.source_commit !== spec.source_commit) {
+    if (!commitsMatch(spec.source_commit, metadata.source_commit)) {
       const anchorShort = (spec.source_commit || '').slice(0, 12);
       const realShort = (metadata.source_commit || '').slice(0, 12);
       errors.push(`COMMIT_DRIFT: ${skillName} — anchors say ${anchorShort}, ` + `metadata.json says ${realShort}`);


### PR DESCRIPTION
## Summary

- **Canonical anchors** — `docs/_data/pinned.yaml` bumps oms-cognee to v1.0.0 (commit `3c048aa4`, upstream v1.0.0 tag, 2026-04-11), test_score 99.00. Verified against [oh-my-skills commit](https://github.com/armelhbobdad/oh-my-skills/pull/12).
- **Docs** — every reference to cognee v0.5.8 across README, concepts, examples, getting-started, how-it-works, verifying-a-skill, workflows now reflects v1.0.0. The verbatim SKILL.md frontmatter, metadata.json excerpt (34/34 exports, t1 34, 93-line file), and managed-section snippet are copied from the real oh-my-skills v1.0.0 tree. The `search()` source line drifts L27 → L26 and `session/__init__.py` L8 → L7 are corrected.
- **Drift validator fix** — `tools/validate-docs-drift.js` now accepts short-SHA prefix matches for `source_commit`, aligning with the convention already documented in `src/skf-update-skill/steps-c/step-03-re-extract.md:36` (*"Accept either a full SHA match or a short-SHA prefix match"*). Previously the strict-equality check forced consumers to mutate their authentic metadata.json output.

## Test plan

- [x] `OMS=../oh-my-skills node tools/validate-docs-drift.js` → `OK: 4 skills checked, no drift`
- [x] Regression test: validator passes when metadata.json holds the full SHA (anchor full + metadata full)
- [x] Regression test: validator passes when metadata.json holds only the short SHA (anchor full + metadata short) — the new prefix-match path
- [x] Every v1.0.0 value cited in the docs (exports, line numbers, description, metadata fields) copied verbatim from the real oh-my-skills files — nothing paraphrased
- [x] `npm test` green via pre-commit hook
- [x] Reviewer: spot-check the managed-section block in `docs/how-it-works.md` against the live [oh-my-skills CLAUDE.md](https://github.com/armelhbobdad/oh-my-skills/blob/main/CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)