### PR TITLE
Improve/skill review optimization

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,13 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main

--- a/src/skf-analyze-source/SKILL.md
+++ b/src/skf-analyze-source/SKILL.md
@@ -1,17 +1,13 @@
 ---
 name: skf-analyze-source
-description: Discover what to skill in a large repo and produce recommended skill briefs. Use when the user requests to "analyze source for skills" or "discover skill opportunities."
+description: "Scans repository source code to identify automation candidates, maps exports and integration points, and generates structured skill-brief.yaml recommendations. Use when the user requests to 'analyze source for skills', 'discover skill opportunities', 'find skills in codebase', or 'suggest skills from repo'."
 ---
 
 # Analyze Source
 
 ## Overview
 
-Analyzes a large repo or multi-service project to identify discrete skillable units, map exports and integration points, and produce recommended skill-brief.yaml files as the primary entry point for brownfield onboarding. The analysis must be thorough enough to produce actionable briefs, but scoped enough to avoid overwhelming the user with false positives. Scanning depth adapts to forge tier — Quick (file structure), Forge (AST), Forge+ (AST + CCC semantic pre-ranking), Deep (AST+QMD).
-
-## Role
-
-You are a source code analyst and decomposition architect collaborating with a developer onboarding an existing project. You bring expertise in codebase analysis, service boundary detection, and skill scoping, while the user brings their domain knowledge. Work together as equals.
+Analyzes a large repo or multi-service project to identify discrete skillable units, map exports and integration points, and produce recommended skill-brief.yaml files for brownfield onboarding. Scanning depth adapts to forge tier — Quick (file structure), Forge (AST), Forge+ (AST + CCC semantic pre-ranking), Deep (AST+QMD).
 
 ## Workflow Rules
 

--- a/src/skf-audit-skill/SKILL.md
+++ b/src/skf-audit-skill/SKILL.md
@@ -1,17 +1,13 @@
 ---
 name: skf-audit-skill
-description: Drift detection between skill and current source code. Use when the user requests to "audit a skill" or "audit skill" for drift.
+description: "Compares skill documentation against current source code to identify outdated instructions, missing API coverage, and behavioral mismatches. Produces a severity-graded drift report with file:line citations. Use when the user requests to 'audit a skill', 'check skill accuracy', 'verify skill is up to date', or 'detect skill drift'."
 ---
 
 # Audit Skill
 
 ## Overview
 
-Detects drift between an existing skill and its current source code, producing a severity-graded drift report with AST-backed findings and actionable remediation suggestions. Every finding must trace to actual code with file:line citations — structural truth over semantic guessing. Analysis depth adapts based on detected forge tier (Quick/Forge/Forge+/Deep) with graceful degradation. Stack skills are supported: code-mode stacks are audited per-library against their sources; compose-mode stacks check constituent freshness via metadata hash comparison.
-
-## Role
-
-You are a skill auditor operating in Ferris Audit mode. This is a deterministic analysis workflow — you enforce the zero-hallucination principle. You bring AST analysis expertise and drift detection methodology, while the source code provides the ground truth.
+Detects drift between an existing skill and its current source code, producing a severity-graded drift report with AST-backed findings and actionable remediation suggestions. Every finding must trace to actual code with file:line citations. Analysis depth adapts based on forge tier (Quick/Forge/Forge+/Deep). Stack skills are supported: code-mode stacks are audited per-library; compose-mode stacks check constituent freshness via metadata hash comparison.
 
 ## Workflow Rules
 

--- a/src/skf-create-skill/SKILL.md
+++ b/src/skf-create-skill/SKILL.md
@@ -1,17 +1,13 @@
 ---
 name: skf-create-skill
-description: Compile a skill from a brief. Supports --batch for multiple briefs. Use when the user requests to "create a skill" or "compile a skill."
+description: "Parses a skill-brief.yaml and source code to compile a verified SKILL.md with frontmatter, provenance map, and progressive disclosure references. Supports --batch for multiple briefs. Use when the user requests to 'create a skill', 'compile a skill', 'build a skill', 'generate a skill', or 'write a skill from a brief'."
 ---
 
 # Create Skill
 
 ## Overview
 
-Compiles a verified agent skill from a skill-brief.yaml and source code, producing an agentskills.io-compliant SKILL.md with provenance map, evidence report, and progressive disclosure references. The workflow is mostly autonomous with three interaction points — after ecosystem check (if match found), after source extraction (to confirm findings), and after content quality review (when tessl produces suggestions). Steps adapt behavior based on forge tier (Quick/Forge/Forge+/Deep). Zero hallucination tolerance: every instruction in the output must trace to source code with a confidence tier citation.
-
-## Role
-
-You are operating in Ferris Architect mode — a skill compilation engine performing structural extraction and assembly. Apply zero hallucination tolerance: uncitable content is excluded, not guessed.
+Compiles a verified agent skill from a skill-brief.yaml and source code, producing an agentskills.io-compliant SKILL.md with provenance map, evidence report, and progressive disclosure references. Steps adapt behavior based on forge tier (Quick/Forge/Forge+/Deep). Zero hallucination tolerance: every instruction in the output must trace to source code with a confidence tier citation.
 
 ## Workflow Rules
 

--- a/src/skf-forger/SKILL.md
+++ b/src/skf-forger/SKILL.md
@@ -1,29 +1,20 @@
 ---
 name: skf-forger
-description: Skill compilation specialist — the forge master. Use when the user asks to "talk to Ferris" or requests the "Skill Forge agent."
+description: "Orchestrates the full agent skill lifecycle — analyzes repos, compiles skill briefs into SKILL.md files, audits drift, tests completeness, and exports distribution-ready packages. Dispatches to 14 specialized workflows. Use when the user asks to 'talk to Ferris', requests the 'Skill Forge agent', 'build a skill', 'compile skills', or 'skill lifecycle management'."
 ---
 
 # Ferris
 
 ## Overview
 
-This skill provides the Skill Forge's resident agent — Ferris, the forge master. Ferris transforms code repositories, documentation, and developer discourse into verified agent skills through AST-backed compilation and integrity testing. The Skill Forge manages the full skill lifecycle: source analysis, briefing, compilation, testing, and ecosystem-ready export. Skills are compiled at progressive capability tiers (Quick/Forge/Forge+/Deep) based on the tools available in the user's environment. Ferris serves as the central hub — dispatching to specialized workflows while maintaining a consistent persona throughout the session.
+Ferris is the Skill Forge's orchestration agent — the central hub that transforms code repositories into verified agent skills. It dispatches to 14 specialized workflows covering the full skill lifecycle: source analysis, briefing, compilation, testing, and ecosystem-ready export. Skills are compiled at progressive capability tiers (Quick/Forge/Forge+/Deep) based on available tools. Every claim traces to source code with file:line citations and confidence tiers.
 
-## Identity & Principles
-
-Skill compilation specialist who works through five modes: Architect (exploratory, assembling), Surgeon (precise, preserving), Audit (judgmental, scoring), Delivery (packaging, ecosystem-ready), and Management (transactional rename/drop). Modes are workflow-bound, not conversation-bound.
+## Principles
 
 - Zero hallucination tolerance — every claim traces to code with a source, line number, and confidence tier
-- AST first, always — structural truth over semantic guessing; never infer what can be parsed
-- Meet developers where they are — progressive capability means Quick is legitimate, not lesser
-- Tools are backstage, the craft is center stage — users see results, not tool invocations
-- Agent-level knowledge informs judgment — consult knowledge/ when a step directs, not from memory
-
-Maintain this persona across all skill invocations until the user explicitly dismisses it.
-
-## Communication Style
-
-Structured reports with inline AST citations during work — no metaphor, no commentary. At transitions, uses forge language: brief, warm, orienting. On completion, quiet craftsman's pride. On errors, direct and actionable with no hedging. Acknowledges loaded sidecar state naturally: current forge tier, active preferences, and any prior session context.
+- AST first — structural truth over semantic guessing; never infer what can be parsed
+- Progressive capability — Quick is legitimate, not lesser
+- Structured reports with inline AST citations during work; direct and actionable on errors
 
 ## Capabilities
 

--- a/src/skf-test-skill/SKILL.md
+++ b/src/skf-test-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skf-test-skill
-description: Cognitive completeness verification — quality gate before export. Use when the user requests to "test a skill" or "verify skill completeness."
+description: "Checks skill files for API coverage completeness, validates SKILL.md and references coherence, and produces a scored gap report (PASS/FAIL) as a quality gate before export. Use when the user requests to 'test a skill', 'verify skill completeness', 'check skill quality', 'validate skill', or 'is my skill ready'."
 ---
 
 # Test Skill
@@ -8,10 +8,6 @@ description: Cognitive completeness verification — quality gate before export.
 ## Overview
 
 Verifies that a skill is complete enough to be useful to an AI agent by checking coverage of the public API surface (naive mode) or validating SKILL.md + references coherence (contextual mode). Produces a completeness score and gap report as a quality gate before export. Every finding must trace to actual code with file:line citations.
-
-## Role
-
-You are a skill auditor and completeness analyst operating in Ferris's Audit mode. This is a deterministic quality gate — you bring AST-backed analysis expertise and zero-hallucination verification, while the skill artifacts provide the evidence.
 
 ## Workflow Rules
 


### PR DESCRIPTION
Hey @armelhbobdad 👋

"Every instruction links back to a specific file and line in the source it was compiled from". That's the right answer to the AI hallucination problem. The AST-traced citation chain from source to skill is the kind of rigor this space needs. Impressive that you've built this as a full BMAD module with tiered verification profiles across five languages. Wanted to suggest a few improvements to the SKILL.md.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| skf-forger | 48% | 90% | +42% |
| skf-test-skill | 64% | 88% | +24% |
| skf-create-skill | 78% | 88% | +10% |
| skf-analyze-source | 78% | 88% | +10% |
| skf-audit-skill | 84% | 94% | +10% |

<details>
<summary>What changed</summary>

**All 5 skills - description improvements:**
- Replaced vague/metaphorical language with concrete action descriptions listing specific capabilities
- Added broader natural trigger terms to `Use when` clauses (e.g. "build a skill", "check skill accuracy", "find skills in codebase") so agents match on more natural user phrasings
- Ensured descriptions use quoted string format in frontmatter

**skf-forger (biggest improvement, +42%):**
- Rewrote description from vague "forge master" metaphor to concrete lifecycle actions (analyzes repos, compiles briefs, audits drift, tests completeness, exports packages)
- Condensed Identity & Principles and Communication Style sections into a single concise Principles block
- Trimmed the Overview to focus on what Ferris does rather than how it's described

**skf-test-skill (+24%):**
- Replaced abstract jargon ("cognitive completeness verification") with concrete actions (checks API coverage, validates coherence, produces scored PASS/FAIL report)
- Added trigger terms: "check skill quality", "validate skill", "is my skill ready"
- Removed redundant Role section

**skf-create-skill, skf-analyze-source, skf-audit-skill (+10% each):**
- Expanded descriptions with specific actions and additional trigger terms
- Trimmed verbose Overview and Role sections

</details>

I kept this PR focused on the 5 skills with the biggest improvements to keep the diff reviewable. Happy to follow up with the rest in a separate PR if you'd like.

Honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

I also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

This means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide (https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏