### PR TITLE
TEST: verify ruleset gate (DO NOT MERGE)

### DIFF
--- a/test-ruleset-gate.json
+++ b/test-ruleset-gate.json
@@ -1,0 +1,5 @@
+{
+    "purpose":   "intentionally unformatted — proves main's required_status_checks blocks merge when prettier fails",
+        "story": "1.1",
+  "delete": "closing PR without merge"
+}

--- a/test-ruleset-gate.json
+++ b/test-ruleset-gate.json
@@ -1,5 +1,5 @@
 {
-    "purpose":   "intentionally unformatted — proves main's required_status_checks blocks merge when prettier fails",
-        "story": "1.1",
+  "purpose": "intentionally unformatted — proves main's required_status_checks blocks merge when prettier fails",
+  "story": "1.1",
   "delete": "closing PR without merge"
 }


### PR DESCRIPTION
Story 1.1 — live enforcement test for required_status_checks ruleset on `main`.

This PR intentionally adds an unformatted `test-ruleset-gate.json`. Expected:

1. `prettier` check FAILS.
2. Merge banner shows "Required status check failing" or equivalent, blocking the merge button.
3. After fixing formatting, all 7 required checks turn green.
4. This PR is then **closed without merging**.

No review needed. Will close once checks prove the gate works.