### PR TITLE
fix(export-skill): close two health-check findings (#190, #191)

### DIFF
--- a/src/skf-export-skill/SKILL.md
+++ b/src/skf-export-skill/SKILL.md
@@ -39,9 +39,10 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | skill_name [required], --all [optional] |
-| **Gates** | step-01: Confirm Gate [C] | step-04: Confirm Gate [C] |
-| **Outputs** | Updated .export-manifest.json, updated context files (CLAUDE.md/AGENTS.md/.cursorrules) |
+| **Inputs** | skill_name [one or more, required unless `--all`], `--all` [optional — exports every non-deprecated skill in `.export-manifest.json`] |
+| **Gates** | step-01: single Confirm Gate [C] for the whole batch | step-04: single Confirm Gate [C] for the whole batch |
+| **Outputs** | Updated .export-manifest.json (every skill in the batch), updated context files (CLAUDE.md/AGENTS.md/.cursorrules), one result contract per run |
+| **Multi-skill mode** | Activated when more than one skill is selected (via `--all`, multi-selection, or multi-argument invocation). See `steps-c/step-01-load-skill.md` §1c for the per-step iteration map. |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
 
 ## On Activation

--- a/src/skf-export-skill/steps-c/step-01-load-skill.md
+++ b/src/skf-export-skill/steps-c/step-01-load-skill.md
@@ -58,6 +58,38 @@ For each IDE in `config.yaml.ides`:
 **Context file(s):** {context-file-list} (skill root: {skill-root-list})
 **Dry Run:** {yes/no}"
 
+### 1b. Detect Snippet Root Prefix Mismatch
+
+**Skip entirely if `snippet_skill_root_override` is already set in `config.yaml`** — the authoring-repo escape hatch is already configured and any on-disk prefix that matches it is ground truth (see `assets/managed-section-format.md` override rules).
+
+Otherwise, probe existing snippets to catch the authoring-repo case (skills live under a single shared directory like `skills/` that does not match any per-IDE `skill_root`) before step-04 silently rewrites their root paths:
+
+1. Collect candidate snippet paths:
+   - Read `{skills_output_folder}/.export-manifest.json` if it exists. For each skill in `exports` with a resolvable `active_version`, add `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/context-snippet.md`
+   - Also include the current skill's snippet if present (resolved via manifest / `active` symlink / flat path per `knowledge/version-paths.md`)
+2. For each snippet that exists on disk, read the first line and parse the `root:` value. Strip the trailing `{skill-name}/` to extract the prefix (e.g. `skills/`, `.claude/skills/`)
+3. Collect unique prefixes into `observed_prefixes`
+4. Compare against `target_context_files[0].skill_root` (the first entry's IDE-mapped skill root — used as reference since step-03 §2.7 picks this same entry for snippet generation when no override is set)
+
+**If `observed_prefixes` contains any value that does not match the reference `skill_root`:**
+
+Emit a single warning (once, not per snippet) and present resolution options before proceeding:
+
+"**Snippet root prefix mismatch detected.**
+Existing snippets use: `{observed_prefixes}`
+IDE-mapped skill_root:  `{target_context_files[0].skill_root}`
+
+This usually means you are in an authoring repo where skills live under a single shared directory. Options:
+- **(a) Set override** — add `snippet_skill_root_override: {observed_prefix}` to `config.yaml`. Snippets keep their on-disk prefix; the managed section references the real location.
+- **(b) Proceed with IDE mapping** — step-04 will rewrite every snippet's root path to the IDE's skill_root. Use this only if the IDE's skill directory actually contains the skill files.
+- **(c) Cancel** — abort export and investigate.
+
+If multiple distinct prefixes were observed, the snippets disagree with each other — investigate before choosing (a)."
+
+In `{headless_mode}`, default to (b) and log the observed prefix(es) so the mismatch is visible in run logs. In interactive mode, wait for user choice before continuing to section 2.
+
+**If all observed prefixes match the reference `skill_root` (or no existing snippets were found):** Proceed silently.
+
 ### 2. Load and Validate Skill Artifacts
 
 Resolve the skill's versioned path before loading artifacts:

--- a/src/skf-export-skill/steps-c/step-01-load-skill.md
+++ b/src/skf-export-skill/steps-c/step-01-load-skill.md
@@ -21,18 +21,22 @@ To load the target skill's artifacts, validate they meet agentskills.io spec com
 
 "**Starting skill export...**"
 
-Determine the skill to export and any flags:
+Determine the skill(s) to export and any flags:
 
 **Skill Path Discovery (version-aware — see `knowledge/version-paths.md`):**
-- If user provided a skill name or path as argument, use that
-- If not provided, discover available skills using the export manifest:
+- If user provided one or more skill names or paths as arguments, use that list directly
+- If `--all` was passed, build the list from every skill in `{skills_output_folder}/.export-manifest.json.exports` whose `active_version` entry is not `status: "deprecated"` (deprecated skills are excluded from all exports — see step-04 §4b)
+- If no explicit skill and no `--all`, discover available skills using the export manifest:
   1. Read `{skills_output_folder}/.export-manifest.json` — list skill names from `exports`
   2. For each skill group directory in `{skills_output_folder}/`, check for `{skill_group}/active/{skill-name}/SKILL.md`
   3. If neither manifest nor `active` symlink yields results, fall back to flat path: `{skills_output_folder}/{skill-name}/SKILL.md`
-- If multiple skills found, present list and ask user to select
+- If multiple skills are found, present the list and accept either a single selection or a comma-/space-separated multi-selection (e.g. `1, 2, 3` or `all`)
 - If no skills found, halt: "No skills found in {skills_output_folder}/. Run create-skill first."
 
+Store the resolved selection as `skill_batch` — a list of one or more skill names. `len(skill_batch) > 1` activates multi-skill mode (see §1c below).
+
 **Flag Parsing:**
+- `--all` flag: Check if provided. When true and no explicit skill list was given, `skill_batch` is the full non-deprecated manifest set (see above).
 - `--context-file` flag: Check if explicitly provided (CLAUDE.md, .cursorrules, or AGENTS.md). Replaces the old `--platform` flag.
 - `--dry-run` flag: Check if provided. Default: `false`
 
@@ -54,7 +58,7 @@ For each IDE in `config.yaml.ides`:
 - If mapping produces one or more context files (after dedup), store as `target_context_files` list — each entry has `{context_file, skill_root}`
 - If mapping produces zero entries (empty ides list and no recognized entries), fall back to `[{context_file: "AGENTS.md", skill_root: ".agents/skills/"}]` with note: "No IDEs configured in config.yaml — defaulting to AGENTS.md with `.agents/skills/`."
 
-"**Skill:** {skill-name}
+"**Skill(s):** {skill-batch-list} ({N} total)
 **Context file(s):** {context-file-list} (skill root: {skill-root-list})
 **Dry Run:** {yes/no}"
 
@@ -89,6 +93,25 @@ If multiple distinct prefixes were observed, the snippets disagree with each oth
 In `{headless_mode}`, default to (b) and log the observed prefix(es) so the mismatch is visible in run logs. In interactive mode, wait for user choice before continuing to section 2.
 
 **If all observed prefixes match the reference `skill_root` (or no existing snippets were found):** Proceed silently.
+
+### 1c. Multi-skill Mode (when `len(skill_batch) > 1`)
+
+When multiple skills are being exported in a single run (via `--all`, multi-selection at the discovery menu, or an explicit multi-argument invocation), the workflow does NOT loop the full step-01→step-07 sequence once per skill. Instead, it partitions work across steps to avoid repeated gates and redundant batch work:
+
+| Step | Behavior in multi-skill mode |
+|------|------------------------------|
+| step-01 §2–5 | **Iterate per skill** — load, validate, read metadata, and check the test report for every skill in `skill_batch`. Collect per-skill results. |
+| step-01 §6 | **Single gate** — present one consolidated summary table (one row per skill) and a single [C] gate for the whole batch. |
+| step-02 | **Iterate per skill** — validate each skill's package structure and collect per-skill readiness. |
+| step-03 | **Iterate per skill** — regenerate each skill's `context-snippet.md` independently (each skill has its own prior-gotchas carry-forward state). |
+| step-04 | **Batch once** — §3b orphan detection, §4 skill-index rebuild, §5 managed-section assembly, and §6–9 diff + write all execute once for the entire batch. The exported skill set in §4b already enumerates every skill in the manifest — it does not need per-skill iteration. §9b adds/updates a manifest entry per skill in `skill_batch` (not just the last one), then writes the manifest once. |
+| step-05 | **Iterate per skill** — compute token counts per skill, then present one aggregate report. |
+| step-06 | **One batch summary + one result contract** — the files-written table lists every skill; the result contract JSON covers the whole run, and `outputs` enumerates every context-snippet + target context file touched. |
+| step-07 | **Runs once** — health check is per-workflow-run, not per-skill. |
+
+**Halt semantics in batch mode:** if any single skill fails validation in §2 (required-file or metadata-field failure), halt the entire batch before §5 — do not partially export. Report which skill failed and why.
+
+**Single-skill mode (`len(skill_batch) == 1`)** preserves the legacy behavior: every section below operates on the one skill without iteration.
 
 ### 2. Load and Validate Skill Artifacts
 
@@ -156,6 +179,8 @@ Continue to step 5 regardless — this is advisory, not blocking.
 
 ### 5. Present Skill Summary
 
+**Single-skill mode:**
+
 "**Skill loaded and validated.**
 
 | Field | Value |
@@ -181,9 +206,29 @@ Continue to step 5 regardless — this is advisory, not blocking.
 
 **Is this the correct skill to export?**"
 
+**Multi-skill mode** (`len(skill_batch) > 1`):
+
+"**{N} skills loaded and validated.**
+
+| # | Name | Type | Authority | Tier | Exports | Test |
+|---|------|------|-----------|------|---------|------|
+| 1 | {name-1} | {type} | {authority} | {tier} | {count} | {pass/fail/none} |
+| 2 | {name-2} | ... | ... | ... | ... | ... |
+| N | {name-N} | ... | ... | ... | ... | ... |
+
+**Export Configuration (applies to all):**
+| Setting | Value |
+|---------|-------|
+| **Context File(s)** | {context-file-list} (skill root: {skill-root-list}) |
+| **Explicit --context-file** | {yes / no (from config.yaml)} |
+| **Dry Run** | {yes/no} |
+| **Passive Context** | {enabled/disabled} |
+
+**Are these the correct skills to export?**"
+
 ### 6. Present MENU OPTIONS
 
-Display: "**Select:** [C] Continue to packaging"
+Display: "**Select:** [C] Continue to packaging" (multi-skill mode: the single [C] gate covers the whole batch)
 
 #### Menu Handling Logic:
 

--- a/src/skf-export-skill/steps-c/step-02-package.md
+++ b/src/skf-export-skill/steps-c/step-02-package.md
@@ -12,6 +12,7 @@ To assemble and validate an agentskills.io-compliant package structure from the 
 
 - Focus only on package structure assembly and validation — do not modify SKILL.md content
 - Auto-proceed when complete
+- **Multi-skill mode:** when step-01 loaded more than one skill (`len(skill_batch) > 1`), iterate sections 1–4 below per skill using each skill's `{resolved_skill_package}`. Collect per-skill status; report the aggregate in §4 as one row per skill. Halt the batch if any skill is NOT READY. See step-01 §1c.
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-export-skill/steps-c/step-03-generate-snippet.md
+++ b/src/skf-export-skill/steps-c/step-03-generate-snippet.md
@@ -13,6 +13,7 @@ To generate or update context-snippet.md for the skill in the Vercel-aligned ind
 
 - Focus only on generating the context-snippet.md content — T1-now only, no T2 annotations
 - If `passive_context: false` was detected in step-01, skip this step entirely
+- **Multi-skill mode:** when step-01 loaded more than one skill (`len(skill_batch) > 1`), iterate sections 2–5 per skill. Each skill has its own prior-gotchas carry-forward state (§2.5) — do not share state across skills. §2.7 resolves `{skill_root}` once for the run (it depends on `target_context_files`, not the skill). See step-01 §1c.
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-export-skill/steps-c/step-04-update-context.md
+++ b/src/skf-export-skill/steps-c/step-04-update-context.md
@@ -15,6 +15,7 @@ To update the managed `<!-- SKF:BEGIN/END -->` section in the platform-appropria
 - Do not modify any content outside `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` markers
 - Do not write without user confirmation — this modifies shared project files
 - If `passive_context: false` was detected in step-01, skip this step entirely
+- **Multi-skill mode:** this step executes ONCE for the whole batch, not once per skill. §4b already builds the exported skill set from the manifest (plus current export targets), so a multi-skill run naturally appears as a single rebuild. The only batch adjustment is in §9b: update the manifest entry for every skill in `skill_batch` (not just one), and include all of them when computing `ides_written`. See step-01 §1c.
 
 ## MANDATORY SEQUENCE
 
@@ -293,7 +294,7 @@ After user confirms with 'C':
 1. Read `{skills_output_folder}/.export-manifest.json` (or start with `{"schema_version": "2", "exports": {}}` if it does not exist)
 2. Ensure `schema_version` is `"2"` (if v1 was migrated in section 4a, the migrated structure is already in context). If any version entry still has a legacy `platforms` key, rename it to `ides` in place (see §4a).
 3. Compute `ides_written` — the set of IDE identifiers from `config.yaml.ides` whose mapped context file was successfully written in section 9 (deduplicated, sorted). When `--context-file` was passed explicitly, `ides_written` contains only the IDEs that map to that single context file.
-4. Add or update the current skill's entry in v2 format:
+4. For each skill in `skill_batch` (multi-skill mode) — or the single current skill (single-skill mode) — add or update its entry in v2 format:
    ```json
    "{skill-name}": {
      "active_version": "{version}",
@@ -306,15 +307,15 @@ After user confirms with 'C':
      }
    }
    ```
-   - `{version}` is the version from `{resolved_skill_package}/metadata.json`
+   - `{version}` is the version from each skill's `{resolved_skill_package}/metadata.json`
    - If the skill already has a manifest entry:
      - Set `active_version` to the current version
      - If the version already exists in `versions`, union its existing `ides` with `ides_written` (deduplicate, keep sorted), refresh `last_exported`, and set `status: "active"`
      - If this is a new version, add it to `versions` with `status: "active"` and set any previously-active version's status to `"archived"`
      - Preserve all other version entries in `versions` (do not delete archived versions)
-5. Write the updated manifest to `{skills_output_folder}/.export-manifest.json`
+5. Write the updated manifest once to `{skills_output_folder}/.export-manifest.json` after all skills in the batch have been applied
 
-**Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name} — ides: {ides_written}.**"
+**Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name-list} — ides: {ides_written}.**" (list every skill in `skill_batch`)
 
 **Error handling:** If manifest write fails, warn but do not fail the workflow — the managed section was already written successfully.
 

--- a/src/skf-export-skill/steps-c/step-05-token-report.md
+++ b/src/skf-export-skill/steps-c/step-05-token-report.md
@@ -12,6 +12,7 @@ To calculate approximate token counts for all exported artifacts and present a c
 
 - Focus only on token counting and reporting — read-only measurement
 - Auto-proceed when complete
+- **Multi-skill mode:** when step-01 loaded more than one skill (`len(skill_batch) > 1`), compute token counts per skill, then present one aggregate table with one row per skill (context-snippet.md, SKILL.md, metadata.json, references/, package total). Measure the managed section once for the run — it is shared across the batch. See step-01 §1c.
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-export-skill/steps-c/step-06-summary.md
+++ b/src/skf-export-skill/steps-c/step-06-summary.md
@@ -12,6 +12,7 @@ To present a complete export summary showing all files written, token counts, an
 
 - Focus only on summarizing what was done and providing next steps — no additional file writes
 - Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing summary is NOT the terminal step
+- **Multi-skill mode:** emit ONE consolidated summary and ONE result contract for the whole batch. The files-written table lists every skill in `skill_batch` (one row per skill's `context-snippet.md` + one row per target managed-section file, shared across the batch). The result contract's `outputs` enumerates every context-snippet file plus every target context file. Distribution instructions (§2) key off `source_authority` per skill — present one block per distinct authority value observed in the batch, listing the skills it applies to. See step-01 §1c.
 
 ## MANDATORY SEQUENCE
 


### PR DESCRIPTION
## Summary

- **#190 (friction)** — step-01 gains §1b that reads the `root:` prefix of every pre-existing `context-snippet.md` (current skill + manifest-listed skills), compares against the first `target_context_files` entry's `skill_root`, and on mismatch emits a single warning with 3 resolution options (set `snippet_skill_root_override`, proceed with IDE mapping, cancel). Eliminates the manual cross-check that authoring-repo exports required.
- **#191 (gap)** — step-01 gains §1c "Multi-skill Mode" that codifies how `--all` / multi-selection partitions work across steps: step-01 §2-5 and steps 02, 03, 05 iterate per skill; step-04 batches once (§9b adds a manifest entry per skill before a single manifest write); step-06 emits one summary + one result contract; step-07 runs once. Prevents operators from having to infer batch-vs-sequential semantics.

Single-skill path is explicitly preserved (no behavior change for existing invocations).

## Test plan

- [x] `npm test` (pre-commit hook on both commits — schemas, install, CLI, workflow, python, knowledge, refs, lint, markdownlint, format)
- [x] Smoke run `skf-export-skill` with `--all` against an authoring repo to confirm §1b mismatch warning triggers and §1c gates collapse to one [C] at step-01 and one [C] at step-04
- [x] Smoke run with a single skill to confirm no regression in the single-skill path

🤖 Generated with [Claude Code](https://claude.com/claude-code)