### PR TITLE
docs(links): fix Install anchor + ignore .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ website/.astro/
 website/dist/
 build/
 skills
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: Install
-      link: ./getting-started/#installation
+      link: ./getting-started/#install
       icon: right-arrow
       variant: secondary
 ---

--- a/docs/why-skf.md
+++ b/docs/why-skf.md
@@ -88,6 +88,6 @@ Everything else is downstream of one question: *are the instructions your AI rea
 
 ## Next
 
-- **[Install SKF](../getting-started/#installation)** — Node ≥ 22, Python ≥ 3.10, `uv`, one `npx` command
+- **[Install SKF](../getting-started/#install)** — Node ≥ 22, Python ≥ 3.10, `uv`, one `npx` command
 - **[Audit a skill in 60 seconds](../verifying-a-skill/)** — see the receipts before you install
 - **[Browse real skills](https://github.com/armelhbobdad/oh-my-skills)** — four Deep-tier skills, all shipping their audit trails

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ export default [
       'src/modules/*/sub-modules/**',
       '.bundler-temp/**',
       'temp/**',
+      '.playwright-mcp/**',
     ],
   },
 


### PR DESCRIPTION
## Summary

- Fixed the `Install` action in the hero on `docs/index.md` and the `Install SKF` link in the `## Next` list on `docs/why-skf.md` — both pointed at `../getting-started/#installation`, but the heading in `getting-started.md` is `## Install`, i.e. slug `#install`. They now land on the Install section instead of the page top.
- Audited every anchor and external link across `docs/` — all remaining anchors resolve to real headings, and all 54 unique external URLs return 200 (the npm page returns 403 to curl under Cloudflare bot protection; `registry.npmjs.org/skills` confirms the package exists).
- Added `.playwright-mcp/` to `.gitignore` and to `eslint.config.mjs` ignores. Playwright MCP writes per-session log/snapshot files that are not part of the repo; when present, they were tripping `unicorn/filename-case` and `yml/file-extension` on every full-repo lint.

## Test plan

- [x] `npm test` passes locally (full pre-commit suite ran green on both commits)
- [x] Preview deploy: click the hero **Install** button on the home page and confirm it scrolls to the Install section on Getting Started
- [x] Preview deploy: on the Why page, click **Install SKF** at the bottom and confirm same behavior
- [x] Confirm no Playwright MCP artifacts leak into the repo after a browser-agent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)