### PR TITLE
docs(release): sign off v1.0.0-rc.3 smoke test (Story 5.2)

### DIFF
--- a/release-audits/v1.0.0-launch-audit.md
+++ b/release-audits/v1.0.0-launch-audit.md
@@ -198,10 +198,190 @@ None — audit passes clean; Story 5.2 unblocked.
 
 ## Sign-off
 
-TBD — signed by Armel at Story 5.2 dispatch time.
+Signed off by Armel (@armelhbobdad) at 2026-04-23 16:27Z. v1.0.0-rc.3 survived smoke test clean; Story 5.3 unblocked.
 
 ## Post-commit footer
 
 - **Audit-completion commit SHA:** [`540fdda`](https://github.com/armelhbobdad/bmad-module-skill-forge/commit/540fdda419fc7e71bfdc571dab279b5de1b42578) — seven-file envelope (`docs(release): pre-v1.0.0 readiness audit (Story 5.1)`)
 - **Back-fill commit SHA:** this commit (the one that made this footer sentence self-referential)
 - **`git status --short` after commit:** clean working tree (verified per Story 5.1 AC 1 seven-file envelope)
+
+## Story 5.2 RC Cut + Smoke Test
+
+### Hand-bump commit
+
+- **Commit 1 subject:** `chore(release): pre-RC bump to 1.0.0-rc.0 (Story 5.1 hand-off)`
+- **PR:** [#197](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/197)
+- **Merge commit on main:** [`689501c`](https://github.com/armelhbobdad/bmad-module-skill-forge/commit/689501c) (merge-commit pattern, matching PR #195/#196)
+- **Hand-bump commit SHA under merge:** [`3fc1f00`](https://github.com/armelhbobdad/bmad-module-skill-forge/commit/3fc1f00)
+- **Scope:** `package.json` + `package-lock.json` — single-line version flip `0.10.0 → 1.0.0-rc.0`. No other files touched per AC 1(a) / AC 16.
+- **`npm run quality`:** all 13 subcommands green before opening PR.
+- **PR checks:** all 7 required status checks passed (eslint 22s, markdownlint 21s, prettier 24s, python ubuntu 24s, python windows 1m22s, validate ubuntu 21s, validate windows 1m10s).
+- **Remote `main` post-merge verification (AC 5 stronger precondition):** `gh api repos/.../contents/package.json` → `1.0.0-rc.0`.
+
+### Workflow dispatch run
+
+**Seven dispatch attempts** were required to land a passing RC end-to-end. Each attempt surfaced a distinct latent defect in the release pipeline — none of which had been exercised by the pre-v1.0.0 alpha cut (`v0.10.1-alpha.0`) because that cut dispatched from a feature branch and took the `Skip main push` pattern, bypassing the entire `main`-bound path. Story 5.2 was the first real E2E validation of the canonical path.
+
+| # | Run ID | Failed step | Root cause | Remediation |
+|---|---|---|---|---|
+| 1 | — | (not dispatched) | — | — |
+| 2 | [24829166764](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24829166764) | `Push commit to main` | Branch protection ruleset `Default` rejected direct `github-actions[bot]` push (GH013). AC 17's claimed bot-bypass-via-PR was factually wrong. | Story 3.4 refactor: push via auto-merge PR ([issue #198](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/198)); merged as PRs #199 + #200. |
+| 3 | [24838486851](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24838486851) | `Open bot PR` | Repo setting `can_approve_pull_request_reviews: false` blocked `gh pr create` under GITHUB_TOKEN. | Side-fix: `gh api -X PUT /actions/permissions/workflow -F can_approve_pull_request_reviews=true`. Should be codified as a Story 3.4 follow-up. |
+| 4 | [24838762562](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24838762562) | `Wait for required status checks` | `gh pr checks --required --watch` does NOT see check-runs posted by `workflow_dispatch`-triggered runs (they land in a different check suite than the PR's pull_request suite). All 7 required contexts were green on the SHA but invisible to the PR rollup. | Story 3.5: replace `gh pr checks` with direct `/commits/:sha/check-runs` API polling ([issue #202](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/202)); merged as PR #203. |
+| 5 | [24842070205](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24842070205) | `Wait for required status checks` (20-min timeout) | Story 3.5's `for CTX in $(jq -r '.[]')` unquoted command substitution word-split context names with spaces (`validate (ubuntu-latest)`, etc.) into separate tokens. | PR [#205](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/205): swap to `while IFS= read -r CTX; do ... done < <(...)`. |
+| 6 | [24844278359](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24844278359) | `Wait for PR approval or admin-bypass merge` (30-min timeout) | `gh pr view --json merged` is invalid — the valid field is `state` (returns `"OPEN"`/`"CLOSED"`/`"MERGED"`). The call exited 1, the guard treated it as transient, retried forever. Blocked both admin-bypass AND formal-approval paths. | PR [#207](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/207): swap `--json merged` → `--json state` + string comparison update in both Wait steps. |
+| 7 | [24845860915](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24845860915) | `Create and push tag` | Transient GitHub 500 on `git fetch origin main`. The tag-step's defensive guard correctly bailed rather than anchoring on stale state. Not a code bug. | Dispatch again; 500 self-resolved. |
+| 8 (passing) | [24846332151](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24846332151) | — | Full end-to-end success. | — |
+
+- **Passing run:** [24846332151](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24846332151)
+- **Start:** `2026-04-23T16:21:33Z`
+- **End:** `2026-04-23T16:27:30Z`
+- **Duration:** 5m 4s
+- **Conclusion:** `success`
+- **Release commit subject:** `release: bump to v1.0.0-rc.3`
+- **Release commit SHA:** [`78ac999`](https://github.com/armelhbobdad/bmad-module-skill-forge/commit/78ac999) (authored by `github-actions[bot]`)
+- **Bot PR merged via:** [#209](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/209) (admin-bypass-merge by @armelhbobdad at `2026-04-23T16:27:20Z`)
+- **Merge commit on main:** [`5fad470`](https://github.com/armelhbobdad/bmad-module-skill-forge/commit/5fad470)
+
+### npm publish evidence
+
+```json
+{
+  "version": "1.0.0-rc.3",
+  "dist": {
+    "tarball": "https://registry.npmjs.org/bmad-module-skill-forge/-/bmad-module-skill-forge-1.0.0-rc.3.tgz",
+    "shasum": "85bcb22f65cb98debda06c9ec22062bdc85fea4f",
+    "attestations": {
+      "url": "https://registry.npmjs.org/-/npm/v1/attestations/bmad-module-skill-forge@1.0.0-rc.3",
+      "provenance": { "predicateType": "https://slsa.dev/provenance/v1" }
+    }
+  }
+}
+```
+
+`npm view bmad-module-skill-forge dist-tags --json`:
+
+```json
+{ "latest": "0.10.0", "alpha": "0.10.1-alpha.0", "rc": "1.0.0-rc.3" }
+```
+
+- **AC 6 provenance:** ✅ SLSA L2 attestation present (`provenance/v1`).
+- **AC 7 dist-tag:** ✅ `rc: 1.0.0-rc.3`; `latest: 0.10.0` UNCHANGED; `alpha: 0.10.1-alpha.0` UNCHANGED.
+
+### GitHub Release v1.0.0-rc.3
+
+```json
+{
+  "tagName": "v1.0.0-rc.3",
+  "isPrerelease": true,
+  "createdAt": "2026-04-23T16:27:20Z",
+  "name": "Skill Forge (SKF) v1.0.0-rc.3",
+  "url": "https://github.com/armelhbobdad/bmad-module-skill-forge/releases/tag/v1.0.0-rc.3"
+}
+```
+
+### Main-branch side-effects
+
+- `git log main -1 --format='%H %s'` → `5fad470 Merge pull request #209 from armelhbobdad/release/bot/v1.0.0-rc.3-24846332151`
+- `git log main --grep='bump to v1.0.0-rc.3' --oneline` → `78ac999 release: bump to v1.0.0-rc.3` (workflow-authored, one behind merge tip)
+- `jq -r .version package.json` → `1.0.0-rc.3` ✅ (AC 8b)
+- `jq -r '.plugins[0].version' .claude-plugin/marketplace.json` → `1.0.0-rc.3` ✅ (AC 8c — **first live proof of Story 5.1 H3 jq fix working end-to-end**)
+- `grep -c '^## \[1.0.0-rc.3\]' CHANGELOG.md` → `1` ✅ (AC 8d)
+- `grep -c '^## \[1.0.0\] - TBD' CHANGELOG.md` → `1` ✅ (AC 8e — placeholder survives)
+- `head -5 CHANGELOG.md` → `# Changelog` + preamble + `## [Unreleased]` ✅ (AC 8f — Story 3.3 awk preamble-restore verified)
+- `git tag -l 'v1.0.0-rc.3'` → `v1.0.0-rc.3` ✅ (AC 8g)
+- `gh release view v1.0.0-rc.3` → `isPrerelease: true` ✅ (AC 8h)
+
+**Topology note (AC 8 re-interpretation under Story 3.4 PR-auto-merge flow):** the pre-3.4 AC 8(a) wording ("main tip SHA advanced by exactly one commit") is outdated — under the new PR-auto-merge flow, main advances by TWO commits per release cut (merge commit + the release commit underneath). `git log main -1` returns the merge commit; the release commit is reachable via `git log main --grep='bump to v1.0.0-rc.3'`. Functionally equivalent; the verification grep in AC 1 still works unchanged.
+
+### Clean-env smoke test transcripts
+
+**`--version` transcript (AC 9b):** `npx --yes bmad-module-skill-forge@rc --version` in a fresh `/tmp/skf-rc3-smoke/` → printed `1.0.0-rc.3`, exit `0`. The npm `11.6.2` `Permission denied` issue that Story 5.1 Task 10 hit on `.tgz`-path did NOT recur on the registry-resolved `@rc` path — as expected per Story 5.2 Dev Notes (F).
+
+**`install` transcript (AC 9d) — deviation from spec noted:** AC 9(d) specified piped-defaults via `printf 'skf-rc1-smoke\n\n\n\n\n' | npx ... install`, but the install TUI's `multiselect` IDE prompt (`required: true`) cannot be driven by piped stdin — the piped newlines get consumed by the first 3 text prompts (project name, skills folder, forge folder), and prompt 4 (multiselect) requires keystroke-level interaction (space + enter). Story 5.1 Task 10 also only smoke-tested `--version`, not the full install. **This is an AC 9 documentation defect, not an RC defect.** To complete the install smoke test, Armel ran the install **interactively** in a real terminal, selecting Claude Code as the IDE. Install completed cleanly with Ferris agent set up and all expected artifacts present:
+
+```
+◇  Installation complete! ──────────────────────────────────╮
+│                                                           │
+│  Get Started                                              │
+│  1. Open this folder in Claude Code                       │
+│  2. Activate Ferris:  /skf-forger                         │
+│  3. Ferris (your Skill Architect) will guide you through  │
+│     setting up and forging your first agent skill         │
+│                                                           │
+├───────────────────────────────────────────────────────────╯
+│
+└  ⚒  Agent: Ferris (Skill Architect & Integrity Guardian)
+```
+
+Artifact verification:
+
+- `ls /tmp/skf-rc3-smoke/_bmad/skf/` → `config.yaml, knowledge, module-help.csv, module.yaml, shared, skf-analyze-source, skf-audit-skill, skf-brief-skill, skf-create-skill, skf-create-stack-skill, ...`
+- `[ -f /tmp/skf-rc3-smoke/_bmad/_config/skf-manifest.yaml ]` → present
+- Zero `Installation failed.` in stderr
+
+**`status` transcript (AC 10):** `npx --yes bmad-module-skill-forge@rc status` exit `0`. All 6 STABILITY.md contract fields present in stdout:
+
+```
+  Skill Forge — Status
+  v1.0.0-rc.3
+
+  Installation
+    Project:      skf-rc3-smoke
+    SKF folder:   _bmad/skf/
+    Agent:        installed
+    Skills:       14
+    Installed:    4/23/2026
+    Manifest:     present
+
+  IDEs
+    ● Claude Code
+
+  Forge Tier
+    Not detected yet — run @Ferris SF
+    ast-grep:     not detected
+    gh CLI:       not detected
+    ccc:          not detected
+    QMD:          not detected
+
+  Output Folders
+    Skills:       skills/ ✓
+    Forge data:   forge-data/ ✓
+
+  Sidecar
+    State:        initialized
+    Location:     _bmad/_memory/forger-sidecar/
+```
+
+| STABILITY.md contract field | Observed | ✓ |
+|---|---|---|
+| installation-present | Installation section rendered | ✓ |
+| installed version string | `v1.0.0-rc.3` | ✓ |
+| forge-tier name | `Not detected yet` (plus ast-grep/gh/ccc/QMD tool rows) | ✓ |
+| configured IDE list | `● Claude Code` | ✓ |
+| workflow-skill count | `Skills: 14` | ✓ |
+| sidecar state | `State: initialized` | ✓ |
+| output-folder paths | `Skills: skills/ ✓` + `Forge data: forge-data/ ✓` | ✓ |
+
+**`uninstall` transcript (AC 11):** `printf 'y\n' | npx --yes bmad-module-skill-forge@rc uninstall` — note that unlike `install`, uninstall's only prompt is a simple `Yes/No` confirm which IS satisfied by piped `y\n`. Exit `0`. Final message: `SKF uninstalled successfully.` Post-uninstall:
+
+- `ls /tmp/skf-rc3-smoke/_bmad/skf/ 2>/dev/null | wc -l` → `0`
+- `[ -f /tmp/skf-rc3-smoke/_bmad/_config/skf-manifest.yaml ]` → absent ✓
+
+### NFR1 cycle-time record
+
+- **Dispatch → success wall-clock:** 5m 4s (run 24846332151: `2026-04-23T16:21:33Z` → `16:27:30Z`).
+- **NFR1 target:** 20 min (15 CI + 5 approval).
+- **Status:** WELL within envelope. The passing run is a clean data point for the rolling-over-10-releases series.
+- **Caveat:** this measurement excludes the cumulative time of attempts 2–7 (all failures). Total story wall-clock from first dispatch attempt to successful publish was ~6 hours including dev-cycle time on Stories 3-4, 3-5, and PRs #205/#207. That cumulative cost is retrospective-relevant but does NOT represent steady-state NFR1 performance — it represents first-time E2E discovery overhead, which by definition cannot repeat.
+
+### Decision: v1.0.0-rc.3 status
+
+**PASS — cleared for Story 5.3 promotion to v1.0.0 under --tag latest with manual approval.**
+
+Note to Story 5.3 dev-agent: the `## [1.0.0] - TBD` block at `CHANGELOG.md:396` was verified accurate against shipped rc.3 behavior (AC 15 — all bullets match: 1 agent Ferris, 14 workflows, 23 IDEs via `platform-codes.yaml`, tier names Quick/Forge/Forge+/Deep match the `Forge Tier` detection section). No CHANGELOG refinements flagged for Story 5.3. The only date-flip Story 5.3 must handle is `- TBD` → `- 2026-04-23` (or whatever date 5.3 dispatches).
+
+**Derogation from original AC 1 RC-number envelope:** the originally-planned RC number was `rc.1`; actually-shipped is `rc.3`. Stories 5.1 and 5.2 both authored AC text referencing `rc.1` literal. Under Story 5.2's 7-attempt execution, `rc.1` and `rc.2` were both committed to main (via PR #206's bypass-merge and PR #208's auto-merge respectively) but never tagged or published because downstream defects blocked each. Both are cosmetic-only stale release commits on main — npm immutability does NOT apply (nothing was published under those names); dist-tags never pointed at them. Story 5.3 dispatches on top of `rc.3` → `1.0.0`. This derogation is recorded per AC 12's spirit (defect discovery protocol), though each failure was a pipeline defect rather than an RC-content defect.
+
+**Lesson for Epic 5 retrospective:** The canonical release path from `main` dispatch had zero prior E2E validation before Story 5.2 attempted it. Stories 3-1 through 3-4 implicitly assumed the path worked; each defect surfaced by Story 5.2 was invisible because the alpha cut (`v0.10.1-alpha.0`) took the non-main-dispatch branch and skipped every affected step. Recommendation: future release-pipeline epics must include a **staging dispatch test** against a sandbox repo (or at minimum a full-workflow dry-run against the default branch) before declaring the pipeline ready. Catching 5+ defects via the first real v1.0.0 cut is demonstrably more expensive than discovering them in pre-launch testing.


### PR DESCRIPTION
## Summary

Story 5.2 Commit 2. Closes the Story 5.2 loop by populating the Sign-off block of the pre-v1.0.0 readiness audit artifact and appending the full § Story 5.2 RC Cut + Smoke Test H2 with 8 sub-sections of evidence per AC 14(b).

## What's in this commit

- **Sign-off** (was `TBD — signed by Armel at Story 5.2 dispatch time.`) → signed off as of `2026-04-23 16:27Z`; rc.3 survived smoke test clean; Story 5.3 unblocked.
- **New § Story 5.2 RC Cut + Smoke Test** with:
  - Hand-bump commit: PR #197 / merge `689501c` / bump `3fc1f00`
  - Workflow dispatch run: passing run [24846332151](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24846332151) with a full 7-attempt defect-discovery table documenting each prior failure and its remediation (Stories 3-4, 3-5, PRs #205, #207, and a repo-setting side-fix)
  - npm publish evidence (SLSA L2 provenance attestation at `provenance/v1`; dist-tag `rc: 1.0.0-rc.3`; `latest: 0.10.0` unchanged; `alpha: 0.10.1-alpha.0` unchanged)
  - GitHub Release v1.0.0-rc.3 (prerelease true)
  - Main-branch side-effects — all 8 verifications from AC 8(a)–(h) pass, plus a topology note on AC 8(a) re-interpretation under the Story 3-4 PR-auto-merge flow (main advances by 2 commits, not 1)
  - Clean-env smoke test transcripts — `--version`, `install` (with deviation note about AC 9(d) piped-stdin infeasibility on the multiselect IDE prompt; install was completed interactively in a real terminal), `status` (all 6 STABILITY.md contract fields verified), `uninstall`
  - NFR1 cycle-time record — 5m 4s well within 20-min envelope
  - Decision: **PASS** — cleared for Story 5.3
- Also records rc.1 → rc.3 derogation (rc.1/rc.2 release commits landed on main during failed attempts but were never tagged/published; npm immutability does not apply), a CHANGELOG verification note for Story 5.3, and an Epic 5 retrospective lesson re: lack of pre-launch E2E validation.

## Scope envelope per AC 1

**EXACTLY ONE FILE** modified: `release-audits/v1.0.0-launch-audit.md` (+181 / -1).

Not touched:
- `CHANGELOG.md` (Story 5.3 reconciles the `[1.0.0] - TBD` → actual-date flip)
- `.claude-plugin/marketplace.json` (workflow owns)
- `package.json` (workflow owns)
- `docs/RELEASING.md` (Story 5.1 territory; no refinements flagged)

## Test plan

- [x] `npm run quality` green locally (all 13 subcommands)
- [x] `git status --short` shows exactly 1 entry: `M release-audits/v1.0.0-launch-audit.md`
- [x] Conventional-commit subject (58 chars under 72-char limit); body references AC N form (not #N)
- [x] 7 required status checks pass on this PR (CI)

## Context

- Story: 5.2 Cut v1.0.0-rc.1 and run clean-environment smoke test (landed as rc.3)
- Related: #197 (hand-bump), #198, #202 (blocker issues), #199/#200/#203/#205/#207 (release.yaml fixes), #206/#208/#209 (bot release PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)