### PR TITLE
docs(release): reconcile CHANGELOG v1.0.0 and sign off publication (Story 5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ## [1.0.0](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v1.0.0-rc.3...v1.0.0) (2026-04-23)
+
+### First Major Release
+
+First major release of Skill Forge (SKF). Introduces the `INCONCLUSIVE` test verdict, atomic stack-skill writes, a shared feasibility schema across VS/RA/SS, and formalizes Linux/macOS-only support. Sets the stable contract for subsequent 1.x releases.
+
+### Initial Release
+
+Skill Forge (SKF) — an agent skill compiler that transforms code repositories, documentation, and developer discourse into [agentskills.io](https://agentskills.io)-compliant agent skills with AST-backed provenance.
+
+### Highlights
+
+- **1 agent** — Ferris (Skill Architect & Integrity Guardian) with 5 workflow-driven modes
+- **14 workflows** — full lifecycle from source analysis to ecosystem-ready export, with pre-code architecture verification
+- **Progressive capability tiers** — Quick (baseline), Forge (+ast-grep), Forge+ (+ccc), Deep (+gh+qmd)
+- **Source-traced instructions** — every documented symbol cites an upstream file and line
+- **Dual-output strategy** — active skills (SKILL.md) + passive context (context-snippet.md) in ADR-L v2 format
+- **CLI installer** — `npx bmad-module-skill-forge install` with skill directory installation for 23 IDEs
+- **14 knowledge fragments** — curated cross-cutting principles loaded just-in-time by workflows
+
+### Workflows
+
+| Trigger | Name                | Purpose                                                            |
+| ------- | ------------------- | ------------------------------------------------------------------ |
+| SF      | Setup Forge         | Initialize forge environment, detect tools, set tier               |
+| AN      | Analyze Source      | Discover what to skill in a large repo                             |
+| BS      | Brief Skill         | Design a skill scope through guided discovery                      |
+| CS      | Create Skill        | Compile a skill from brief with AST extraction                     |
+| QS      | Quick Skill         | Fast skill from package name or GitHub URL                         |
+| SS      | Stack Skill         | Consolidated project stack skill with integration patterns         |
+| US      | Update Skill        | Regenerate a skill while preserving manual sections                |
+| AS      | Audit Skill         | Drift detection between skill and current source                   |
+| TS      | Test Skill          | Verify whether a skill covers its target completely and accurately |
+| VS      | Verify Stack        | Pre-code stack feasibility verification against architecture       |
+| RA      | Refine Architecture | Improve architecture doc using verified skill data                 |
+| EX      | Export Skill        | Package for distribution, inject into CLAUDE.md                    |
+| RS      | Rename Skill        | Rename a skill and update all references                           |
+| DS      | Drop Skill          | Remove a skill and clean up references                             |
+
+### Confidence Tiers
+
+- **T1** — AST-verified signatures (Forge/Forge+/Deep)
+- **T1-low** — Source reading without structural verification (Quick)
+- **T2** — QMD-enriched temporal context (Deep)
+- **T3** — External documentation, quarantined as untrusted
+
+### IDE Support
+
+23 IDEs supported: Claude Code, Cursor, Windsurf, Cline, Roo Code, GitHub Copilot, Codex, Gemini CLI, Junie, Kiro, Trae, Google Antigravity, Auggie, CodeBuddy, Crush, iFlow, KiloCoder, Ona, OpenCode, Pi, Qoder, QwenCoder, Rovo Dev
+
+### Links
+
+- Documentation: <https://armelhbobdad.github.io/bmad-module-skill-forge>
+- npm: <https://www.npmjs.com/package/bmad-module-skill-forge>
+
 ## [1.0.0-rc.3](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v0.10.0...v1.0.0-rc.3) (2026-04-23)
 
 ### Features
@@ -394,67 +448,6 @@ All notable changes to this project will be documented in this file. The format 
 ### Reverts
 
 * Revert "chore(release): add temporary push trigger for Story 3.2 alpha cut (revert in same story)" ([7208ff4](https://github.com/armelhbobdad/bmad-module-skill-forge/commit/7208ff48640e97a2175b99b5d21dde192d85fdb3))
-## [1.0.0] - TBD
-
-<!--
-Hand-curated v1.0.0 release notes. Source: _bmad-output/planning-artifacts/v1-0-0-changelog-draft.md.
-Date placeholder "TBD" — replaced with actual publish date at Story 5.3's v1.0.0 final cut (see
-docs/RELEASING.md § Cutting v1.0.0-rc.1 for the reconciliation procedure).
--->
-
-### First Major Release
-
-First major release of Skill Forge (SKF). Introduces the `INCONCLUSIVE` test verdict, atomic stack-skill writes, a shared feasibility schema across VS/RA/SS, and formalizes Linux/macOS-only support. Sets the stable contract for subsequent 1.x releases.
-
-### Initial Release
-
-Skill Forge (SKF) — an agent skill compiler that transforms code repositories, documentation, and developer discourse into [agentskills.io](https://agentskills.io)-compliant agent skills with AST-backed provenance.
-
-### Highlights
-
-- **1 agent** — Ferris (Skill Architect & Integrity Guardian) with 5 workflow-driven modes
-- **14 workflows** — full lifecycle from source analysis to ecosystem-ready export, with pre-code architecture verification
-- **Progressive capability tiers** — Quick (baseline), Forge (+ast-grep), Forge+ (+ccc), Deep (+gh+qmd)
-- **Source-traced instructions** — every documented symbol cites an upstream file and line
-- **Dual-output strategy** — active skills (SKILL.md) + passive context (context-snippet.md) in ADR-L v2 format
-- **CLI installer** — `npx bmad-module-skill-forge install` with skill directory installation for 23 IDEs
-- **14 knowledge fragments** — curated cross-cutting principles loaded just-in-time by workflows
-
-### Workflows
-
-| Trigger | Name                | Purpose                                                            |
-| ------- | ------------------- | ------------------------------------------------------------------ |
-| SF      | Setup Forge         | Initialize forge environment, detect tools, set tier               |
-| AN      | Analyze Source      | Discover what to skill in a large repo                             |
-| BS      | Brief Skill         | Design a skill scope through guided discovery                      |
-| CS      | Create Skill        | Compile a skill from brief with AST extraction                     |
-| QS      | Quick Skill         | Fast skill from package name or GitHub URL                         |
-| SS      | Stack Skill         | Consolidated project stack skill with integration patterns         |
-| US      | Update Skill        | Regenerate a skill while preserving manual sections                |
-| AS      | Audit Skill         | Drift detection between skill and current source                   |
-| TS      | Test Skill          | Verify whether a skill covers its target completely and accurately |
-| VS      | Verify Stack        | Pre-code stack feasibility verification against architecture       |
-| RA      | Refine Architecture | Improve architecture doc using verified skill data                 |
-| EX      | Export Skill        | Package for distribution, inject into CLAUDE.md                    |
-| RS      | Rename Skill        | Rename a skill and update all references                           |
-| DS      | Drop Skill          | Remove a skill and clean up references                             |
-
-### Confidence Tiers
-
-- **T1** — AST-verified signatures (Forge/Forge+/Deep)
-- **T1-low** — Source reading without structural verification (Quick)
-- **T2** — QMD-enriched temporal context (Deep)
-- **T3** — External documentation, quarantined as untrusted
-
-### IDE Support
-
-23 IDEs supported: Claude Code, Cursor, Windsurf, Cline, Roo Code, GitHub Copilot, Codex, Gemini CLI, Junie, Kiro, Trae, Google Antigravity, Auggie, CodeBuddy, Crush, iFlow, KiloCoder, Ona, OpenCode, Pi, Qoder, QwenCoder, Rovo Dev
-
-### Links
-
-- Documentation: <https://armelhbobdad.github.io/bmad-module-skill-forge>
-- npm: <https://www.npmjs.com/package/bmad-module-skill-forge>
-
 ## [0.10.0](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v0.9.0...v0.10.0) (2026-04-06)
 
 ### Features

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -556,61 +556,78 @@ The `POST` body needs the same `name`, `target`, `enforcement`, `conditions`, `r
 
 For the `release` environment, a deletion+restore similarly uses the two-call pattern already documented at `## Release Environment § Restore / re-apply` — feed the environment-level baseline JSON to the `PUT .../environments/release` call, then re-POST each entry from the branch-policies baseline to `.../environments/release/deployment-branch-policies`.
 
-### Cutting v1.0.0-rc.1
+### Cutting v1.0.0 under --tag latest
 
-- **Trigger.** Story 5.1 audit ([`release-audits/v1.0.0-launch-audit.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/release-audits/v1.0.0-launch-audit.md)) signed off and all blockers cleared; Story 5.2 ready to cut the first release-candidate. `package.json` still on a `0.x` line (at audit time: `0.10.0`). Running `release.yaml` with `version_bump: rc` on `0.10.0` would produce `0.10.1-rc.0` — NOT `1.0.0-rc.0` — because `npm version prerelease --preid=rc` advances the patch segment of the current version. The one-time hand-bump below lifts `package.json` onto the `1.0.0` line so the next workflow dispatch advances that line cleanly.
+- **Trigger.** The passing RC has survived a clean-environment smoke test (`release-audits/v1.0.0-launch-audit.md § Story 5.2 RC Cut + Smoke Test § Decision: PASS — cleared for Story 5.3 promotion to v1.0.0 under --tag latest with manual approval`); `npm view bmad-module-skill-forge@rc version` returns the passing RC (at Story 5.3 dispatch time: `1.0.0-rc.3`); Story 5.3 is ready to promote to `latest` under manual approval.
 - **CLI.**
 
   ```bash
-  # Hand-bump main onto the 1.0.0 line. Do not tag; release.yaml owns tags.
   git checkout main && git pull
-  npm version 1.0.0-rc.0 --no-git-tag-version
-  # Leave .claude-plugin/marketplace.json alone — release.yaml's jq-based
-  # sync step rewrites .plugins[0].version atomically at RC cut time. A
-  # double-bump here would race against that step.
-  # Include package-lock.json — npm version bumps both files; committing
-  # only package.json leaves the lockfile out-of-sync and breaks `npm ci`.
-  git add package.json package-lock.json
-  git commit -m "chore(release): pre-RC bump to 1.0.0-rc.0 (Story 5.1 hand-off)"
-  # Push via the normal PR path (branch protection blocks direct push to main).
-  # Merge the PR to main after review.
 
-  # Dispatch the canonical release workflow. `version_bump: rc` runs
-  # `npm version prerelease --preid=rc` on 1.0.0-rc.0 → 1.0.0-rc.1.
-  gh workflow run release.yaml -f version_bump=rc
+  # Pre-dispatch sanity check (read version from remote, not local clone).
+  gh api repos/armelhbobdad/bmad-module-skill-forge/contents/package.json \
+    --jq '.content' | base64 -d | jq -r .version
+  # expected: the passing RC (e.g., 1.0.0-rc.3)
+
+  # Dispatch the canonical release workflow. `version_bump: major` on
+  # 1.0.0-rc.N strips the prerelease suffix and produces 1.0.0 (node-semver
+  # inc(ver, 'major') behavior on a prerelease). The --ref main is
+  # load-bearing — non-main dispatches take the legacy tag-only path.
+  gh workflow run release.yaml -f version_bump=major --ref main
+
+  # Capture the run id for monitoring + audit transcript.
+  RUN_ID=$(gh run list --workflow=release.yaml --limit 1 \
+    --json databaseId --jq '.[0].databaseId')
+  gh run watch $RUN_ID
   ```
 
-- **Expected outcome.** `main` tip at `1.0.0-rc.1`; `npm view bmad-module-skill-forge@rc version` returns `1.0.0-rc.1`; a GitHub Release `v1.0.0-rc.1` exists with `prerelease: true` and the auto-generated body; `CHANGELOG.md` now carries an auto-generated `## [1.0.0-rc.1]` entry prepended ABOVE the hand-curated `## [1.0.0] - TBD` placeholder (Story 5.1 staged that placeholder; Story 5.3 reconciles the date at the v1.0.0 final cut); `.claude-plugin/marketplace.json`'s `.plugins[0].version` reflects `1.0.0-rc.1`.
+  The workflow pauses at **two** gates that the maintainer must clear in the browser:
+
+  1. The `release` environment deployment gate (at job start). Approve via "Review deployments" → "Approve and deploy" on the run page.
+  2. The bot PR review-decision gate (after the 7 required status checks pass). EITHER approve the bot PR via the review UI, OR admin-bypass-merge via the PR merge button — both paths are accepted by `release.yaml`'s `Wait for PR approval or admin-bypass merge` step. Admin-bypass-merge is the observed pattern for prior cuts (PRs #209 and #213).
+
+  Expected wall-clock: ~5–8 minutes end-to-end when both gates are approved promptly.
+
+- **Expected outcome.** `main` tip advances by 2 commits (the `release: bump to v1.0.0` commit on the bot temp branch `release/bot/v1.0.0-<run_id>`, plus the merge commit from the auto-merged or admin-bypass-merged bot PR); `jq -r .version package.json` → `1.0.0`; `jq -r '.plugins[0].version' .claude-plugin/marketplace.json` → `1.0.0`; `npm view bmad-module-skill-forge dist-tags.latest` → `1.0.0` (flipped from the prior stable, e.g. `0.10.0`); `rc` dist-tag UNCHANGED at the prior RC; SLSA L2 provenance attached (NFR4); GitHub Release `v1.0.0` with `prerelease: false` (NFR6 threshold — `1.0.0` contains no `alpha|beta|rc` substring); tag `v1.0.0` anchors on the bot PR's merge commit per Story 3.4 P9 (the tag is annotated, so `git rev-parse 'v1.0.0^{}'` gives the commit SHA to compare against `main` tip).
+
 - **Constraints.**
-  - Execute ONLY after `v1.0.0-launch-audit.md § Sign-off` is populated with a date.
-  - The pre-RC bump commit subject MUST be `chore(release): pre-RC bump to 1.0.0-rc.0 (Story 5.1 hand-off)` — use the `chore(release):` prefix (not bare `release:`) or the commit-msg hook rejects it for non-conventional form.
-  - Do NOT bump `.claude-plugin/marketplace.json` in the hand-bump commit. `release.yaml`'s jq-based marketplace sync handles it atomically at RC cut time; a double-bump here would race the workflow.
-  - The RC cut is the FIRST time the jq-based marketplace.json update path runs in anger. A failure there (jq syntax error, missing `jq` on runner — unlikely on `ubuntu-latest` but treat as a real risk) would halt the cut mid-step, possibly leaving a half-updated `CHANGELOG.md` on `main` with no `marketplace.json` follow-through. Recovery: `git revert` the pre-RC bump PR + retry after fixing the workflow.
-  - If the workflow dispatch emits `1.0.1-rc.0` instead of `1.0.0-rc.1`, the hand-bump commit never landed on `main` OR `npm version prerelease --preid=rc` behavior diverged from the documented semantics. Abort the RC cut and investigate before retry.
+  - Execute ONLY after the RC audit `§ Sign-off` is populated AND the smoke-test `Decision` is `PASS`.
+  - The cut is IRREVERSIBLE — once `npm publish --tag latest` succeeds for `1.0.0`, NFR6 forbids unpublish regardless of eligibility window. Rollback is `npm deprecate` + ship-forward (Scenarios A / B).
+  - The CHANGELOG reconciliation is a POST-workflow step (authored as a separate sign-off commit on `feat/v1-final-signoff`). Do NOT hand-edit the `## [1.0.0] - TBD` placeholder BEFORE dispatch — let the workflow auto-generate its `## [1.0.0]` block (which may be EMPTY when there are zero conventional-commit `feat:` / `fix:` entries between the RC and the final cut, which is the normal case), then merge the hand-curated prose into the auto-gen header's position and delete the stale placeholder in one commit.
+  - Do NOT pre-bump `package.json` or `.claude-plugin/marketplace.json` — the workflow's `Bump version` and `Update marketplace.json version` steps handle both atomically and own those files.
+  - If `npm version major` unexpectedly emits `2.0.0` instead of `1.0.0` on `1.0.0-rc.N`, the node-semver engine behavior has regressed. Abort the dispatch and investigate before retry — a workflow override (`npm version 1.0.0 --no-git-tag-version`) would be required in `release.yaml`.
+
 - **Verification.**
 
   ```bash
-  # Confirm the rc dist-tag advanced.
-  npm view bmad-module-skill-forge@rc version
-  # expected: 1.0.0-rc.1
+  # Confirm the latest dist-tag flipped to 1.0.0.
+  npm view bmad-module-skill-forge dist-tags --json
+  # expected: {"latest":"1.0.0","alpha":"...","rc":"1.0.0-rc.N"}
 
-  npm view bmad-module-skill-forge dist-tags --json | jq -r .rc
-  # expected: 1.0.0-rc.1
+  npm view bmad-module-skill-forge@latest version
+  # expected: 1.0.0
 
-  # Confirm SLSA L2 provenance is attached (NFR4 reconfirm).
-  npm view bmad-module-skill-forge@1.0.0-rc.1 --json | jq '.dist.attestations'
-  # expected: non-null object containing a provenance url
+  # Confirm SLSA L2 provenance (NFR4 CRITICAL). A null attestation is a
+  # blocker — emergency-deprecate + cut 1.0.1 with provenance per Scenario B.
+  npm view bmad-module-skill-forge@1.0.0 --json | jq '.dist.attestations'
+  # expected: non-null object; .provenance.predicateType starts with
+  #           "https://slsa.dev/provenance/"
 
-  # Confirm the GitHub Release exists and is marked prerelease.
-  gh release view v1.0.0-rc.1 --json tagName,isPrerelease
-  # expected: {"tagName":"v1.0.0-rc.1","isPrerelease":true}
+  # Confirm the GitHub Release exists and is NOT a prerelease (NFR6 threshold).
+  gh release view v1.0.0 --json tagName,isPrerelease
+  # expected: {"tagName":"v1.0.0","isPrerelease":false}
 
-  # Confirm the CHANGELOG carries both the auto-generated rc entry and the
-  # hand-curated v1.0.0 placeholder (Story 5.3 reconciles the placeholder).
-  grep -c '^## \[1.0.0-rc.1\]' CHANGELOG.md   # expected: 1
-  grep -c '^## \[1.0.0\] - TBD' CHANGELOG.md  # expected: 1
+  # Confirm tag anchors on the merge commit (annotated tag — dereference with ^{}).
+  git fetch origin --tags
+  [ "$(git rev-parse 'v1.0.0^{}')" = "$(git log main -1 --format='%H')" ] && echo OK
+  # expected: OK
+
+  # Confirm CHANGELOG reconciliation after the sign-off commit lands on main.
+  grep -c '^## \[1\.0\.0\] - TBD' CHANGELOG.md    # expected: 0 (stale placeholder gone)
+  grep -cE '^## \[1\.0\.0\]' CHANGELOG.md         # expected: 1 (one reconciled block)
+  grep -cE '^## \[1\.0\.0\]\(https' CHANGELOG.md  # expected: 1 (compare-URL header survived)
   ```
 
-#### Story 3.4 refactor note — PR-auto-merge flow
+  **NFR6 immutability activation** is the `npm publish --tag latest` success timestamp for `1.0.0`, recorded verbatim in `release-audits/v1.0.0-launch-audit.md § Story 5.3 v1.0.0 Final Cut § NFR6 v1.0.0 immutability activation`. For Story 5.3's dispatch, that instant was **2026-04-23T18:56:39Z**. From that moment, `v1.0.0` is forever-burned — `npm deprecate` + ship-forward is the only rollback path.
 
-After Story 3.4 (GitHub issue [#198](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/198), [PR #199](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/199)), `release.yaml` no longer pushes the `release: bump to vX.Y.Z` commit directly to `main`. Instead, a main-dispatched cut pushes the release commit to a temp branch `release/bot/vX.Y.Z-<run_id>`, opens a bot PR against `main`, force-triggers `quality.yaml` against the temp branch via `workflow_dispatch` (so the 7 required status checks run and gate the merge), then auto-merges once checks pass and a maintainer approves. Approval is required at **two** gates — the `release` environment gate at job start, and the PR review-decision gate before auto-merge. Non-main dispatches (feature-branch alpha cuts) skip the PR dance and keep the legacy tag-only behavior. Story 5.2's dev agent on resume will refresh the § Cutting v1.0.0-rc.1 prose above to describe the refactored flow directly.
+  The `release` environment + bot PR approval-or-admin-bypass-merge pattern is the canonical flow for all main-dispatched cuts since Story 3.4 ([GitHub issue #198](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/198), [PR #199](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/199)): the release commit is pushed to a temp branch `release/bot/vX.Y.Z-<run_id>`, a bot PR is opened against `main`, the 7 required status checks are force-triggered against the temp branch via `workflow_dispatch`, and the merge is gated behind maintainer approval at both the `release` environment gate and the PR review-decision gate. Non-main dispatches (feature-branch alpha cuts) skip the PR dance entirely and keep the legacy tag-only behavior.

--- a/release-audits/v1.0.0-launch-audit.md
+++ b/release-audits/v1.0.0-launch-audit.md
@@ -198,7 +198,7 @@ None — audit passes clean; Story 5.2 unblocked.
 
 ## Sign-off
 
-Signed off by Armel (@armelhbobdad) at 2026-04-23 16:40Z (post-publish, after smoke test completion). v1.0.0-rc.3 survived smoke test clean; Story 5.3 unblocked.
+Signed off by Armel (@armelhbobdad) at 2026-04-23 16:40Z (post-publish, after smoke test completion). v1.0.0-rc.3 survived smoke test clean; Story 5.3 unblocked. v1.0.0 launched 2026-04-23 18:56:39Z; Story 5.4 cross-platform verification in scope.
 
 ## Post-commit footer
 
@@ -415,3 +415,242 @@ $ npm view bmad-module-skill-forge versions --json | jq '. | map(select(startswi
 **AC 12 title-convention note (D2 resolution):** AC 12 prescribes issue titles `v1.0.0-rc.N blocker: <one-line>` for failures of AC 6/7/8/9/10/11 (RC-content defects). Issues [#198](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/198) and [#202](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/202) were filed during Story 5.2 with `release.yaml`-prefixed titles instead, because each failure was a pipeline/workflow defect (failing step inside `release.yaml`), not an RC-content defect — none of the ACs 6–11 fired. The title-convention distinction: use `v1.0.0-rc.N blocker:` when the RC itself has a content defect (wrong version on npm, missing attestation, broken install, etc.); use `fix(release):` conventional-commit prefix when the release workflow has a defect. Codify this split at the Epic 5 retrospective.
 
 **Lesson for Epic 5 retrospective:** The canonical release path from `main` dispatch had zero prior E2E validation before Story 5.2 attempted it. Stories 3-1 through 3-4 implicitly assumed the path worked; each defect surfaced by Story 5.2 was invisible because the alpha cut (`v0.10.1-alpha.0`) took the non-main-dispatch branch and skipped every affected step. Recommendation: future release-pipeline epics must include a **staging dispatch test** against a sandbox repo (or at minimum a full-workflow dry-run against the default branch) before declaring the pipeline ready. Catching 5+ defects via the first real v1.0.0 cut is demonstrably more expensive than discovering them in pre-launch testing.
+
+## Story 5.3 v1.0.0 Final Cut
+
+Story 5.3 promoted the passing `v1.0.0-rc.3` RC to `v1.0.0` under `--tag latest` via the canonical `release.yaml` workflow with two-gate maintainer approval. The dispatch succeeded on the first attempt (in contrast to Story 5.2's 7-attempt saga), validating that the pipeline defects surfaced during Story 5.2 (Stories 3-4, 3-5, and PRs #205 / #207) were fully resolved. The cut is the NFR6 immutability activation event: from `2026-04-23T18:56:39Z`, `v1.0.0` is forever-burned on npm under `--tag latest`; rollback from this instant is `npm deprecate` + ship-forward only.
+
+### Workflow dispatch run
+
+- **Run URL:** <https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24852899833>
+- **Run id:** `24852899833`
+- **Dispatch command:** `gh workflow run release.yaml -f version_bump=major --ref main`
+- **Dispatch timestamp:** `2026-04-23T18:49:47Z`
+- **Release env gate approved at:** `2026-04-23T18:52:32Z` (set-up-job start; 2m 45s gate wait from dispatch)
+- **Bot PR approval-or-admin-bypass merge at:** `2026-04-23T18:56:30Z` (admin-bypass-merge — the PR's `Wait for PR approval or admin-bypass merge` step cleared in 0s because the merge had already happened by the time that step evaluated; matches the rc.3 pattern where PR #209 was admin-bypass-merged)
+- **Run completion:** `2026-04-23T18:56:48Z`
+- **Final conclusion:** `success`
+- **Step failures:** none (all 31 job steps completed successfully; step 27 `Skip PR flow (non-main dispatch ref)` was `skipped` by design — `github.ref == 'refs/heads/main'` evaluated true, so the non-main branch is correctly bypassed)
+
+### Bot PR auto-merge evidence
+
+- **Bot PR:** [#213 `release: bump to v1.0.0`](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/213)
+- **Head branch:** `release/bot/v1.0.0-24852899833` (temp branch; auto-deleted post-merge per standard flow)
+- **Head commit:** `62d56418836c90153401eae2d49500dbfa1c70d8` (the `release: bump to v1.0.0` commit)
+- **Merge commit:** `393a5a2012e8914faa3f67e1af94bc3ca0c90062`
+- **Merged at:** `2026-04-23T18:56:30Z`
+- **Merge path:** admin-bypass-merge (maintainer clicked merge on the PR without formal review approval; both `reviewDecision == APPROVED` and `state == MERGED` are accepted by `release.yaml:481-569`). This matches the Story 5.2 rc.3 pattern and is the expected path per Story 3.4.
+
+### npm publish evidence
+
+**Pre-cut dist-tags snapshot (from Task 1 recon, `2026-04-23 ~18:48Z`):**
+
+```json
+{
+  "latest": "0.10.0",
+  "alpha": "0.10.1-alpha.0",
+  "rc": "1.0.0-rc.3"
+}
+```
+
+**Post-cut dist-tags snapshot (from Task 3 verification, `2026-04-23 ~18:57Z`):**
+
+```json
+{
+  "latest": "1.0.0",
+  "alpha": "0.10.1-alpha.0",
+  "rc": "1.0.0-rc.3"
+}
+```
+
+**Dist-tag deltas:** `latest` flipped `0.10.0` → `1.0.0` (the whole point of Story 5.3); `rc` UNCHANGED at `1.0.0-rc.3` (Story 5.3's `major`-from-rc cut does NOT bump the rc tag); `alpha` UNCHANGED at `0.10.1-alpha.0`.
+
+**`npm view bmad-module-skill-forge@1.0.0 --json | jq '.dist'` (verbatim):**
+
+```json
+{
+  "integrity": "sha512-6tQOBCuf05SMRs/1MNWm6+f7OYOGh6tz62AbTvMG3bjspqMQa6Ln9y5paQtQRh4eWyuPvTlPaKqV6Vug8IIOeA==",
+  "shasum": "a582acf226016bb075dc5235a721da9d16104b35",
+  "tarball": "https://registry.npmjs.org/bmad-module-skill-forge/-/bmad-module-skill-forge-1.0.0.tgz",
+  "fileCount": 227,
+  "unpackedSize": 1697974,
+  "attestations": {
+    "url": "https://registry.npmjs.org/-/npm/v1/attestations/bmad-module-skill-forge@1.0.0",
+    "provenance": {
+      "predicateType": "https://slsa.dev/provenance/v1"
+    }
+  },
+  "signatures": [
+    {
+      "keyid": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U",
+      "sig": "MEUCIHcz/PIyH7DaVNN872V0uwQXmO29h6WmeXgGRxP0RFR7AiEA2zX6/x2aXiDN4V7irzXiWKNYG+uqFiQwBRGdt0DGFvg="
+    }
+  ]
+}
+```
+
+**Provenance attestation URL:** <https://registry.npmjs.org/-/npm/v1/attestations/bmad-module-skill-forge@1.0.0>
+
+**Versions list (after publish):**
+
+```
+$ npm view bmad-module-skill-forge versions --json | jq '. | map(select(startswith("1.0.0")))'
+[
+  "1.0.0-rc.3",
+  "1.0.0"
+]
+```
+
+**AC 6 NFR4 provenance-coverage status:** PASS — SLSA L2 attestation present for `1.0.0` (`predicateType: https://slsa.dev/provenance/v1`).
+
+### GitHub Release v1.0.0
+
+**`gh release view v1.0.0 --json tagName,isPrerelease,name,createdAt,url`:**
+
+```json
+{
+  "createdAt": "2026-04-23T18:56:33Z",
+  "isPrerelease": false,
+  "name": "Skill Forge (SKF) v1.0.0",
+  "tagName": "v1.0.0",
+  "url": "https://github.com/armelhbobdad/bmad-module-skill-forge/releases/tag/v1.0.0"
+}
+```
+
+- `isPrerelease: false` ✓ — load-bearing for NFR6 threshold; `release.yaml:697-704` computes `prerelease` as `contains(version, 'alpha|beta|rc')` and `1.0.0` contains none of those substrings.
+- Release URL: <https://github.com/armelhbobdad/bmad-module-skill-forge/releases/tag/v1.0.0>
+- Release body: auto-generated by `release.yaml § Generate release notes` from the conventional-commits between `v1.0.0-rc.3` and `v1.0.0` (expected sparse given the narrow commit-range; reconciled CHANGELOG carries the hand-curated v1.0.0 prose separately).
+
+### Main-branch side-effects
+
+**`main` branch advance (AC 8a):**
+
+```
+$ git log main -2 --format='%H %an %s'
+393a5a2012e8914faa3f67e1af94bc3ca0c90062 github-actions[bot] Merge pull request #213 from armelhbobdad/release/bot/v1.0.0-24852899833
+62d56418836c90153401eae2d49500dbfa1c70d8 github-actions[bot] release: bump to v1.0.0
+```
+
+- Merge commit: `393a5a2` (parents: `3e60788` pre-Story-5.3 main tip + `62d56418` bot release commit)
+- Release commit: `62d56418` (parent: `3e60788`)
+- Topology matches rc.3 precedent: PR merge commit on top, workflow-authored release commit underneath.
+
+**Version-file bumps (AC 8b, 8c):**
+
+```
+$ jq -r .version package.json
+1.0.0
+
+$ jq -r '.plugins[0].version' .claude-plugin/marketplace.json
+1.0.0
+```
+
+AC 8c: 2nd live end-to-end proof of the Story 5.1 H3 jq-based marketplace-sync step (1st was rc.3).
+
+**CHANGELOG post-workflow topology (AC 8d, 8e, 8f):**
+
+```
+$ grep -cE '^## \[1\.0\.0\]' CHANGELOG.md    # 2 (auto-gen + stale TBD; reconciled in Commit 2)
+$ grep -c '^## \[1.0.0-rc.3\]' CHANGELOG.md  # 1 (rc.3 block survived)
+$ head -5 CHANGELOG.md                        # # Changelog + preamble + ## [Unreleased]
+```
+
+**Zero-conventional-commit edge case:** the auto-generated `## [1.0.0]` block had an EMPTY body (no `### Features` / `### Bug Fixes` sub-sections) because the commit range `v1.0.0-rc.3..v1.0.0` contained only `docs(release):` and `chore(release):` entries. This is the expected behavior per deferred-work 3-3; AC 10 reconciliation preserves the auto-gen header (compare URL + date) and injects the hand-curated prose. The `awk`-based preamble-restore from Story 3.3 worked correctly despite the empty block.
+
+**Tag anchor verification (AC 9):**
+
+```
+$ git tag -l 'v1.0.0'
+v1.0.0
+
+$ git rev-parse 'v1.0.0^{}'   # dereference annotated tag to commit
+393a5a2012e8914faa3f67e1af94bc3ca0c90062
+
+$ git log main -1 --format='%H'
+393a5a2012e8914faa3f67e1af94bc3ca0c90062
+
+=> MATCH ✓ (tag anchors on PR merge commit per Story 3.4 P9 defensive guard)
+
+$ git log v1.0.0 -1 --format='%s'
+Merge pull request #213 from armelhbobdad/release/bot/v1.0.0-24852899833
+```
+
+**Note:** `v1.0.0` is an **annotated tag object** (tag SHA `4579b954ee6512a1c39ef4e3f06ecdb60e67358f`), not a lightweight tag. `git rev-parse v1.0.0` returns the tag object SHA, not the commit SHA — use `^{}` to dereference. This is consistent with the rc.3 tag shape from Story 5.2.
+
+### CHANGELOG reconciliation
+
+**Pre-reconciliation state (post-workflow):** two `## [1.0.0]` H2 blocks — (A) auto-generated at line 7 with compare URL `compare/v1.0.0-rc.3...v1.0.0` and empty body, (B) hand-curated `## [1.0.0] - TBD` placeholder at line 397 (originally staged by Story 5.1).
+
+**Post-reconciliation state:** single `## [1.0.0]` block at line 7 with preserved auto-gen header (compare URL + date `2026-04-23`) and hand-curated body (First Major Release → Initial Release → Highlights → Workflows → Confidence Tiers → IDE Support → Links); stale TBD placeholder deleted.
+
+**Post-edit verification (AC 10 iii):**
+
+```
+$ grep -cE '^## \[1\.0\.0\]' CHANGELOG.md         # 1 (exactly one reconciled block)
+$ grep -c  '^## \[1\.0\.0\] - TBD' CHANGELOG.md   # 0 (stale placeholder gone)
+$ grep -cE '^## \[1\.0\.0\]\(https' CHANGELOG.md  # 1 (compare-URL header preserved)
+$ grep -c  '^## \[1.0.0-rc.3\]' CHANGELOG.md      # 1 (rc.3 block untouched)
+$ grep -c  '^## \[0.10.0\]' CHANGELOG.md          # 1 (older history intact)
+```
+
+**Diff excerpt (block A insertion, head):**
+
+```diff
+ ## [1.0.0](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v1.0.0-rc.3...v1.0.0) (2026-04-23)
++
++### First Major Release
++
++First major release of Skill Forge (SKF). Introduces the `INCONCLUSIVE` test verdict, atomic stack-skill writes, a shared feasibility schema across VS/RA/SS, and formalizes Linux/macOS-only support. Sets the stable contract for subsequent 1.x releases.
++
++### Initial Release
++
++Skill Forge (SKF) — an agent skill compiler that transforms code repositories, documentation, and developer discourse into [agentskills.io](https://agentskills.io)-compliant agent skills with AST-backed provenance.
++[... hand-curated body continues with Highlights / Workflows / Confidence Tiers / IDE Support / Links ...]
+ ## [1.0.0-rc.3](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v0.10.0...v1.0.0-rc.3) (2026-04-23)
+```
+
+**Diff excerpt (block B deletion, tail):**
+
+```diff
+-## [1.0.0] - TBD
+-
+-<!--
+-Hand-curated v1.0.0 release notes. Source: _bmad-output/planning-artifacts/v1-0-0-changelog-draft.md.
+-Date placeholder "TBD" — replaced with actual publish date at Story 5.3's v1.0.0 final cut (see
+-docs/RELEASING.md § Cutting v1.0.0-rc.1 for the reconciliation procedure).
+--->
+-
+-### First Major Release
+-[... full hand-curated body deleted from here (moved up into reconciled block A) ...]
+-- npm: <https://www.npmjs.com/package/bmad-module-skill-forge>
+-
+ ## [0.10.0](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v0.9.0...v0.10.0) (2026-04-06)
+```
+
+**Net CHANGELOG delta:** 710 lines → 703 lines (−7 lines from removing the TBD placeholder's HTML comment + header markers; the body itself was relocated, not deleted).
+
+### NFR1 cycle-time record
+
+- **Dispatch → success wall-clock:** **7m 1s** (run `24852899833`: `2026-04-23T18:49:47Z` → `2026-04-23T18:56:48Z`)
+- **Env-gate approval sub-budget:** 2m 45s (`2026-04-23T18:49:47Z` dispatch → `2026-04-23T18:52:32Z` set-up-job start)
+- **Workflow automation sub-budget:** 4m 16s (`2026-04-23T18:52:32Z` → `2026-04-23T18:56:48Z`)
+- **NFR1 target:** 20 min (15 CI + 5 approval)
+- **Status:** within envelope; 13 min of headroom against the 20-min target.
+- **Rolling-10-release window:** 2 / 10 data points collected — `[Story 5.2 rc.3: 5m 4s, Story 5.3 v1.0.0: 7m 1s]`. Both well under NFR1's 20-min target. Stories 5.4 onward continue filling the window.
+- **Story 5.2 retrospective comparison:** Story 5.3 dispatched successfully on the first attempt (7m 1s wall-clock). Story 5.2 took 7 attempts and ~6 hours of cumulative dev-cycle time to discover and fix 5 pipeline defects (Stories 3-4, 3-5, PRs #205 / #207). Story 5.3's first-attempt success is evidence that those fixes landed correctly; the pipeline is now E2E-proven for main-dispatched cuts.
+
+### NFR6 v1.0.0 immutability activation
+
+**v1.0.0 is live on npm under --tag latest as of 2026-04-23T18:56:39Z. NFR6 immutability policy is now in force: this version SHALL NEVER be unpublished or republished; rollback uses npm deprecate + ship forward per docs/RELEASING.md § Scenario A/B.**
+
+This timestamp is the `Publish to npm via OIDC trusted publishing` step's completion time (step 29 of run `24852899833`; `2026-04-23T18:56:34Z` → `2026-04-23T18:56:39Z` in the GitHub Actions step timeline). From this instant, the version-number `1.0.0` on npm is an irreversible forensic fact: any future defect surfaced against `1.0.0` is resolved via `npm deprecate bmad-module-skill-forge@1.0.0 "<reason>"` and shipping `1.0.1` forward with the fix, NEVER via `npm unpublish` (regardless of eligibility-window rules — NFR6 forbids reclaim). This record is the auditable boundary between "pre-NFR6 state" and "NFR6-active state."
+
+### Decision: v1.0.0 launch status
+
+**LAUNCHED — v1.0.0 is live on npm under --tag latest with SLSA L2 provenance. Story 5.4 cross-platform verification cleared to begin (NFR9: within 1h of publish).**
+
+The `## Sign-off` section (above) is updated with the dual-sentence form:
+
+> Signed off by Armel (@armelhbobdad) at 2026-04-23 16:40Z (post-publish, after smoke test completion). v1.0.0-rc.3 survived smoke test clean; Story 5.3 unblocked. v1.0.0 launched 2026-04-23 18:56:39Z; Story 5.4 cross-platform verification in scope.
+
+Story 5.4 opens with `v1.0.0 is live on npm` as its precondition; NFR9 requires cross-platform install verification (Linux + Windows via the `quality.yaml` matrix + macOS manual spot-check) within 60 minutes of the `2026-04-23T18:56:39Z` publish timestamp. Story 5.4 dispatches are in scope starting immediately after Story 5.3's Commit 2 (this audit append) lands on `main`.


### PR DESCRIPTION
## Summary

- **Reconciles CHANGELOG.md** — merges the auto-gen `## [1.0.0]` compare-URL header with the hand-curated prose from the stale `## [1.0.0] - TBD` placeholder staged by Story 5.1. Net: one reconciled v1.0.0 entry (AC 10).
- **Signs off the v1.0.0 launch audit** — appends `## Story 5.3 v1.0.0 Final Cut` with 9 sub-sections recording the workflow dispatch, bot PR evidence, npm publish, GitHub Release, main-branch side-effects, CHANGELOG reconciliation, NFR1 cycle-time record, NFR6 immutability activation (2026-04-23T18:56:39Z), and Decision: LAUNCHED. Extends the `## Sign-off` block to dual-sentence form (AC 11, AC 18).
- **Flips `docs/RELEASING.md § Cutting v1.0.0-rc.1`** → `§ Cutting v1.0.0 under --tag latest`, documenting the two-gate maintainer-approval promotion path as the canonical major-cut procedure; absorbs the former Story 3.4 appendix into the main section body (AC 14).

## Release context

v1.0.0 is **live on npm** under `--tag latest` with SLSA L2 provenance, published 2026-04-23T18:56:39Z via [release.yaml run 24852899833](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24852899833) on first attempt (7m 1s dispatch-to-complete, well within NFR1's 20-min envelope).

NFR6 immutability policy is in force: v1.0.0 is now forever-burned under `--tag latest`; rollback from this instant is `npm deprecate` + ship-forward only (see [`docs/RELEASING.md § Scenario A / B`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/docs/RELEASING.md)).

- **Workflow run:** https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24852899833
- **Bot PR #213** (admin-bypass-merged 2026-04-23T18:56:30Z): https://github.com/armelhbobdad/bmad-module-skill-forge/pull/213 — merge commit `393a5a2012e8914faa3f67e1af94bc3ca0c90062`
- **GitHub Release v1.0.0:** https://github.com/armelhbobdad/bmad-module-skill-forge/releases/tag/v1.0.0
- **npm:** `bmad-module-skill-forge@1.0.0` under dist-tag `latest`

## Test plan

- [x] `npm run quality` green on feat/v1-final-signoff (all 13 subcommands pass: format, lint, lint:md, test:schemas, test:install, test:cli, test:workflow, test:python, test:knowledge, validate:schemas, validate:skills, validate:refs, docs:validate-drift)
- [x] CHANGELOG post-edit invariants hold (AC 10 iii): exactly 1 `## [1.0.0]` H2, 0 `## [1.0.0] - TBD`, 1 `## [1.0.0](https` compare-URL block, 1 `## [1.0.0-rc.3]`, 1 `## [0.10.0]`
- [x] `docs/RELEASING.md § Cutting v1.0.0 under --tag latest` present; `§ Cutting v1.0.0-rc.1` gone; Story 3.4 appendix absorbed
- [x] `release-audits/v1.0.0-launch-audit.md § Story 5.3 v1.0.0 Final Cut` present with all 9 AC 11 sub-sections; Sign-off block dual-sentence form includes the 18:56:39Z NFR6 activation timestamp
- [ ] 7 required status checks pass on this PR
- [ ] Reviewer approves OR admin-bypass-merge (matching rc.3 pattern per PRs #210 + #212)

## Next up

Story 5.4 — cross-platform install verification within NFR9's 60-min window from publish — cleared to begin once this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)