### PR TITLE
chore(release): pre-RC bump to 1.0.0-rc.0 (Story 5.1 hand-off)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmad-module-skill-forge",
-  "version": "0.10.0",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmad-module-skill-forge",
-      "version": "0.10.0",
+      "version": "1.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "bmad-module-skill-forge",
-  "version": "0.10.0",
+  "version": "1.0.0-rc.0",
   "description": "BMAD module — Turn code and docs into instructions AI agents can actually follow. Progressive capability tiers (Quick/Forge/Forge+/Deep).",
   "keywords": [
     "bmad",


### PR DESCRIPTION
## Summary

Pre-RC hand-bump from `0.10.0` to `1.0.0-rc.0` so the canonical `release.yaml` workflow's `Bump version` step (case `rc` → `npm version prerelease --preid=rc`) advances to `1.0.0-rc.1` on the next dispatch. Per the CLI block in [`docs/RELEASING.md § Cutting v1.0.0-rc.1`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/docs/RELEASING.md).

Without this hand-bump, `npm version prerelease --preid=rc` on `0.10.0` would produce `0.10.1-rc.0`, not the desired `1.0.0-rc.1`.

## Scope

- `package.json` — `"version": "0.10.0"` → `"version": "1.0.0-rc.0"` (single-line flip)
- `package-lock.json` — lockfile `.version` and `.packages[""].version` re-synced by `npm version`

**Not touched** (intentionally — race prevention):
- `.claude-plugin/marketplace.json` — synced atomically by the workflow's `Update marketplace.json version` step (jq-based, Story 5.1 H3)
- `CHANGELOG.md` — prepended by the workflow's `Update CHANGELOG.md` step via `conventional-changelog-cli -s`

## Precondition

Story 5.1's pre-v1.0.0 readiness audit at [`release-audits/v1.0.0-launch-audit.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/release-audits/v1.0.0-launch-audit.md) is signed clean (§ Blockers → "None — audit passes clean; Story 5.2 unblocked.").

## Test plan

- [x] `npm run quality` green locally (all 13 subcommands)
- [x] `jq -r .version package.json` → `1.0.0-rc.0`
- [x] `jq -r .version package-lock.json` → `1.0.0-rc.0`
- [x] `jq -r '.packages[""].version' package-lock.json` → `1.0.0-rc.0`
- [x] `jq -r '.plugins[0].version' .claude-plugin/marketplace.json` → `0.10.0` (UNCHANGED; workflow-owned)
- [x] 7 required status checks pass on this PR (CI)
- [x] Merge → `main` tip reflects the hand-bump
- [x] Follow-up: `gh workflow run release.yaml -f version_bump=rc --ref main` (Story 5.2 Task 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)