### PR TITLE
docs: Medium article link + Layer 2/3 candidate pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You ask an AI agent to use a library. It invents function names that don't exist
 
 This isn't an edge case. It's the default experience.
 
+For the full story behind SKF, read [*Hallucination has a line number*](https://medium.com/@armelhbobdad/hallucination-has-a-line-number-32209b4688de) on Medium.
+
 ## Before vs After
 
 **Without SKF** — your agent guesses:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,23 +28,39 @@ Ship when Layer 1 is stable and a target tool meets the **Tool Maturity Gate**: 
 
 Ship when Layer 2 graphify (or alternative) integration is proven AND a graph-merging API exists. Scope: merge per-repo graphs into a unified stack graph, Leiden community detection across repos for architectural layers, forge intelligence prompts ("you've forged N skills from this repo, here are unexplored communities"), stack-skill drift detection at the relationship level, and workspace-level QMD collections.
 
+### Architectural decision: two-tier vs collapsed-tier
+
+Layer 2/3 as written assumes tenants produce per-repo outputs that Layer 3 merges later — matching graphify-shaped tools. A credible alternative (CodeGraphContext-shaped) indexes all repos into a single embedded graph backend (KùzuDB) with queries scoped by `repo_path`, collapsing Layer 2 and Layer 3 into one tier.
+
+**Both shapes remain open.** Path A preserves tenant modularity and matches the current roadmap; Path B reaches Layer 3 primitives sooner at the cost of letting one tool own more of the surface. The choice will be made when a candidate tool first meets the Tool Maturity Gate; this decision is recorded here so integration work stays coherent with whichever path we commit to.
+
 ---
 
-## Graphify Upstream Contribution
+## Layer 2 Tenant Candidates
 
-Partner with [safishamsi/graphify](https://github.com/safishamsi/graphify) (MIT, 16.6k stars) to mature it into a viable Layer 2 tenant. SKF commits to contributing upstream rather than forking.
+SKF contributes upstream rather than forking. Three OSS candidates are tracked as parallel options; none currently clears the Tool Maturity Gate (the 6-months-of-releases criterion in particular). The first to clear becomes the Layer 2 anchor; the others remain referenced.
 
-**P0 blockers for Layer 2 integration:**
-- Schema versioning for `graph.json` (currently unversioned)
-- File deletion handling in `--update` (ghost nodes persist after deletes)
-- Full Windows support across build/query/watch/MCP server
+Layer 3 decomposes into two primitives — cross-repo graph merge and community detection. No single candidate ships both today, which is load-bearing context for the path chosen.
 
-**P1 blockers for Layer 3 integration:**
-- Graph merging API (CLI or Python) for cross-repo unified graphs
-- Stable, documented Python API for programmatic consumption
-- Shallow-clone compatibility validation
+**Candidates (as of 2026-04-19):**
 
-Backup candidates if graphify stalls: GitNexus (watching for MIT relicense), CodeGraphContext (MIT, 2.2k stars), CodeGraph-Rust.
+- **[safishamsi/graphify](https://github.com/safishamsi/graphify)** — MIT, ~30k stars. Tree-sitter + NetworkX + **Leiden clustering** (the algorithm named in Layer 3 above; other candidates do not ship it). Narrowest surface to audit; parallel version branches in CI signal healthier release-engineering than a single-branch pre-1.0 project.
+  - Open P0s: versioned `graph.json` schema; Windows CI coverage (CI is currently `ubuntu-latest` only).
+  - Open P1s: cross-repo graph-merge API; stable, documented Python API; shallow-clone validation.
+
+- **[CodeGraphContext/CodeGraphContext](https://github.com/CodeGraphContext/CodeGraphContext)** — MIT, ~3k stars, 14 languages. **Native multi-repo unified graph** via KùzuDB (embedded, Windows-supported) scoped by `repo_path`; "Bundles" ship pre-indexed library graphs. Would require committing to the collapsed-tier architectural path.
+  - Open P0s: **no community detection implemented** — a direct Layer 3 primitive SKF would need to add upstream or delegate; one-pass security review (a hardened fork exists with claimed path-traversal and Cypher-injection patches — upstream status unverified).
+  - Open P1s: stable programmatic API; shallow-clone validation.
+
+- **[repowise-dev/repowise](https://github.com/repowise-dev/repowise)** — **AGPL-3.0**, ~1.2k stars. Full codebase-intelligence platform (dependency graph, git intelligence, dead code, decision extraction, MCP + REST + dashboard). `--index-only` zero-LLM mode covers the parts SKF cares about without forcing API keys on users.
+  - License note: AGPL-3.0 permits subprocess/CLI use from MIT code (SKF invokes the `repowise` binary). Importing repowise as a library would trigger AGPL contagion — not permitted. Network §13 would constrain any future hosted-SKF offering.
+  - Open P0s: reach 6+ months of releases (currently <1 month old); Louvain → Leiden swap if Layer 3 is to match the algorithm named above; cross-repo support in OSS (currently hosted-only); Windows CI coverage (`ubuntu-latest` only).
+
+**Non-candidates (documented so they are not re-discovered):**
+
+- **[abhigyanpatwari/GitNexus](https://github.com/abhigyanpatwari/GitNexus)** — PolyForm Noncommercial 1.0.0. Source-available, not OSI-open. Disqualified for SKF integration irrespective of technical fit (which is strong: multi-repo groups, CLI + MCP + browser).
+- **github/stack-graphs** — archived 2025-09-09. Referenced only as a cautionary data point against per-language graph-construction DSLs.
+- **CodeGraph-Rust** — no canonical repository located; removed from tracking pending a verified URL.
 
 ---
 


### PR DESCRIPTION
## Summary
- Link the *Hallucination has a line number* Medium announcement from the README's Problem section.
- Broaden ROADMAP's Layer 2 candidate pool (graphify, CodeGraphContext, repowise) and document the two-tier vs collapsed-tier architectural decision.
- Record non-candidates (GitNexus, stack-graphs, CodeGraph-Rust) so they aren't re-evaluated.

## Test plan
- [x] Confirm the Medium link resolves
- [x] Verify ROADMAP renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)