### PR TITLE
fix(release): poll commit check-runs API directly in Wait step (Story 3.5, fix #202)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -336,41 +336,142 @@ jobs:
           fi
           echo "::notice::Dispatched quality.yaml against $TEMP_BRANCH via workflow_dispatch"
 
-      - name: Wait for required status checks
+      - name: Cancel action_required pull_request runs on bot PR head
         if: github.ref == 'refs/heads/main'
-        timeout-minutes: 20
-        # AC #4: poll until all required contexts conclude, 20m hard cap.
-        # `--required` filters to only ruleset-required checks (ignores optional
-        # runs); `--watch` polls every 10s; `--fail-fast` exits 1 on first
-        # failure. Pre-sleep lets the workflow_dispatch from the prior step
-        # register its check-runs on the PR's head SHA before we start watching.
+        # Story 3.5 AC #5 (5.a): GitHub's fork-PR-approval rule applies even to
+        # GITHUB_TOKEN-authored PRs in user-owned repos; the pull_request event
+        # on the bot PR fires quality.yaml + discord-notification.yaml which
+        # land in `conclusion: action_required` and cannot be approved via
+        # POST /actions/runs/:id/approve (returns "This run is not from a fork
+        # pull request."). These orphan runs DO appear in PullRequest.status
+        # CheckRollup and permanently block branch protection even when the
+        # workflow_dispatch-sourced runs conclude success. Cancelling them
+        # transitions conclusion action_required → cancelled (a terminal
+        # state); branch protection's most-recent-wins eval then picks the
+        # workflow_dispatch success runs as authoritative on the SHA.
         run: |
           PR_NUMBER="${{ steps.open_pr.outputs.pr_number }}"
-          # P5: wait for at least one required check-run to register before --watch.
-          # Without this, `gh pr checks --required --watch --fail-fast` may exit 0
-          # immediately if zero required check-runs exist yet (silent-pass bug).
-          # The workflow_dispatch from the prior step needs a few seconds to register
-          # check-runs on the PR head SHA; poll for up to 2m (24 * 5s) before giving up.
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+          # Give GitHub a moment to attach the pull_request runs (they may
+          # still be firing after PR-open / force-trigger dispatch).
+          sleep 10
+          STUCK=$(gh api "/repos/${{ github.repository }}/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+            --paginate --jq '[.workflow_runs[] | select(.conclusion == "action_required") | .id]')
+          COUNT=$(echo "$STUCK" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::notice::No action_required runs on $HEAD_SHA; nothing to cancel."
+            exit 0
+          fi
+          echo "::notice::Cancelling $COUNT action_required run(s) on $HEAD_SHA"
+          for RUN_ID in $(echo "$STUCK" | jq -r '.[]'); do
+            if gh api --method POST "/repos/${{ github.repository }}/actions/runs/$RUN_ID/cancel"; then
+              echo "  Cancelled run $RUN_ID"
+            else
+              echo "::warning::Failed to cancel run $RUN_ID (may already be in a terminal state)"
+            fi
+          done
+
+      - name: Wait for required status checks
+        if: github.ref == 'refs/heads/main'
+        id: wait_checks
+        timeout-minutes: 20
+        # Story 3.5 AC #1–#4 (fixes issue #202): gh pr checks reads GraphQL's
+        # PullRequest.statusCheckRollup which only surfaces check-runs in a
+        # check suite that belongs to the PR (pull_request / push / merge_group
+        # events). The Force-trigger step above uses workflow_dispatch, whose
+        # check-runs land in a SEPARATE suite attached to the SHA by the ref-
+        # level dispatch — invisible to the rollup. Poll the commit's check-
+        # runs API directly to see all check-runs on the SHA regardless of
+        # which check suite created them. Required-context list is fetched
+        # from ruleset 13855503 so the Wait step has a single source of truth
+        # with branch protection.
+        run: |
+          PR_NUMBER="${{ steps.open_pr.outputs.pr_number }}"
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+          echo "Polling check-runs on $HEAD_SHA (PR #$PR_NUMBER)"
+
+          # AC #2: required contexts fetched from the ruleset (not hard-coded)
+          # so the Wait step can never drift from branch protection.
+          REQUIRED_JSON=$(gh api "/repos/${{ github.repository }}/rulesets/13855503" \
+            --jq '[.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]' 2>/dev/null || echo "")
+          if [ -z "$REQUIRED_JSON" ] || [ "$REQUIRED_JSON" = "[]" ]; then
+            echo "::error::Failed to fetch required-context list from ruleset 13855503. Retry the workflow, or verify: gh api /repos/${{ github.repository }}/rulesets/13855503"
+            exit 1
+          fi
+          REQUIRED_COUNT=$(echo "$REQUIRED_JSON" | jq 'length')
+          echo "Required contexts ($REQUIRED_COUNT): $REQUIRED_JSON"
+
+          # AC #3: registration poll — wait up to 2m for check-runs to register
+          # on the SHA. Preserves the Story 3.4 Patch P5 register-before-watch
+          # guard under the new API shape.
           POLL=0
-          REQUIRED_COUNT=0
+          REGISTERED=0
           while [ $POLL -lt 24 ]; do
-            REQUIRED_COUNT=$(gh pr checks "$PR_NUMBER" --required --json name --jq 'length' 2>/dev/null || echo 0)
-            if [ "${REQUIRED_COUNT:-0}" -ge 1 ]; then
-              echo "::notice::$REQUIRED_COUNT required check-run(s) registered on PR #$PR_NUMBER; entering --watch"
+            REGISTERED=$(gh api "/repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" --paginate --jq '.check_runs | length' 2>/dev/null || echo 0)
+            if [ "${REGISTERED:-0}" -ge 1 ]; then
+              echo "::notice::$REGISTERED check-run(s) registered on $HEAD_SHA; entering main wait loop"
               break
             fi
             sleep 5
             POLL=$((POLL + 1))
           done
-          if [ "${REQUIRED_COUNT:-0}" -lt 1 ]; then
-            echo "::error::No required check-runs registered on PR #$PR_NUMBER within 2m of workflow_dispatch. Likely causes: (a) quality.yaml didn't actually dispatch (see prior step logs), (b) check-run names don't match the ruleset's required contexts (AC #3 path-3.i caveat — dispatched names may be namespaced differently). PR left open for manual inspection."
+          if [ "${REGISTERED:-0}" -lt 1 ]; then
+            echo "::error::No check-runs registered on $HEAD_SHA within 2m. Likely causes: (a) workflow_dispatch of quality.yaml failed silently at the Force-trigger step (see prior step logs); (b) ruleset required-context list is empty (verify: gh api /repos/.../rulesets/13855503)."
             exit 1
           fi
-          if ! gh pr checks "$PR_NUMBER" --required --watch --fail-fast; then
-            echo "::error::PR #$PR_NUMBER has failing required check(s). PR left open for manual inspection. Re-run release.yaml after the underlying defect is fixed on main."
-            exit 1
-          fi
-          echo "::notice::All required status checks passed on PR #$PR_NUMBER"
+
+          # AC #4: main wait loop — most-recent-wins per context, fail-fast on
+          # any concluded failure state, 20m hard cap via step-level timeout.
+          ELAPSED=0
+          TIMEOUT=1200
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            CHECKS=$(gh api "/repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" \
+              --paginate --jq '[.check_runs[] | {name, status, conclusion, started_at, html_url}]')
+            ALL_GREEN=true
+            PENDING=()
+            FAILED=()
+            for CTX in $(echo "$REQUIRED_JSON" | jq -r '.[]'); do
+              CTX_RUN=$(echo "$CHECKS" | jq -c --arg n "$CTX" '[.[] | select(.name==$n)] | sort_by(.started_at) | last')
+              if [ "$CTX_RUN" = "null" ] || [ -z "$CTX_RUN" ]; then
+                PENDING+=("$CTX(unregistered)")
+                ALL_GREEN=false
+                continue
+              fi
+              STATUS=$(echo "$CTX_RUN" | jq -r .status)
+              CONCL=$(echo "$CTX_RUN" | jq -r .conclusion)
+              if [ "$STATUS" != "completed" ]; then
+                PENDING+=("$CTX($STATUS)")
+                ALL_GREEN=false
+                continue
+              fi
+              case "$CONCL" in
+                success|skipped|neutral)
+                  : # green
+                  ;;
+                failure|cancelled|timed_out|action_required)
+                  RUN_URL=$(echo "$CTX_RUN" | jq -r .html_url)
+                  FAILED+=("$CTX(conclusion=$CONCL, run=$RUN_URL)")
+                  ALL_GREEN=false
+                  ;;
+                *)
+                  echo "::warning::Unexpected conclusion '$CONCL' on $CTX; treating as green"
+                  ;;
+              esac
+            done
+            if [ ${#FAILED[@]} -gt 0 ]; then
+              echo "::error::Required context(s) failed: ${FAILED[*]}. PR left open for manual inspection. Re-run release.yaml after the underlying defect is fixed on main."
+              exit 1
+            fi
+            if [ "$ALL_GREEN" = "true" ]; then
+              echo "::notice::All $REQUIRED_COUNT required contexts green on $HEAD_SHA"
+              exit 0
+            fi
+            echo "Waiting on: ${PENDING[*]} (elapsed ${ELAPSED}s of ${TIMEOUT}s)"
+            sleep 20
+            ELAPSED=$((ELAPSED + 20))
+          done
+          echo "::error::Required status checks did not all succeed within ${TIMEOUT}s on $HEAD_SHA. Pending: ${PENDING[*]}. PR left open for manual inspection."
+          exit 1
 
       - name: Wait for PR approval or admin-bypass merge
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Story 3.5 — fixes GitHub issue [#202](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/202): `release.yaml § Wait for required status checks` stalls indefinitely under the Story 3.4 PR-auto-merge flow (PRs #199, #200) because `gh pr checks --required` reads GraphQL's `PullRequest.statusCheckRollup`, which only surfaces check-runs in a check suite that belongs to the PR (`pull_request` / `push` / `merge_group` events). The Force-trigger step uses `workflow_dispatch`, whose check-runs land in a **separate** check suite attached to the SHA by the ref-level dispatch — invisible to the PR-scoped rollup.

- **Refactor the Wait step** to poll `gh api /repos/.../commits/:sha/check-runs --paginate` directly. The required-context list is fetched from ruleset `13855503` (single source of truth with branch protection). Preserves the Story 3.4 Patch P5 register-before-watch guard under the new API shape; adds most-recent-wins per context + fail-fast on any concluded failure state.
- **Add a pre-Wait `Cancel action_required pull_request runs on bot PR head` step** (AC #5 path 5.a). GitHub's fork-PR-approval rule applies to `GITHUB_TOKEN`-authored PRs in user-owned repos, landing the auto-fired `pull_request` runs in `conclusion: action_required`. They cannot be approved via `POST /runs/:id/approve` ("This run is not from a fork pull request.") and permanently block branch protection; cancelling them transitions `action_required → cancelled` so most-recent-wins eval picks the `workflow_dispatch` success runs as authoritative.

## Root-cause evidence

Failed run [`24838762562`](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24838762562) (Story 5.2's first v1.0.0-rc.1 dispatch):
- All 7 required contexts DID register on PR #201's head SHA `9d4fde5` with `conclusion: success` — confirmed at issue-file time via `gh api /repos/.../commits/9d4fde5/check-runs`.
- `gh pr checks 201 --required` returned `no checks reported` and `gh pr view 201 --json statusCheckRollup` returned `{"statusCheckRollup": []}`. The check-runs exist; the PR-scoped rollup just doesn't see them.
- Story 3.4 AC #3 path 3.i (`workflow_dispatch` re-trigger) was the correct mitigation for "`GITHUB_TOKEN` doesn't fire downstream workflows," but it created a second unstated constraint: whatever reads the check-runs has to look at the SHA, not the PR.

## Files changed

- `.github/workflows/release.yaml` — Wait step body + one new Cancel step before it. All other Story 3.4 steps preserved unchanged (AC #6, AC #7).

## AC #5 path chosen

**5.a alone** (Cancel `action_required` runs before the Wait step). `5.b` (edit `quality.yaml` + `discord-notification.yaml` to skip on `release/bot/*` branches) is parked as a post-validation escalation if 5.a empirically doesn't unblock on the Story 5.2 RC cut (AC #5 option 5.c — residual risk low, surfaces as re-block of a future release, not silent).

## Validation plan

- **This PR** — standard `pull_request` trigger, so `gh pr checks --required` works fine here. Story 3.5's fix is for the BOT PR path the release workflow creates, not for feature-branch PRs like this one.
- **End-to-end** — Story 5.2 resumes after merge and dispatches `release.yaml -f version_bump=rc --ref main` from `main` tip. Success criteria: (a) workflow run reaches `conclusion: success`; (b) bot PR auto-merges; (c) tag `v1.0.0-rc.1` lands on `main`; (d) npm publish completes with provenance; (e) `main` advances by exactly one merge commit + the bot's commit underneath. Evidence captured in Dev Agent Record.

## Rollback

If the refactor merges and Story 5.2's validation cut fails in a way that can't be immediately patched forward: `gh pr revert <this-PR>` → approve + admin-merge the revert PR. The Wait step returns to the pre-3.5 (Story 3.4 + patches P5) form — which issue #202 blocks on, so Story 5.2 re-blocks. Most likely: fall-forward via `fix(release):` patches on `main`.

## Story spec

`_bmad-output/implementation-artifacts/3-5-release-workflow-wait-for-checks-direct-api-poll.md`

## Test plan

- [x] `npx js-yaml .github/workflows/release.yaml > /dev/null` — YAML parseable.
- [x] `npm run quality` — exit 0; all 13 subcommands green on the committing branch.
- [x] Pre-commit + commit-msg hooks pass without `--no-verify`.
- [ ] The 7 required status checks pass on this PR.
- [ ] Admin-bypass merge via `gh pr merge --merge --admin` (same pattern as PRs #195–200).
- [ ] Story 5.2 RC cut validates the fix end-to-end.

Fixes #202
