### PR TITLE
Fix 14 health-check issues (#173–#186): test-skill, create-skill, create-stack-skill, brief-skill

### DIFF
--- a/src/skf-brief-skill/assets/scope-templates.md
+++ b/src/skf-brief-skill/assets/scope-templates.md
@@ -22,6 +22,12 @@ Present these options to the user for selection:
 - Auto-exclude demo/example/story files (with user confirmation)
 - Variant consolidation across design systems
 
+**[R] Reference App** — Whole-app pattern-reference skill. Use when the source is a working example app and the skill's value is **wiring patterns** (lifecycle, IPC, build-config, distribution) rather than a public library API.
+- Pattern surface as primary API slot (not individual exports)
+- Adoption Steps as primary workflow format (not API-call chains)
+- Tier 2 organized as `references/pattern-*.md` groupings (not per-function)
+- Export-count stats are pattern-surface proxies, not library exports
+
 ## Boundary Definitions by Scope Type
 
 ### Full Library Boundaries
@@ -64,6 +70,23 @@ Prompt: "Which of these would you like to include? (Enter numbers, or 'all'):"
 
 Exclusions will include all internal implementation files, tests, and utilities.
 Prompt: "Any additional items you'd like to include or exclude?"
+
+### Reference App Boundaries
+
+**Phase 1 — Pattern surface intent:**
+
+Ask: "What is the authored pattern surface for this skill? List the files (or directories) the user must touch to adopt the pattern — entry points, config files, lifecycle hooks, build scripts."
+
+- Record the user's list as `scope.tier_a_include` when narrower than a broad `scope.include`. Reference-app briefs benefit strongly from `tier_a_include` because the denominator is small and precise.
+- Prompt follow-up: "Any files outside that list that should still be in scope for completeness (tests, fixtures, supporting configs)?"
+
+**Phase 2 — Scope.include and exclusions:**
+
+Set `scope.include` to the pattern-surface file list (or broader union when the author flagged supporting files). Default exclusions mirror the Full Library defaults (tests, build artifacts, docs source). Record `scope.notes` with a one-sentence description of the pattern (e.g., "Embedded Python sidecar pattern for Electron apps — lifecycle orchestration, RPC proxy, build-copy wiring").
+
+**Phase 3 — Confirmation:**
+
+Summary showing: pattern surface count, `tier_a_include` vs `include` distinction, notes. Prompt: "Does this reference-app scope look right? Adjust before continuing."
 
 ### Docs-Only Boundaries
 

--- a/src/skf-brief-skill/assets/skill-brief-schema.md
+++ b/src/skf-brief-skill/assets/skill-brief-schema.md
@@ -56,7 +56,7 @@ The create-skill workflow (step-03-extract) also performs version reconciliation
 
 ```yaml
 scope:
-  type: full-library | specific-modules | public-api | component-library | docs-only
+  type: full-library | specific-modules | public-api | component-library | reference-app | docs-only
   include:
     - "src/**/*.ts"           # Glob patterns for included files/directories
   exclude:
@@ -133,7 +133,7 @@ forge_tier: "{Quick|Forge|Forge+|Deep}"
 created: "{date}"
 created_by: "{user_name}"
 scope:
-  type: "{full-library|specific-modules|public-api|component-library|docs-only}"
+  type: "{full-library|specific-modules|public-api|component-library|reference-app|docs-only}"
   include:
     - "{pattern}"
   exclude:
@@ -199,7 +199,7 @@ Created by: {created_by}
 1. `name` must be unique within {forge_data_folder}
 2. `source_repo` must be accessible (gh api for GitHub, path exists for local)
 3. `language` must be a recognized programming language
-4. `scope.type` must be one of the five defined types
+4. `scope.type` must be one of the six defined types
 5. `scope.include` must have at least one pattern (exception: `docs-only` scope, where include patterns are optional since no source code is available)
 6. `forge_tier` must be one of: Quick, Forge, Forge+, Deep (Title Case, must match the tier from forge-tier.yaml, or default to Quick)
 7. When `source_type: "docs-only"`: `doc_urls` must have >= 1 entry, `source_repo` becomes optional

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -71,7 +71,7 @@ Wait for confirmation. Record any changes to `doc_urls`.
 
 ### 2c. Offer Scope Templates
 
-Load `{scopeTemplatesFile}` for the scope type options ([F], [M], [P], [C]) and their descriptions.
+Load `{scopeTemplatesFile}` for the scope type options ([F], [M], [P], [C], [R]) and their descriptions.
 
 Present: "**How broadly should this skill cover the library?**" followed by the scope type options from the loaded reference.
 
@@ -81,7 +81,7 @@ Wait for user selection.
 
 ### 3. Define Boundaries Based on Selection
 
-Using the boundary definitions from `{scopeTemplatesFile}`, present the appropriate flow for the user's selected scope type ([F], [M], [P], or [C]). Follow each type's prompts and wait for user input at each phase before proceeding.
+Using the boundary definitions from `{scopeTemplatesFile}`, present the appropriate flow for the user's selected scope type ([F], [M], [P], [C], or [R]). Follow each type's prompts and wait for user input at each phase before proceeding.
 
 ### 4. Handle Language Override
 
@@ -97,7 +97,7 @@ Wait for confirmation or override.
 
 "**Scope Summary:**
 
-**Type:** {Full Library / Specific Modules / Public API / Component Library}
+**Type:** {Full Library / Specific Modules / Public API / Component Library / Reference App}
 
 **Include:**
 {bulleted list of include patterns}
@@ -116,7 +116,7 @@ Wait for confirmation. Make adjustments if requested.
 
 ### 5b. Scripts & Assets Intent (Optional)
 
-**Only ask when `scope.type` is `full-library`, `specific-modules`, or `component-library` (skip for `public-api` and `docs-only`).**
+**Only ask when `scope.type` is `full-library`, `specific-modules`, `component-library`, or `reference-app` (skip for `public-api` and `docs-only`). Reference apps routinely ship wiring scripts and build-config assets — prompt for them.**
 
 "Does this library include executable scripts (CLI tools, validation scripts, setup helpers) or static assets (config templates, JSON schemas, example configs) that should be packaged with the skill?"
 

--- a/src/skf-create-skill/assets/compile-assembly-rules.md
+++ b/src/skf-create-skill/assets/compile-assembly-rules.md
@@ -222,6 +222,55 @@ When `scope.type: "component-library"`, add these fields to `stats`:
 
 These are in addition to the standard stats fields (exports_documented, etc.).
 
+### Reference-App Assembly Overrides
+
+When `scope.type: "reference-app"` in the brief, apply these overrides to the standard assembly. The skill's value is an integration pattern (wiring), not a library surface — the default library-export template would force assemblers to remap wiring onto export slots and produce fuzzy counts. These overrides give that value a first-class home.
+
+**Section 4 (Key API Summary) — Pattern Surface override:**
+
+Replace the per-function table with an ordered list of wiring steps. Each step names a file, a surface (decorator, build field, lifecycle hook, config key), and a one-line description of what the user does there — not a function signature. The goal is that a reader copying the pattern can follow the list in order.
+
+```markdown
+## Pattern Surface
+
+| # | File | Surface | Purpose |
+|---|------|---------|---------|
+| 1 | {src/main.py} | {@app.startup decorator} | {brief wiring purpose} |
+| 2 | {electron.vite.config.ts} | {build.copy field} | {brief wiring purpose} |
+| … | … | … | … |
+```
+
+Source: the authored pattern surface from extraction + brief `scope.tier_a_include` (when present) or the curated provenance-map entries (when absent). Provenance: cite the originating source files.
+
+**Section 3 (Common Workflows) — Adoption Steps override:**
+
+Replace the function-call-chain format with copy-this-wiring narrative. Prefer numbered imperative steps that the user can execute in order, not an API-call sequence. Keep each step's code snippet minimal (5–15 lines) — full wiring lives in Tier 2.
+
+```markdown
+## Adoption Steps
+
+1. **{Step name}** — {one-line description}
+   ```{language}
+   {minimal wiring snippet}
+   ```
+2. **{Step name}** — {one-line description}
+   …
+```
+
+**Tier 2 (Full API Reference) — pattern-oriented override:**
+
+Replace per-function subsections with `references/pattern-*.md` groupings: one reference file per coherent wiring concern (e.g. `pattern-lifecycle.md`, `pattern-build-config.md`, `pattern-ipc.md`). Each reference file covers every file/surface touched by that concern with full code snippets, gotchas, and provenance. Tier 1 (Pattern Surface) stays index-like; Tier 2 carries the copy-paste-able depth.
+
+**metadata.json — Reference-App stats semantics:**
+
+`stats.exports_documented` is a **library concept** and does not carry over cleanly. When `scope.type: "reference-app"`:
+
+- `stats.exports_documented` MAY be set to the Pattern Surface row count as a proxy, but its semantics change: it counts authored pattern surfaces, not public exports. Emit an adjacent `stats.pattern_surfaces_documented` with the same integer so downstream consumers (test-skill, feasibility, discovery) can discriminate.
+- `exports_public_api` / `exports_internal` / `exports_total` are not meaningful for a reference app — omit them, or set all three to the Pattern Surface count with a note in `stats.notes`: `"reference-app: export counts are pattern-surface proxies, not library exports"`.
+- Do NOT fabricate signature / type-coverage data from pattern surfaces. skf-test-skill will skip those categories when metadata flags a reference-app (same skip path as `stackSkill` once that flag is wired — see scoring-rules.md).
+
+**When this clause does NOT apply:** `full-library`, `specific-modules`, `public-api`, `component-library`, or `docs-only`. Those scope types have their own assembly semantics and export-count conventions — do not mix.
+
 ### Assembly Rules
 
 1. Assemble all Tier 1 sections first — these form the essential standalone body

--- a/src/skf-create-skill/assets/skill-sections.md
+++ b/src/skf-create-skill/assets/skill-sections.md
@@ -343,6 +343,13 @@ When `file_type: "doc"`:
 ## evidence-report.md Structure
 
 ```markdown
+---
+skill_name: {skill-name}
+generated: {date}
+forge_tier: {tier}
+t2_future_count: {N}
+---
+
 # Evidence Report: {skill-name}
 
 **Generated:** {date}
@@ -382,5 +389,7 @@ When `file_type: "doc"`:
 ## Remaining Warnings
 - {any warnings from extraction or validation}
 ```
+
+**Frontmatter — pinned detection contract:** the `t2_future_count` field is the authoritative forward-looking-annotation count for downstream gate checks (e.g. skf-test-skill §2b migration-section rule). Emit **always**, even when 0 — omission is indistinguishable from "no T2-future data" and silently flips the gate into Case 2/3 for a Case-1 skill. `generated` and `forge_tier` mirror the narrative header for consumers that read only the frontmatter. Downstream gate rules MUST parse `t2_future_count` from frontmatter, not grep prose — prose drift (heading renames, alternate phrasings like "forward-looking annotations") silently breaks the detection.
 
 **Description Guard slot:** populated by step-06 §0 (create-skill) and §0 (update-skill) when the guard protocol fires. `Restored: true` indicates that an external tool (typically `skill-check --fix` or `split-body`) rewrote the frontmatter `description` and the guard restored the pre-tool value. When `Restored: false`, leave `Triggering tool`, `Original description preserved`, and `Notes` as `—`. When `Restored: true`, fill all four fields: tool name, whether the original was successfully written back, and a one-sentence note describing what the tool had changed (e.g., "replaced with generic summary", "truncated at 80 chars", "angle-bracket tokens re-introduced"). Downstream test-skill assertions can grep for `Restored: true` to detect unintended tool rewrites without parsing free-form warning prose.

--- a/src/skf-create-skill/steps-c/step-03-extract.md
+++ b/src/skf-create-skill/steps-c/step-03-extract.md
@@ -31,7 +31,7 @@ Load `{extractionPatternsData}` completely. Identify the strategy for the curren
 
 From the brief, apply scope and pattern filters:
 
-- `scope.type` — determines what to extract (e.g., `full-library`, `specific-modules`, `public-api`, `component-library`, `docs-only`)
+- `scope.type` — determines what to extract (e.g., `full-library`, `specific-modules`, `public-api`, `component-library`, `reference-app`, `docs-only`). Use `reference-app` when the source is a whole app and the skill's value is wiring patterns rather than public exports (embedded-sidecar reference apps, CLI-demo repos, integration-pattern demonstrators). `reference-app` triggers the compile-assembly overrides in `{compileAssemblyRules}` that replace "Key API Summary" with a "Pattern Surface" section and make `stats.exports_documented` semantics pattern-oriented. Do NOT pick `full-library` for reference apps — downstream assembly will remap wiring onto export slots, producing fuzzy counts and an awkward SKILL.md.
 - `scope.include` — file globs to include
 - `scope.exclude` — file globs to exclude
 

--- a/src/skf-create-skill/steps-c/step-03-extract.md
+++ b/src/skf-create-skill/steps-c/step-03-extract.md
@@ -5,6 +5,12 @@ extractionPatternsData: 'references/extraction-patterns.md'
 extractionPatternsTracingData: 'references/extraction-patterns-tracing.md'
 tierDegradationRulesData: 'references/tier-degradation-rules.md'
 sourceResolutionData: 'references/source-resolution-protocols.md'
+# Probe installed SKF module path first, src/ dev-checkout fallback. At first
+# use below, resolve `{atomicWriteHelper}` to the first existing path; HALT if
+# neither candidate exists — losing atomic-write guarantees is not an option.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 3: Extract
@@ -101,7 +107,7 @@ This protocol detects such files, prompts the user, and records the decision in 
            {forge_data_folder}/{skill_name}/skill-brief.yaml.bak
 
         # 2. Atomic write (stdin → tmp → fsync → rename)
-        cat <<'AMENDED_YAML' | python3 {project-root}/src/shared/scripts/skf-atomic-write.py write \
+        cat <<'AMENDED_YAML' | python3 {atomicWriteHelper} write \
             --target {forge_data_folder}/{skill_name}/skill-brief.yaml
         {amended brief YAML}
         AMENDED_YAML

--- a/src/skf-create-skill/steps-c/step-05-compile.md
+++ b/src/skf-create-skill/steps-c/step-05-compile.md
@@ -160,6 +160,8 @@ Each `file_entries[]` row has the same shape regardless of `file_type`: `{file_n
 
 Compilation audit trail: generation date, forge tier, source info, tool versions, extraction summary (files/exports/confidence), warnings. For validation-specific fields (Schema, Body, Security, Content Quality, tessl, Metadata), insert the placeholder text `[PENDING — populated by step-06]`. Step-06 will replace these placeholders with actual results. See `{skillSectionsData}` for full template. Use the same `{skf_version}` value resolved in section 4 when populating the Tool Versions block.
 
+**Frontmatter — pinned fields (MANDATORY):** emit YAML frontmatter at the top of `evidence-report.md` with at minimum `skill_name`, `generated`, `forge_tier`, and `t2_future_count`. Compute `t2_future_count` as the count of forward-looking (T2-future) temporal annotations in the enrichment data produced by step-04 (`qmd query` + temporal classification). **Emit `t2_future_count: 0` when no T2-future annotations exist** — omission is indistinguishable from "no data" for downstream consumers and would silently flip the skf-test-skill §2b/§5b migration-section gate into Case 2/3 for a Case-1 skill. This frontmatter is the authoritative detection contract — `migration-section-rules.md` Case Rules parse it deterministically rather than grepping prose.
+
 **Auto-Decisions section (headless buffer flush):** read the in-context `headless_decisions[]` list (populated by step-01 tier-override handling, step-02 ecosystem gate, and any future step that auto-resolves a gate under `{headless_mode}`). Emit an `## Auto-Decisions` section with one row per entry:
 
 ```

--- a/src/skf-create-skill/steps-c/step-06-validate.md
+++ b/src/skf-create-skill/steps-c/step-06-validate.md
@@ -1,6 +1,13 @@
 ---
 nextStepFile: './step-07-generate-artifacts.md'
 tesslDismissalData: 'assets/tessl-dismissal-rules.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves — losing atomic-write guarantees is not
+# an option for the staging-directory artifacts this step produces.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 6: Validate
@@ -51,7 +58,7 @@ To prevent this, any tool invocation that may touch SKILL.md must run inside the
 Run: `timeout 30s npx skill-check -h` — the short timeout protects against a cold `npx` download blocking the workflow indefinitely on a slow network.
 
 - If succeeds: Continue to automated validation (section 2)
-- If fails or times out: Perform manual fallback (section 3); add note to evidence-report: "Spec validation performed manually — skill-check tool unavailable". Also set `metadata.validation_status: 'manual-only'` in `metadata.json` (write via `python3 {project-root}/src/shared/scripts/skf-atomic-write.py write --target <staging-skill-dir>/metadata.json`), and in the evidence-report's `Validation Results` section mark Security, Body, and Content Quality (tessl) rows explicitly as `skipped — skill-check unavailable`. Downstream consumers (pipeline, forger, test-skill) check `validation_status` to decide how much weight to put on the artifact; leaving it unset would make a manual-only run look equivalent to a fully automated PASS.
+- If fails or times out: Perform manual fallback (section 3); add note to evidence-report: "Spec validation performed manually — skill-check tool unavailable". Also set `metadata.validation_status: 'manual-only'` in `metadata.json` (write via `python3 {atomicWriteHelper} write --target <staging-skill-dir>/metadata.json`), and in the evidence-report's `Validation Results` section mark Security, Body, and Content Quality (tessl) rows explicitly as `skipped — skill-check unavailable`. Downstream consumers (pipeline, forger, test-skill) check `validation_status` to decide how much weight to put on the artifact; leaving it unset would make a manual-only run look equivalent to a fully automated PASS.
 
 **Important:** Do not assume availability — empirical check required.
 

--- a/src/skf-create-skill/steps-c/step-07-generate-artifacts.md
+++ b/src/skf-create-skill/steps-c/step-07-generate-artifacts.md
@@ -1,6 +1,13 @@
 ---
 nextStepFile: './step-08-report.md'
 forgeTierConfig: '{sidecar_path}/forge-tier.yaml'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves — the active-symlink flip and registry
+# writes below MUST go through the atomic helper for concurrency safety.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 7: Generate Artifacts
@@ -87,7 +94,7 @@ Write these 3 files from the compiled content:
 Create or update the `active` symlink at `{skill_group}/active` pointing to `{version}` using the shared atomic-flip helper. The helper holds an `flock` on `{skill_group}/active.skf-lock`, refuses to replace a non-symlink at `{skill_group}/active` (protecting against accidental rm-rf of a real directory), and uses a rename-over-symlink pattern so the update is atomic from a concurrent reader's perspective:
 
 ```bash
-python3 {project-root}/src/shared/scripts/skf-atomic-write.py flip-link \
+python3 {atomicWriteHelper} flip-link \
   --link {skill_group}/active \
   --target {version}
 ```

--- a/src/skf-create-skill/steps-c/step-08-report.md
+++ b/src/skf-create-skill/steps-c/step-08-report.md
@@ -1,5 +1,11 @@
 ---
 nextStepFile: './step-09-health-check.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 8: Report
@@ -119,7 +125,7 @@ End workflow. No further steps.
 
 **Resolve the schema reference:** before writing, verify that `{project-root}/src/shared/references/output-contract-schema.md` exists and is readable. Try in order: `{project-root}/src/shared/references/output-contract-schema.md`, then `{project-root}/_bmad/skf/shared/references/output-contract-schema.md` (installed-forge path).
 
-- **If resolved:** write the result contract per the schema — the per-run record at `{forge_version}/create-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/create-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`. Use `python3 {project-root}/src/shared/scripts/skf-atomic-write.py write --target {forge_version}/create-skill-result-{YYYYMMDD-HHmmss}.json` (stdin-piped JSON) for the per-run record, then the same helper for the `-latest.json` copy.
+- **If resolved:** write the result contract per the schema — the per-run record at `{forge_version}/create-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/create-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include `SKILL.md`, `context-snippet.md`, and `metadata.json` paths in `outputs` and confidence distribution in `summary`. Use `python3 {atomicWriteHelper} write --target {forge_version}/create-skill-result-{YYYYMMDD-HHmmss}.json` (stdin-piped JSON) for the per-run record, then the same helper for the `-latest.json` copy.
 
 - **If neither candidate path resolves:** skip the result-contract write entirely. Append a warning to `evidence-report.md`: "Result contract skipped — `shared/references/output-contract-schema.md` could not be resolved at either candidate path." Then set `validation_status: 'schema-unavailable'` in `metadata.json` (and re-write metadata.json via `skf-atomic-write.py write`). Pipeline consumers will observe the missing `-latest.json` and the metadata flag.
 

--- a/src/skf-create-skill/steps-c/sub/step-03b-fetch-temporal.md
+++ b/src/skf-create-skill/steps-c/sub/step-03b-fetch-temporal.md
@@ -1,5 +1,11 @@
 ---
 nextStepFile: './step-03c-fetch-docs.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 3b: Fetch Temporal Context
@@ -171,7 +177,7 @@ fi
 1. Acquire an exclusive `flock` on `{sidecar_path}/forge-tier.yaml.lock` (create the lock file if absent). Use `flock -x {lockfile} -c "..."` or an equivalent `fcntl.flock(LOCK_EX)` guard.
 2. Read the current `forge-tier.yaml`, capturing its `st_mtime` as `mtime_before`.
 3. Perform the read-modify-write below.
-4. Write via `python3 {project-root}/src/shared/scripts/skf-atomic-write.py write --target {sidecar_path}/forge-tier.yaml`.
+4. Write via `python3 {atomicWriteHelper} write --target {sidecar_path}/forge-tier.yaml`.
 5. Release the flock.
 
 **Fallback when `flock` is unavailable:** re-stat the file after the write; if the on-disk `st_mtime` is newer than `mtime_before` by more than this run's own write timestamp, halt with "forge-tier.yaml modified mid-update by another process — refusing to clobber. Re-run after the other run completes." This read-CAS-by-mtime is the belt-and-braces safety net for environments without `flock`.

--- a/src/skf-create-skill/steps-c/sub/step-03c-fetch-docs.md
+++ b/src/skf-create-skill/steps-c/sub/step-03c-fetch-docs.md
@@ -1,5 +1,11 @@
 ---
 nextStepFile: '../step-04-enrich.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 3c: Fetch Remote Documentation
@@ -125,7 +131,7 @@ Parse the successfully fetched markdown for:
 1. Write fetched markdown files to a staging directory: `_bmad-output/{skill-name}-docs/`
 2. Index into QMD with atomic replace + rollback: if a `{skill-name}-docs` collection already exists, run `qmd collection remove {skill-name}-docs` first, then `qmd collection add {project-root}/_bmad-output/{skill-name}-docs/ --name {skill-name}-docs --mask "*.md"`. **If `qmd collection add` fails after a successful `remove`:** remove any matching `{skill-name}-docs` entry from `forge-tier.yaml` → `qmd_collections[]` to keep the registry consistent with QMD's actual state, warn in evidence-report, and skip the embed — docs enrichment degrades gracefully.
 3. Generate embeddings scoped to this collection (only if step 2 `add` succeeded): `qmd embed --collection {skill-name}-docs` (required for semantic `type:'vec'` and HyDE `type:'hyde'` sub-queries within the QMD `query` tool). If the installed `qmd` CLI does not accept `--collection`, gate the embed behind a freshness check: skip re-embedding if the existing `{skill-name}-docs` registry entry is within 24 hours, and log the skip in the evidence report to prevent unbounded batch-mode re-embedding.
-4. Register in forge-tier.yaml `qmd_collections` array — **acquire an exclusive `flock` on `{sidecar_path}/forge-tier.yaml.lock` for the read-modify-write** (see the locking pattern documented in step-03b §4). Write via `python3 {project-root}/src/shared/scripts/skf-atomic-write.py write --target {sidecar_path}/forge-tier.yaml`. If `flock` is unavailable, fall back to read-CAS-by-mtime (capture `st_mtime` before, re-check after; refuse to clobber if a concurrent run wrote in between).
+4. Register in forge-tier.yaml `qmd_collections` array — **acquire an exclusive `flock` on `{sidecar_path}/forge-tier.yaml.lock` for the read-modify-write** (see the locking pattern documented in step-03b §4). Write via `python3 {atomicWriteHelper} write --target {sidecar_path}/forge-tier.yaml`. If `flock` is unavailable, fall back to read-CAS-by-mtime (capture `st_mtime` before, re-check after; refuse to clobber if a concurrent run wrote in between).
 
 ```yaml
 - name: "{skill-name}-docs"

--- a/src/skf-create-stack-skill/steps-c/step-05-detect-integrations.md
+++ b/src/skf-create-stack-skill/steps-c/step-05-detect-integrations.md
@@ -26,9 +26,11 @@ From `confirmed_dependencies`, generate all unique pairs:
 - N libraries → N*(N-1)/2 pairs
 - Skip pairs where either library had extraction failure in step 04
 
-**Top-K cap (S7):** If `|confirmed_dependencies| > 50`, cap pair analysis at the top **50** libraries ranked by import count (code-mode) or export count (compose-mode). Pairs outside the top-50 are excluded from integration detection. Warn the user explicitly: `"dependency count {N} exceeds pair-analysis cap — analyzing top 50 by {metric}; {excluded_count} libraries skipped for integration detection"`. Record this cap in the evidence report.
+**File-list intersection fast path (MANDATORY first pass, all N):** before issuing any pair grep, compute each pair's candidate file set by **intersecting the per-library file lists recorded by step-03 import-count extraction**. Pairs with an empty intersection cannot be integration candidates by construction — drop them. Subsequent grep passes run only against pairs with a non-empty intersection, and grep scope is restricted to those intersection files rather than the whole source tree. This is NOT a "subprocess-unavailable" fallback; it is the default strategy for every N. Rationale: at N≈21 this collapses 210 prescribed pair greps to ~12 non-empty-intersection pairs in typical codebases; at larger N the compression is even greater.
 
-Report: "**Analyzing {pair_count} library pairs for integration patterns...**"
+**Top-K cap (S7, lowered to 20):** If the file-list-intersection prune still leaves more than **20** non-empty-intersection pairs, cap at the top 20 pairs ranked by intersection size (or by import count if tied). Dropped pairs are excluded from integration detection — warn the user explicitly: `"non-empty-intersection pair count {N} exceeds cap — analyzing top 20 by intersection size; {excluded_count} pairs skipped"`. Record this cap in the evidence report. The legacy 50-dependency threshold that formerly gated a separate Top-K pass is retired — the file-intersection prune does the bulk of the work and the cap is now a second-order safety limit, not a primary strategy.
+
+Report: "**Analyzing {pair_count} library pairs for integration patterns** (pruned from {N*(N-1)/2} via file-list intersection; {capped_count} after Top-K if applicable)**...**"
 
 ### 2. Detect Co-Import Files
 
@@ -77,7 +79,7 @@ For each library pair (A, B):
 
 **Subprocess returns:** `{pair: [A, B], co_import_files: [{path, line_A, line_B}], count: N}`
 
-**If subprocess unavailable:** Intersect the file lists from step 03 import counts for each pair.
+**Note on file-list intersection:** per §1, the intersection has already been computed and the pair's `intersection_files` set is known. The grep below runs against that set only, not the whole source tree. If a subprocess is entirely unavailable, the intersection itself is the integration evidence — count the intersection files against the 2-file threshold below without the grep. The intersection is mandatory first-pass work, not a fallback.
 
 **Threshold:** A pair must have 2+ co-import files to qualify as an integration pattern (single file co-imports may be incidental).
 

--- a/src/skf-create-stack-skill/steps-c/step-07-generate-output.md
+++ b/src/skf-create-stack-skill/steps-c/step-07-generate-output.md
@@ -1,6 +1,13 @@
 ---
 nextStepFile: './step-08-validate.md'
 stackSkillTemplate: 'assets/stack-skill-template.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves — stage/commit/flip-link/write below
+# MUST go through the atomic helper, per §1 rollback contract.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 7: Generate Output Files
@@ -46,7 +53,7 @@ Do NOT proceed to staging or commit.
 Create the staging directory:
 
 ```bash
-python3 {project-root}/src/shared/scripts/skf-atomic-write.py stage-dir --target {skill_package}
+python3 {atomicWriteHelper} stage-dir --target {skill_package}
 ```
 
 After this call, writes land in `{skill_package}.skf-tmp/` (referred to below as `{skill_staging}`). Create the required subdirectories inside the staging dir:
@@ -64,7 +71,7 @@ mkdir -p {forge_version}
 **Rollback contract:** If ANY write in sections 2–7 below fails, immediately run:
 
 ```bash
-python3 {project-root}/src/shared/scripts/skf-atomic-write.py commit-dir --rollback --target {skill_package}
+python3 {atomicWriteHelper} commit-dir --rollback --target {skill_package}
 ```
 
 Then abort with a structured error contract (see B7): purge any `{forge_version}/*-tmp` staging artifacts, emit `{"status":"error","skill":"skf-create-stack-skill","stage":"step-07","reason":"<message>"}` on stderr, and halt the workflow.
@@ -176,8 +183,8 @@ Populate all fields from the metadata.json schema defined in `{stackSkillTemplat
 Write workspace artifacts directly to `{forge_version}` (these are workspace-only, not part of the skill package — no staging required). Each individual file MUST be written via `skf-atomic-write.py write` to avoid partial-write corruption:
 
 ```bash
-<json-content> | python3 {project-root}/src/shared/scripts/skf-atomic-write.py write --target {forge_version}/provenance-map.json
-<md-content>   | python3 {project-root}/src/shared/scripts/skf-atomic-write.py write --target {forge_version}/evidence-report.md
+<json-content> | python3 {atomicWriteHelper} write --target {forge_version}/provenance-map.json
+<md-content>   | python3 {atomicWriteHelper} write --target {forge_version}/evidence-report.md
 ```
 
 If any workspace write fails, invoke the rollback contract from §1.
@@ -277,7 +284,7 @@ If any workspace write fails, invoke the rollback contract from §1.
 After all staged writes in sections 2–6 completed successfully, atomically swap the staging dir into place:
 
 ```bash
-python3 {project-root}/src/shared/scripts/skf-atomic-write.py commit-dir --target {skill_package}
+python3 {atomicWriteHelper} commit-dir --target {skill_package}
 ```
 
 The helper moves any existing `{skill_package}` aside to a `.skf-rollback-<pid>` dir before the swap. On failure the helper restores the prior target and exits non-zero — in that case invoke the rollback contract from §1 and HALT.
@@ -287,7 +294,7 @@ The helper moves any existing `{skill_package}` aside to a `.skf-rollback-<pid>`
 ONLY AFTER `commit-dir` succeeds, flip the `{skill_group}/active` symlink to point at `{version}`:
 
 ```bash
-python3 {project-root}/src/shared/scripts/skf-atomic-write.py flip-link --link {skill_group}/active --target {version}
+python3 {atomicWriteHelper} flip-link --link {skill_group}/active --target {version}
 ```
 
 The helper holds an flock on `{skill_group}/active.skf-lock` and refuses to replace a non-symlink at `{skill_group}/active` — this guards against accidentally overwriting a real directory (ECH BLOCKER 6/B6). After the flip, `{skill_group}/active/{project_name}-stack/` resolves to the just-committed skill package.

--- a/src/skf-create-stack-skill/steps-c/step-09-report.md
+++ b/src/skf-create-stack-skill/steps-c/step-09-report.md
@@ -1,5 +1,11 @@
 ---
 nextStepFile: './step-10-health-check.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in order
+# (installed SKF module path first, src/ dev-checkout fallback); first existing
+# path wins. HALT if neither resolves.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
 # Step 9: Stack Skill Report
@@ -95,7 +101,7 @@ Write the result contract per `shared/references/output-contract-schema.md` usin
 **Per-run record (inside the version dir):**
 
 ```bash
-<json-content> | python3 {project-root}/src/shared/scripts/skf-atomic-write.py write \
+<json-content> | python3 {atomicWriteHelper} write \
   --target {forge_version}/create-stack-skill-result-{YYYYMMDD-HHmmss}-{pid}-{rand}.json
 ```
 
@@ -105,7 +111,7 @@ Write the result contract per `shared/references/output-contract-schema.md` usin
 **Stable latest pointer (ABOVE the version dir, at the stack group root):**
 
 ```bash
-<json-content> | python3 {project-root}/src/shared/scripts/skf-atomic-write.py write \
+<json-content> | python3 {atomicWriteHelper} write \
   --target {forge_data_folder}/{project_name}-stack/create-stack-skill-result-latest.json
 ```
 

--- a/src/skf-test-skill/references/migration-section-rules.md
+++ b/src/skf-test-skill/references/migration-section-rules.md
@@ -42,8 +42,30 @@ authoring rule.
 ## Case Rules
 
 Check whether SKILL.md contains a "Migration & Deprecation Warnings" section
-(Section 4b). Then check the skill's `evidence-report.md` for T2-future
-annotation counts.
+(Section 4b). Then parse `evidence-report.md`'s **YAML frontmatter** for the
+pinned `t2_future_count` field — this is the authoritative count, not the
+narrative body.
+
+**Detection contract (MANDATORY).** Read the frontmatter deterministically:
+
+```bash
+# Extract t2_future_count from frontmatter. Requires a `---` delimiter pair.
+awk '/^---$/{c++;next} c==1 && /^t2_future_count:/{print $2; exit}' \
+    {forge_data_folder}/{skill_name}/evidence-report.md
+```
+
+- **Frontmatter missing OR `t2_future_count` absent** → treat as Case 4 (see
+  below) and skip silently. Do NOT fall back to grepping prose (`grep "T2-future"`) —
+  prose drift (heading renames, alt phrasings like "forward-looking
+  annotations", capitalization variance) silently breaks detection and can
+  invert Case-1 vs Case-2/3 severity.
+- **`t2_future_count` parsed** → use its integer value for the Case Rules
+  below.
+
+The pinned field is emitted by `skf-create-skill/steps-c/step-05-compile.md`
+§7 (frontmatter-pinned fields), which ALWAYS writes `t2_future_count: N`
+(including 0). Legacy skills whose `evidence-report.md` predates the pinned
+field land in Case 4.
 
 ### Case 1 — T2-future > 0 AND Section 4b absent
 

--- a/src/skf-test-skill/references/scoring-rules.md
+++ b/src/skf-test-skill/references/scoring-rules.md
@@ -56,6 +56,18 @@ This is functionally identical to Quick tier weight redistribution but with a di
 
 **S4 external-validator requirement for docs-only:** docs-only mode removes two categories (Signature Accuracy, Type Coverage) from scoring. If External Validation is ALSO unavailable, the evidence base collapses to Coverage alone (naive) or Coverage + Coherence (contextual) — which in the naive/Quick case trips the minimum-evidence floor (INCONCLUSIVE). To keep docs-only skills gradable when external validators are present but still deterministic when they are missing: **when `docsOnly: true` AND `externalValidation is null`, step-05 MUST cap `totalScore` at `threshold - 1` (forcing FAIL) before the INCONCLUSIVE floor is evaluated.** This prevents a docs-only skill from PASSing with only one or two redistributed categories carrying all the weight. Implement in step-05 §4 as a pre-compare cap, recorded in the report as `scoring_notes: docs-only without external validators — capped below threshold per S4`.
 
+### Stack Skills (Any Tier)
+
+When `metadata.json.skill_type == "stack"` (set `stackSkill: true` in the scoring input):
+
+- **Signature Accuracy:** N/A — a stack skill's "signature surface" is the external library API it composes (pydantic, SQLAlchemy, FastAPI, etc.), not a proprietary surface the skill authors. Grading signatures against a surface the skill does not own produces meaningless numbers.
+- **Type Coverage:** N/A — same rationale; the type surface belongs to the external libraries.
+- **Weight redistribution:** Same as Quick tier / docs-only / State 2 — Signature Accuracy (22%) and Type Coverage (14%) weights redistributed proportionally to remaining active categories (Export Coverage, Coherence, External Validation).
+- **Applies regardless of detected tier** (Quick, Forge, Forge+, Deep) and is independent of `docsOnly` and `state2`. A stack skill can also be docs-only or State 2; the skip reasons combine additively (e.g. `"stack skill (external type surface) + State 2 (provenance-map)"`).
+- **Detection:** step-05 reads `metadata.json.skill_type` from the skill package. If the value is `"stack"`, set `stackSkill: true` in the scoring input JSON.
+
+Equivalence-class note: stack skills with `docsOnly:false` / `state2:false` map to the same equivalence class as State 2 contextual rows (class B) or State 2 naive rows (class D) — the redistribution math is identical; only the `skipReasons` string changes.
+
 ### State 2 Source Access (Any Tier, Provenance-Map Only)
 
 When source is not locally available and analysis resolves to State 2 (provenance-map baseline per source-access-protocol.md):

--- a/src/skf-test-skill/references/source-access-protocol.md
+++ b/src/skf-test-skill/references/source-access-protocol.md
@@ -23,7 +23,22 @@
 
   Leave `analysis_confidence` unchanged (still `full` or `provenance-map` per the waterfall) — stratified scope does not degrade confidence, only the denominator. Annotate the coverage report with: `Stratified scope — denominator: {effective_denominator | tier_a_include union | scope.include union} ({N} files matched, {M} exports union)`.
 
-  **When this clause does NOT apply:** `scope.type: "full-library"` skills, single-package repositories, or stratified briefs where the full monorepo is intentionally in scope. For those, use the standard barrel-based denominator.
+  **When this clause does NOT apply:** `scope.type: "full-library"` skills, single-package repositories, or stratified briefs where the full monorepo is intentionally in scope. For those, use the standard barrel-based denominator — **unless** the single-package repo is a pattern-reference app (see next bullet).
+
+- **Pattern-reference apps (non-library source):** If the source is a single-package repo whose purpose is demonstrating an integration pattern rather than distributing a library API — typical markers are `scope.type: "full-library"` **without** a barrel file at any recognized entry-point path (`__init__.py`, `index.ts`/`index.js`, `lib.rs`, `mod.rs`) AND without a monorepo layout — the skill's value lives in wiring patterns, not exports. None of the preceding three clauses fits: there is no barrel to count from, no empty-barrel `scope.include` to consult, and no monorepo stratification to re-derive.
+
+  **Trigger (either fires):**
+
+  1. `scope.notes` in `forge-data/{skill_name}/skill-brief.yaml` flags pattern-reference intent (phrases such as "Reference app, not a library", "pattern-reference", "embedded-pattern skill", or "skill value is the … pattern"). The `scope.notes` field is authoritative when the author wrote it.
+  2. Source tree lacks a barrel file at every recognized entry-point path AND the repo is not a monorepo (no `packages/`, `workspaces`, `lerna.json`, `rush.json`, `nx.json`, or Cargo `[workspace]`). Detected at test time by filesystem inspection of `{source_path}`.
+
+  **Denominator:** canonicalized provenance-map entry count (same canonicalization as the "Provenance-map canonicalization" section below). `skf-create-skill`'s extraction pass has already curated the provenance-map to the authored pattern surface; treat it as the authoritative enumeration of the skill's documented reach.
+
+  **Recommendation — prefer `tier_a_include`:** authors should add `scope.tier_a_include` to the brief listing the files that constitute the authored pattern surface, the same way stratified-scope briefs do. When `tier_a_include` is present, use its re-derived union (filtered by `scope.exclude`) as the denominator exactly as in the stratified-scope clause. When absent, fall back to the canonicalized provenance-map count — do not fabricate a denominator from arbitrary source-tree sweeps.
+
+  **Confidence:** leave `analysis_confidence` unchanged (still `full` or `provenance-map` per the waterfall). Pattern-reference does not degrade confidence — the surface is smaller than a library barrel, not lower quality. Annotate the coverage report with: `Pattern-reference — denominator: {tier_a_include union | canonicalized provenance-map count} ({N} pattern surfaces)`.
+
+  **When this clause does NOT apply:** any repo with a non-empty barrel file, any monorepo (use the stratified-scope clause), or any single-package repo whose `scope.type` is explicitly `public-api` / `specific-modules` / `component-library` / `docs-only` (those scope types have their own denominator semantics). Also does NOT apply if `scope.type: "reference-app"` exists in the enum (pending upgrade in `skf-create-skill/steps-c/step-03-extract.md`) — in that case the brief speaks for itself and this clause's filesystem trigger is moot.
 
 Internal module symbols are **excluded** from the coverage denominator unless they are explicitly documented in SKILL.md (in which case they count as documented extras, not missing coverage).
 

--- a/src/skf-test-skill/scripts/compute-score.py
+++ b/src/skf-test-skill/scripts/compute-score.py
@@ -66,7 +66,7 @@ def make_error(message):
 # --- Validation ---
 
 
-BOOL_FIELDS = ("docsOnly", "state2")
+BOOL_FIELDS = ("docsOnly", "state2", "stackSkill")
 
 
 def validate_input(inp):
@@ -129,6 +129,7 @@ def compute_score(inp):
     tier = inp["tier"]
     docs_only = inp.get("docsOnly") is True
     state2 = inp.get("state2") is True
+    stack_skill = inp.get("stackSkill") is True
     threshold = inp.get("threshold") if inp.get("threshold") is not None else DEFAULT_THRESHOLD
     scores = inp["scores"]
 
@@ -137,7 +138,7 @@ def compute_score(inp):
 
     # 3. Determine skip set
     skip_reasons = {}
-    skip_sig_type = tier == "Quick" or docs_only or state2
+    skip_sig_type = tier == "Quick" or docs_only or state2 or stack_skill
 
     if skip_sig_type:
         reasons = []
@@ -147,6 +148,8 @@ def compute_score(inp):
             reasons.append("docs-only mode")
         if state2:
             reasons.append("State 2 (provenance-map)")
+        if stack_skill:
+            reasons.append("stack skill (external type surface)")
         reason = " + ".join(reasons)
         skip_reasons["signatureAccuracy"] = reason
         skip_reasons["typeCoverage"] = reason
@@ -257,6 +260,7 @@ def compute_score(inp):
             "tier": tier,
             "docsOnly": docs_only,
             "state2": state2,
+            "stackSkill": stack_skill,
             "threshold": threshold,
             "scores": scores_echo,
         },

--- a/src/skf-test-skill/steps-c/step-03-coverage-check.md
+++ b/src/skf-test-skill/steps-c/step-03-coverage-check.md
@@ -80,7 +80,7 @@ test-skill is a quality gate — it MUST NOT trust subagent output blindly. Befo
 **Schema validation (required keys + types):**
 
 1. Parse the subagent response as JSON. On parse failure → HALT "coverage-check: subagent response not valid JSON".
-2. Required keys present: `skill_name` (string), `exports` (list), `cross_check_mismatches` (list — may be empty). Missing key or wrong type → HALT "coverage-check: subagent JSON schema invalid — missing/typo: {key}".
+2. Required keys present: `exports` (list), `cross_check_mismatches` (list — may be empty). Missing key or wrong type → HALT "coverage-check: subagent JSON schema invalid — missing/typo: {key}". Note: the parent already knows the skill name from workflow context (`{resolved_skill_package}` from step-01) — the subagent is not required to echo it back, and doing so introduces a contract-drift surface without improving verification.
 3. Each `exports[]` entry must be a dict with at minimum `name` (non-empty string) and `kind` (one of `function|class|type|constant|hook|interface|method`). Reject entries violating this; if >0 rejections, HALT "coverage-check: subagent returned malformed export entries — {count} entries do not match schema".
 4. `cross_check_mismatches[]` entries (when non-empty) must carry `export`, `skill_md_line`, `reference_file`, `reference_line`, `issue`. Missing fields → HALT.
 

--- a/src/skf-test-skill/steps-c/step-04-coherence-check.md
+++ b/src/skf-test-skill/steps-c/step-04-coherence-check.md
@@ -33,11 +33,13 @@ Read `testMode` from `{outputFile}` frontmatter.
 
 Perform the following explicit checks (no hand-waving — each recipe is a shell recipe or a literal pattern). Severity assignments are binding; do not relax them.
 
-**2.1 Required sections present.** For each required top-level H2, run `grep -n "^## {section}" SKILL.md`:
-- `## Description` (or frontmatter `description` field — either satisfies)
-- `## Usage` or `## Examples`
-- `## Exports` or equivalent API surface heading
-- **Zero matches for any required section → High severity** finding: `naive-coherence — missing required section: {section}`
+**2.1 Required sections present.** For each required top-level H2, run `grep -n "^## {section}" SKILL.md`. A required section is satisfied if **any** synonym in its set matches:
+- Description: `## Description` OR frontmatter `description` field — either satisfies
+- Usage: `## Usage` OR `## Examples` OR `## Quick Start` OR `## Common Workflows`
+- API surface: `## Exports` OR `## Key API Summary` OR `## API`
+- **Zero matches across an entire synonym set → High severity** finding: `naive-coherence — missing required section: {section-set-name}`
+
+Note: SKF-template skills ship with `## Quick Start`, `## Common Workflows`, and `## Key API Summary`. These are first-class synonyms — do not downgrade to Low on literal-name miss; accept them.
 
 **2.2 Code fence balance.** Count triple-backtick fences with `grep -c '^```' SKILL.md`. **Odd count → High severity** finding: `naive-coherence — unbalanced code fence (unclosed block)`.
 

--- a/src/skf-test-skill/steps-c/step-04-coherence-check.md
+++ b/src/skf-test-skill/steps-c/step-04-coherence-check.md
@@ -70,7 +70,20 @@ for i, line in enumerate(open('SKILL.md'), 1):
 - Description says async + example shows no `await` → **High severity** finding: `naive-coherence — \`{name}\` described as async but example lacks \`await\``
 - Description says sync + example uses `await {name}` → **High severity** finding: `naive-coherence — \`{name}\` described as sync but example awaits it`
 
-**2.6 Table syntax.** `grep -nE '^\|.*\|$' SKILL.md | head` — for each table row, verify adjacent rows have the same pipe count (split on `|` and compare column count). **Column-count drift → Medium severity** finding: `naive-coherence — table row at line {N} has {X} columns; neighboring rows have {Y}`.
+**2.6 Table syntax.** `grep -nE '^\|.*\|$' SKILL.md | head` — for each table row, normalize escaped pipes (`\|`) before splitting, then verify adjacent rows have the same column count. **Escaped pipes appear inside TypeScript union types and discriminated payloads** (e.g. `string \| undefined`) and must not inflate the count.
+
+Recipe:
+
+```bash
+# Normalize `\|` to a placeholder, split on |, count, restore.
+grep -nE '^\|.*\|$' SKILL.md \
+  | sed 's/\\|/\x00/g' \
+  | awk -F'|' '{print NR, NF-2}'   # -2 drops the empty leading/trailing fields
+```
+
+Or equivalent: hand off to a proper markdown-table parser. A plain `split on |` WILL produce false "column drift" findings on any table whose cells contain union types.
+
+**Column-count drift → Medium severity** finding: `naive-coherence — table row at line {N} has {X} columns; neighboring rows have {Y}`.
 
 **2.7 Scripts & Assets section.** If `{skillDir}/scripts/` or `{skillDir}/assets/` exists, `grep -n '^## Scripts' SKILL.md`:
 - Directory exists AND no `## Scripts` section → **Medium severity** finding: `naive-coherence — scripts/assets directory exists but Scripts & Assets section missing` (per `{scoringRulesFile}`)

--- a/src/skf-test-skill/steps-c/step-04-coherence-check.md
+++ b/src/skf-test-skill/steps-c/step-04-coherence-check.md
@@ -43,7 +43,24 @@ Note: SKF-template skills ship with `## Quick Start`, `## Common Workflows`, and
 
 **2.2 Code fence balance.** Count triple-backtick fences with `grep -c '^```' SKILL.md`. **Odd count → High severity** finding: `naive-coherence — unbalanced code fence (unclosed block)`.
 
-**2.3 Language tags on fences.** `grep -n '^```$' SKILL.md` finds bare fences. **Each match → Medium severity** finding: `naive-coherence — code fence at line {N} missing language tag`.
+**2.3 Language tags on opening fences.** Only **opening** fences are required to carry a language tag; closing fences are bare by markdown convention and must NOT be flagged. Do not use a plain `grep -n '^```$' SKILL.md` — that flags every closing fence and produces one false positive per well-formed code block.
+
+Use a stateful open/close scan (toggle `in_code` on each `^```` line; flag only the line where `in_code` transitions 0→1 with no trailing language tag):
+
+```python
+in_code = False
+for i, line in enumerate(open('SKILL.md'), 1):
+    s = line.rstrip('\n')
+    if s.startswith('```'):
+        if not in_code:
+            if s == '```':
+                print(f'{i}: bare opening fence')
+            in_code = True
+        else:
+            in_code = False
+```
+
+**Each flagged opening fence → Medium severity** finding: `naive-coherence — opening code fence at line {N} missing language tag`.
 
 **2.4 Exports cross-used in Usage section.** For each function name reported in the step-03 subagent inventory (`exports[].name` where `kind == "function"` or `kind == "method"`):
 - `grep -c "{export.name}" SKILL.md` restricted to the Usage section (find the `## Usage` anchor from §2.1 and the next `^## ` anchor; count within that span).

--- a/src/skf-test-skill/steps-c/step-04b-external-validators.md
+++ b/src/skf-test-skill/steps-c/step-04b-external-validators.md
@@ -97,16 +97,20 @@ prevent a cold-cache fetch from stalling the workflow. If the probe exits
 non-zero OR the 15s timeout trips (exit code `124`), record
 `tessl_score: N/A` and skip to section 4.
 
-**Run review (S2 — 120s timeout; S3 — pinned version):**
+**Run review (S2 — 120s timeout):**
+
+The §2 probe (`npx --no-install -y tessl --version`) already resolved tessl via the caller's npm cache or a locally-installed binary on `$PATH`. Invoke the same binary for the review — do not re-pin to a registry-published version.
 
 ```bash
-# S3: pin tessl to a known-working version. Bump TESSL_PIN here (and only
-# here) when upgrading. Treat regex parse failure below as `tessl_score: N/A`.
-TESSL_PIN="@anthropic/tessl@0.4"
-timeout 120s npx -y "$TESSL_PIN" skill review {skillDir}
+# Use the tessl binary the §2 probe just verified. `--no-install` keeps
+# the review execution path identical to the probe; no fresh registry
+# fetch needed.
+timeout 120s npx --no-install -y tessl skill review {skillDir}
 ```
 
 Timeout handling mirrors skill-check: exit `124` → `tessl_score: N/A` with reason `timeout-120s`. If the percentage regex (`/(Description|Content|Review Score):\s*(\d+)%/`) returns fewer than three matches, record `tessl_score: N/A` with reason `parse-failure` and include the first 200 chars of output in evidence-report for debugging.
+
+**Registry-404 branch:** if the invocation emits `npm error 404 Not Found` or the npx wrapper exits with a not-found condition, record `tessl_score: N/A` with reason `pin-not-on-registry` and continue. This branch exists because tessl has historically shipped under shifting scope/tag combinations; do not HALT the workflow on a missing registry entry.
 
 **Parse the output** to extract:
 - `description_score` — percentage (e.g., 100%)

--- a/src/skf-test-skill/steps-c/step-05-score.md
+++ b/src/skf-test-skill/steps-c/step-05-score.md
@@ -73,6 +73,7 @@ Build a JSON object from the data gathered in steps 1-2:
   "tier": "{forge_tier: Quick, Forge, Forge+, or Deep}",
   "docsOnly": "{true if docs_only_mode detected in step 03, else false}",
   "state2": "{true if analysis_confidence is provenance-map, else false}",
+  "stackSkill": "{true if metadata.json.skill_type == 'stack', else false}",
   "scores": {
     "exportCoverage": "{export_coverage_percentage}",
     "signatureAccuracy": "{signature_accuracy_percentage or null if N/A}",
@@ -84,7 +85,7 @@ Build a JSON object from the data gathered in steps 1-2:
 }
 ```
 
-**Important:** Score values must be numbers (not strings). Use `null` (not `"N/A"`) for categories that were not scored.
+**Important:** Score values must be numbers (not strings). Use `null` (not `"N/A"`) for categories that were not scored. Read `metadata.json.skill_type` from `{resolved_skill_package}/metadata.json`; if the value is `"stack"`, set `stackSkill: true` and pass `null` for `signatureAccuracy` and `typeCoverage` (the categories will be redistributed per `{scoringRulesFile}` Stack Skills rule).
 
 #### 3b. Run the Scoring Script
 
@@ -113,7 +114,7 @@ Use these values for Section 4 (pass/fail/inconclusive) and Section 6 (output fo
 If the script is unavailable or returns an error, fall back to manual calculation:
 
 1. Select the weight table from `{scoringRulesFile}` for the detected mode (naive or contextual)
-2. Determine skip conditions: Quick tier/docsOnly/state2 skip Signature Accuracy + Type Coverage; naive mode coherence is already 0; null external validation means skip it
+2. Determine skip conditions: Quick tier/docsOnly/state2/stackSkill skip Signature Accuracy + Type Coverage; naive mode coherence is already 0; null external validation means skip it
 3. For each skipped category, set its weight to 0
 4. Compute sum of active category weights
 5. For each active category: `new_weight = old_weight / sum_active * 100`

--- a/src/skf-test-skill/steps-c/step-06-report.md
+++ b/src/skf-test-skill/steps-c/step-06-report.md
@@ -86,6 +86,15 @@ If no gaps found, append a clean pass message recommending **export-skill** work
 
 After gap enumeration, perform minimum-viable discovery testing. This is a **Medium-weight** check contributing to the Discovery Quality subsection — no longer advisory boilerplate.
 
+**4b.0 Precondition — catalog size check:**
+
+Count the skills in `{skillsOutputFolder}`: `ls -1d {skillsOutputFolder}/*/ 2>/dev/null | wc -l` (directories only — each skill package lives at `{skillsOutputFolder}/<skill-name>/`).
+
+- If `catalog_size < 2`: **skip §4b.1–§4b.3**. Record an Info-severity note in the Discovery Quality subsection: `discovery — skipped: catalog size N={catalog_size}, requires ≥2 candidates for meaningful routing`. The routing test is vacuous with one candidate (any prompt returns the sole skill); reporting `3/3 PASS` under those conditions inflates the Discovery score and masks genuinely bad description triggers. Proceed to §4b.4 (description optimization) if tessl/skill-check flagged description issues; otherwise skip to §4c.
+- If `catalog_size >= 2`: continue with §4b.1 as written.
+
+Optional escape hatch: the workflow accepts `--discovery-catalog=all` to broaden the candidate pool to `.claude/skills/` or `_bmad/agents/` for single-skill repos where the repo-local catalog is trivially too small. When the flag is set, rebuild `catalog_size` from the broader pool before the precondition check.
+
 **4b.1 Extract realistic prompts from the skill under test:**
 
 Parse SKILL.md for the three most "organic" prompts found in its `description`, `Triggers`, or example sections. Prefer prompts that:

--- a/test/fixtures/compute-score-contract.json
+++ b/test/fixtures/compute-score-contract.json
@@ -18,6 +18,7 @@
         "tier": "Deep",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 92,
@@ -75,6 +76,7 @@
         "tier": "Forge",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 90,
@@ -133,6 +135,7 @@
         "tier": "Quick",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 85,
@@ -194,6 +197,7 @@
         "tier": "Deep",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 80,
@@ -254,6 +258,7 @@
         "tier": "Quick",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 95,
@@ -320,6 +325,7 @@
         "tier": "Quick",
         "docsOnly": true,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 88,
@@ -382,6 +388,7 @@
         "tier": "Deep",
         "docsOnly": false,
         "state2": true,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 90,
@@ -444,6 +451,7 @@
         "tier": "Deep",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 90,
         "scores": {
           "exportCoverage": 92,
@@ -502,6 +510,7 @@
         "tier": "Forge",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 84,
         "scores": {
           "exportCoverage": 90,
@@ -561,6 +570,7 @@
         "tier": "Forge",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 84.01,
         "scores": {
           "exportCoverage": 90,
@@ -619,6 +629,7 @@
         "tier": "Forge+",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 92,
@@ -744,6 +755,7 @@
         "tier": "Quick",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 85,
@@ -811,6 +823,7 @@
         "tier": "Quick",
         "docsOnly": true,
         "state2": false,
+        "stackSkill": false,
         "threshold": 75,
         "scores": {
           "exportCoverage": 80,
@@ -876,6 +889,7 @@
         "tier": "Forge",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 90,
@@ -933,6 +947,7 @@
         "tier": "Deep",
         "docsOnly": false,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 95,
@@ -992,6 +1007,7 @@
         "tier": "Deep",
         "docsOnly": true,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 90,
@@ -1054,6 +1070,7 @@
         "tier": "Deep",
         "docsOnly": true,
         "state2": false,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 88,
@@ -1116,6 +1133,7 @@
         "tier": "Deep",
         "docsOnly": false,
         "state2": true,
+        "stackSkill": false,
         "threshold": 80,
         "scores": {
           "exportCoverage": 86,
@@ -1156,6 +1174,69 @@
       "threshold": 80,
       "result": "PASS",
       "weightSum": 100.0
+    }
+  },
+  {
+    "name": "suite_u_stack_skill_deep",
+    "input": {
+      "mode": "contextual",
+      "tier": "Deep",
+      "stackSkill": true,
+      "scores": {
+        "exportCoverage": 90,
+        "signatureAccuracy": null,
+        "typeCoverage": null,
+        "coherence": 85,
+        "externalValidation": 80
+      }
+    },
+    "expected_output": {
+      "input": {
+        "mode": "contextual",
+        "tier": "Deep",
+        "docsOnly": false,
+        "state2": false,
+        "stackSkill": true,
+        "threshold": 80,
+        "scores": {
+          "exportCoverage": 90,
+          "signatureAccuracy": null,
+          "typeCoverage": null,
+          "coherence": 85,
+          "externalValidation": 80
+        }
+      },
+      "activeCategories": [
+        "exportCoverage",
+        "coherence",
+        "externalValidation"
+      ],
+      "skippedCategories": [
+        "signatureAccuracy",
+        "typeCoverage"
+      ],
+      "skipReasons": {
+        "signatureAccuracy": "stack skill (external type surface)",
+        "typeCoverage": "stack skill (external type surface)"
+      },
+      "weights": {
+        "exportCoverage": 56.25,
+        "signatureAccuracy": 0,
+        "typeCoverage": 0,
+        "coherence": 28.13,
+        "externalValidation": 15.63
+      },
+      "weightedScores": {
+        "exportCoverage": 50.63,
+        "signatureAccuracy": 0,
+        "typeCoverage": 0,
+        "coherence": 23.91,
+        "externalValidation": 12.5
+      },
+      "totalScore": 87.04,
+      "threshold": 80,
+      "result": "PASS",
+      "weightSum": 100.01
     }
   }
 ]


### PR DESCRIPTION
## Summary

Fixes 14 open health-check issues across four SKF workflows. 12 commits are organized one per distinct fix (two commits close two issues each — dup/shared-fix cases noted below); one follow-up commit (`a321562`) extends the `scope.type: "reference-app"` work end-to-end through the brief-authoring path after a review caught that the schema rejected the new enum value.

Branches up to date: `dev` was fast-forwarded to `main` at the start of the branch, so this PR contains only these 13 commits.

### Commits → Issues

| Commit | Closes | Description |
|---|---|---|
| `4e1a759` | #183 | test-skill: accept SKF-template section names (`Quick Start`, `Common Workflows`, `Key API Summary`) in §2.1 |
| `755f2cb` | #180, #184 | test-skill: stateful open/close scan so §2.3 stops flagging closing fences (~95% false-positive rate before) |
| `a03ddef` | #185 | test-skill: normalize `\|` before splitting on `|` in §2.6 so union-type cells don't inflate column counts |
| `32f8273` | #181 | test-skill: drop `skill_name` from coverage §1a required keys (contradicted §1 example; HALTed every run) |
| `d8d4055` | #175 | test-skill: unpin tessl (npm 404 on `@anthropic/tessl@0.4`), use `$PATH` binary, add registry-404 branch |
| `c1099d6` | #176 | test-skill: add `stackSkill` skip flag for Deep-tier stack skills (+ new `suite_u_stack_skill_deep` fixture; 24/24 contract tests green) |
| `5e160e5` | #177 | test-skill: skip §4b discovery test when catalog <2 skills (was reporting 3/3 PASS trivially) |
| `ef10c94` | #182 | skf: pin T2-future detection via `evidence-report.md` YAML frontmatter (create-skill emits `t2_future_count`; test-skill parses pinned field instead of grepping prose) |
| `c3e03e7` | #186 | test-skill: add fourth case to `source-access-protocol` for pattern-reference apps (no barrel, not a monorepo) |
| `722844a` | #179 | create-skill: add `scope.type: "reference-app"` to enum + compile-assembly overrides (Pattern Surface, Adoption Steps, `references/pattern-*.md`) |
| `299d369` | #178, #173 | skf: resolve `skf-atomic-write.py` across installed `_bmad/skf/…` and src/ dev-checkout layouts via `{atomicWriteHelper}` + `{atomicWriteProbeOrder}` frontmatter (shared fix covers both workflows) |
| `dbc4107` | #174 | create-stack-skill: make file-list intersection the MANDATORY first pass at all N; lower Top-K cap to 20 non-empty-intersection pairs |
| `a321562` | extends #179 | brief-skill: extend `reference-app` through authoring path (schema enum, scope-templates `[R]` option, step-03 prompts). Review-pass find — without this, brief schema would reject `reference-app`. |

## Verification

- `npm test` (schemas, install, cli, workflow, python, knowledge, validate:schemas/skills/refs, lint, lint:md, format:check) — all green
- Agent schema: 52/52
- `compute-score` contract: 24/24 (23 existing fixtures gain `stackSkill: false` echo — no behavioral change; 1 new fixture pins the new skip path)
- `validate:skills`: 15 skills scanned, 0 findings
- `validate:refs`: 180 files, 269 refs, 0 broken, 0 absolute-path leaks
- `lint:md`: 194 files, 0 errors

## Known follow-ups (not regressions; flagged during review)

Same class of bug exists in workflows not cited by these issues — kept out of this PR to stay scoped to what was reported:

1. `skf-quick-skill/steps-c/step-06-write.md` and all 7 `skf-verify-stack/steps-c/*.md` still hardcode `{project-root}/src/shared/scripts/skf-atomic-write.py` — same bug as #178/#173 in workflows those issues didn't cite.
2. `skf-create-stack-skill/steps-c/step-07-generate-output.md` and `skf-update-skill`'s evidence-report writer do not yet emit `t2_future_count` frontmatter — #182 cited only `skf-create-skill`, but the gate fires on any Deep-tier evidence-report.
3. Redistribution Combinations Matrix in `scoring-rules.md` was not extended with explicit `stackSkill`-true rows — the added equivalence-class note documents that stackSkill folds into classes B (contextual) / D (naive) algebraically, and a new fixture pins the contextual-Deep case.

## Test plan

- [x] `npm test` passes locally
- [x] Diff over `dev...main` matches the commit table above (13 commits, 25 files, +361/−45)
- [x] Each `Fixes #NNN` trailer closes the right issue on merge
- [x] Spot-check one workflow end-to-end (e.g., `skf-test-skill` on an SKF-template skill) to confirm §2.1/§2.3/§2.6 no longer emit false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)