### PR TITLE
docs: reflect Windows CI-matrix support in README + getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If it doesn't, that's a bug — open an issue and SKF will republish with a new 
 
 ## Install
 
-**Supported platforms:** Linux and macOS (tested in CI). The atomic-write helper and shell snippets cross-compile to Windows but native Windows is not exercised by CI yet — the supported path on Windows is **WSL2**. Native Windows works in principle (path quoting, portable file locking, Developer Mode for symlinks) but ships unverified for v1.0; see [CONTRIBUTING.md](./CONTRIBUTING.md) if you want to help test it.
+**Supported platforms:** Linux and Windows — tested in CI on every PR via an `ubuntu-latest` + `windows-latest` matrix on `validate` and `python` jobs. macOS works in practice (POSIX-equivalent to Linux) but isn't CI-gated. On Windows, SKF falls back to NTFS junctions when symlink privilege isn't held, so no Developer Mode or admin is required.
 
 Requires [Node.js](https://nodejs.org/) >= 22, [Python](https://www.python.org/) >= 3.10, and [uv](https://docs.astral.sh/uv/) (Python package runner).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,6 +85,12 @@ The installer reads the installed version from your manifest and shows the delta
 
 Node.js, Python, and uv are required for all tiers. Don't worry about the rest — SKF detects what's available and sets your tier automatically. Security scanning via Snyk is optional and requires an Enterprise plan; it does not affect your tier level.
 
+### Platform support
+
+**Linux and Windows** are exercised in CI on every PR (`ubuntu-latest` + `windows-latest` matrix on `validate` and `python` jobs). **macOS** works in practice — POSIX-equivalent to Linux — but isn't CI-gated; if you hit a macOS-specific bug, please [file an issue](https://github.com/armelhbobdad/bmad-module-skill-forge/issues).
+
+On Windows, SKF transparently falls back to NTFS junctions when symlink privilege isn't held, so no Developer Mode or admin rights are required. Git Bash (bundled with [Git for Windows](https://git-scm.com/download/win)), PowerShell, and WSL2 all work.
+
 ---
 
 ## Configuration


### PR DESCRIPTION
## Summary

Follow-up docs pass after PR #166 shipped the Windows CI matrix to \`main\`. Two documents updated to replace the pre-matrix \"WSL2 is the supported path on Windows\" framing with accurate CI-coverage language.

## Changes

**\`README.md\` (d53f09b):** Supported-platforms paragraph corrected. Two stale claims fixed:
- macOS was labeled CI-tested but never actually was (workflow only had \`ubuntu-latest\`). Now correctly shows Linux + Windows as CI-gated, macOS as works-in-practice-but-not-CI.
- Windows was labeled \"unverified for v1.0, WSL2 is the supported path.\" No longer true — Windows is green on every PR.

**\`docs/getting-started.md\` (0260644):** New \"Platform support\" subsection under Prerequisites. Adds the details README readers don't need but docs readers do:
- No Developer Mode or admin rights required (junction fallback is automatic)
- Git Bash, PowerShell, and WSL2 all work as shells
- Pointer to open an issue for Mac-only bugs

No duplication between the two — README states the support matrix, docs explains the Windows shell story.

## Test plan

- [x] \`npm run docs:validate-drift\` — OK (4 skills, no drift)
- [x] Matrix CI green on this PR (README + docs changes shouldn't touch any code path, but the matrix runs anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)