### PR TITLE
chore(release): apply code-review patches (Story 5.3)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -571,8 +571,9 @@ For the `release` environment, a deletion+restore similarly uses the two-call pa
 
   # Dispatch the canonical release workflow. `version_bump: major` on
   # 1.0.0-rc.N strips the prerelease suffix and produces 1.0.0 (node-semver
-  # inc(ver, 'major') behavior on a prerelease). The --ref main is
-  # load-bearing — non-main dispatches take the legacy tag-only path.
+  # inc(ver, 'major') behavior on a prerelease). `--ref main` is explicit
+  # (gh defaults to the repo's default branch, but any non-main ref takes
+  # the legacy tag-only path inside release.yaml, so pass it defensively).
   gh workflow run release.yaml -f version_bump=major --ref main
 
   # Capture the run id for monitoring + audit transcript.
@@ -581,7 +582,7 @@ For the `release` environment, a deletion+restore similarly uses the two-call pa
   gh run watch $RUN_ID
   ```
 
-  The workflow pauses at **two** gates that the maintainer must clear in the browser:
+  The workflow pauses at **two** gates that the maintainer must clear in the browser. Gate 1 requires explicit approval; gate 2 accepts either approval or admin-bypass-merge:
 
   1. The `release` environment deployment gate (at job start). Approve via "Review deployments" → "Approve and deploy" on the run page.
   2. The bot PR review-decision gate (after the 7 required status checks pass). EITHER approve the bot PR via the review UI, OR admin-bypass-merge via the PR merge button — both paths are accepted by `release.yaml`'s `Wait for PR approval or admin-bypass merge` step. Admin-bypass-merge is the observed pattern for prior cuts (PRs #209 and #213).
@@ -617,9 +618,11 @@ For the `release` environment, a deletion+restore similarly uses the two-call pa
   gh release view v1.0.0 --json tagName,isPrerelease
   # expected: {"tagName":"v1.0.0","isPrerelease":false}
 
-  # Confirm tag anchors on the merge commit (annotated tag — dereference with ^{}).
+  # Confirm the v1.0.0 tag is reachable from main (annotated tag — dereference with ^{}).
+  # Uses --is-ancestor so the check stays valid after subsequent commits land on main;
+  # pin to the recorded merge SHA if you need strict tag-anchor equivalence.
   git fetch origin --tags
-  [ "$(git rev-parse 'v1.0.0^{}')" = "$(git log main -1 --format='%H')" ] && echo OK
+  git merge-base --is-ancestor "$(git rev-parse 'v1.0.0^{}')" origin/main && echo OK
   # expected: OK
 
   # Confirm CHANGELOG reconciliation after the sign-off commit lands on main.

--- a/release-audits/v1.0.0-launch-audit.md
+++ b/release-audits/v1.0.0-launch-audit.md
@@ -38,7 +38,7 @@ description: Pre-flight gate audit of every must-have launch-checklist item, wit
 | H5   | `CHANGELOG.md` missing hand-curated `## [1.0.0]` entry                      | FIXED-IN-THIS-STORY  | Inserted `## [1.0.0] - TBD` section with `v1-0-0-changelog-draft.md` body between lines 5 and 7, and added `(pre-v0.3.0 tag, never published)` parenthetical to the dangling `Revert "0.2.0"` line, per Story 5.1 AC 5 / AC 13 + Task 6                                     | [deferred-work.md → 2-2](../_bmad-output/implementation-artifacts/deferred-work.md)                                     |
 | H6   | `docs/STABILITY.md:6` DRAFT banner                                          | FIXED-IN-THIS-STORY  | Replaced DRAFT banner with `STABLE — locked at v1.0.0. Amendments follow the "Changes to This Contract" section below.` per Story 5.1 AC 14 + Task 7                                                                                                                        | [`docs/STABILITY.md:6`](./STABILITY.md)                                                                                 |
 | H7   | `0.10.1-alpha.0` CHANGELOG `closes [#11]` / `[#12]` pollution               | NOT-APPLICABLE       | The pollution lived in the immutable `v0.10.1-alpha.0` tarball and in the orphaned commit `2a57dcbd`; current `main`'s `CHANGELOG.md` does NOT contain those refs (`grep -c 'closes \[#1[12]\]' CHANGELOG.md` → `0`). Alpha tarball is historical / immutable; no repo edit | [Epic 3 retro](../_bmad-output/implementation-artifacts/epic-3-retro-2026-04-21.md)                                     |
-| H8   | `docs/RELEASING.md` missing `### Cutting v1.0.0-rc.1` hand-bump procedure   | FIXED-IN-THIS-STORY  | Authored new H3 section under `## Rollback Playbook` umbrella (last H3, after `### Baseline snapshots`) with the same five-element shape (Trigger / CLI / Outcome / Constraints / Verification) as Scenarios A–G, per Story 5.1 AC 15 + Task 8                              | [`docs/RELEASING.md` § Cutting v1.0.0-rc.1](./RELEASING.md)                                                             |
+| H8   | `docs/RELEASING.md` missing `### Cutting v1.0.0-rc.1` hand-bump procedure   | FIXED-IN-THIS-STORY  | Authored new H3 section under `## Rollback Playbook` umbrella (last H3, after `### Baseline snapshots`) with the same five-element shape (Trigger / CLI / Outcome / Constraints / Verification) as Scenarios A–G, per Story 5.1 AC 15 + Task 8 (section subsequently renamed to `### Cutting v1.0.0 under --tag latest` by Story 5.3 Commit 2 per AC 14)                              | [`docs/RELEASING.md` § Cutting v1.0.0 under --tag latest](./RELEASING.md)                                                             |
 | H9   | `prevent_self_review: false` on `release` env + admin ruleset bypass        | DEFERRED-POST-V1     | Solo-maintainer repo today; both flips happen together at second-maintainer onboarding. Standing flag with no fire date                                                                                                                                                     | [Epic 3 retro standing flag + `deferred-work.md` 1-2](../_bmad-output/implementation-artifacts/deferred-work.md)        |
 | H10  | `CONTRIBUTING.md` → `docs/` anchor validator coverage                       | DEFERRED-POST-V1     | Pre-existing tooling gap; not introduced by any Epic 1–4 story; captured as a CI-as-enforced-gate candidate for a dedicated post-v1.0.0 tooling story                                                                                                                       | [Epic 4 retro + `deferred-work.md`](../_bmad-output/implementation-artifacts/deferred-work.md)                          |
 
@@ -425,12 +425,12 @@ Story 5.3 promoted the passing `v1.0.0-rc.3` RC to `v1.0.0` under `--tag latest`
 - **Run URL:** <https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/24852899833>
 - **Run id:** `24852899833`
 - **Dispatch command:** `gh workflow run release.yaml -f version_bump=major --ref main`
-- **Dispatch timestamp:** `2026-04-23T18:49:47Z`
-- **Release env gate approved at:** `2026-04-23T18:52:32Z` (set-up-job start; 2m 45s gate wait from dispatch)
+- **Dispatch timestamp:** `2026-04-23T18:49:46Z` (per GitHub API `run_started_at` on run `24852899833`)
+- **Release env gate approved at:** `2026-04-23T18:52:32Z` (set-up-job start; 2m 46s gate wait from dispatch)
 - **Bot PR approval-or-admin-bypass merge at:** `2026-04-23T18:56:30Z` (admin-bypass-merge — the PR's `Wait for PR approval or admin-bypass merge` step cleared in 0s because the merge had already happened by the time that step evaluated; matches the rc.3 pattern where PR #209 was admin-bypass-merged)
 - **Run completion:** `2026-04-23T18:56:48Z`
 - **Final conclusion:** `success`
-- **Step failures:** none (all 31 job steps completed successfully; step 27 `Skip PR flow (non-main dispatch ref)` was `skipped` by design — `github.ref == 'refs/heads/main'` evaluated true, so the non-main branch is correctly bypassed)
+- **Step failures:** none. Of 31 declared job steps, 30 ran successfully and 1 (step 27 `Skip PR flow (non-main dispatch ref)`) was skipped by design: the step's `if: github.ref != 'refs/heads/main'` guard evaluated false (the ref IS main), so the non-main fallback path was correctly bypassed.
 
 ### Bot PR auto-merge evidence
 
@@ -501,7 +501,7 @@ $ npm view bmad-module-skill-forge versions --json | jq '. | map(select(startswi
 ]
 ```
 
-**AC 6 NFR4 provenance-coverage status:** PASS — SLSA L2 attestation present for `1.0.0` (`predicateType: https://slsa.dev/provenance/v1`).
+**AC 6 NFR4 provenance-coverage status:** PASS — SLSA L2 attestation present for `1.0.0` (`predicateType: https://slsa.dev/provenance/v1`; the SLSA Build L2 level follows from npm's trusted-publishing design, which signs provenance statements via GitHub Actions OIDC with tamper-evident build metadata — see <https://docs.npmjs.com/generating-provenance-statements>).
 
 ### GitHub Release v1.0.0
 
@@ -519,7 +519,7 @@ $ npm view bmad-module-skill-forge versions --json | jq '. | map(select(startswi
 
 - `isPrerelease: false` ✓ — load-bearing for NFR6 threshold; `release.yaml:697-704` computes `prerelease` as `contains(version, 'alpha|beta|rc')` and `1.0.0` contains none of those substrings.
 - Release URL: <https://github.com/armelhbobdad/bmad-module-skill-forge/releases/tag/v1.0.0>
-- Release body: auto-generated by `release.yaml § Generate release notes` from the conventional-commits between `v1.0.0-rc.3` and `v1.0.0` (expected sparse given the narrow commit-range; reconciled CHANGELOG carries the hand-curated v1.0.0 prose separately).
+- Release body: auto-generated by `release.yaml § Generate release notes` from the conventional-commits between `v1.0.0-rc.3` and `v1.0.0` (expected empty — the commit range contains only `docs(release):` and `chore(release):` entries, neither of which emits `### Features` or `### Bug Fixes` under conventional-changelog; the reconciled CHANGELOG carries the hand-curated v1.0.0 prose separately). **Post-sign-off amplification (Story 5.3 code-review patch 2a, 2026-04-23):** the Release body was subsequently replaced via `gh release edit v1.0.0 --notes-file …` with the verbatim hand-curated CHANGELOG § [1.0.0] prose (First Major Release / Initial Release / Highlights / Workflows / Confidence Tiers / IDE Support / Links) plus a 6-line footer linking to the CHANGELOG entry and the `v1.0.0-rc.3...v1.0.0` compare view. Post-amplification body length: 3844 bytes (up from 473). This edit does not alter npm, the tag, or provenance; it only changes the public Release-page prose for discoverability.
 
 ### Main-branch side-effects
 
@@ -609,7 +609,7 @@ $ grep -c  '^## \[0.10.0\]' CHANGELOG.md          # 1 (older history intact)
  ## [1.0.0-rc.3](https://github.com/armelhbobdad/bmad-module-skill-forge/compare/v0.10.0...v1.0.0-rc.3) (2026-04-23)
 ```
 
-**Diff excerpt (block B deletion, tail):**
+**Diff excerpt (block B deletion, tail — the bracketed placeholder line inside the code fence below is narrative, not a literal diff line; run `git diff c0b2b67^..c0b2b67 -- CHANGELOG.md` for the verbatim body):**
 
 ```diff
 -## [1.0.0] - TBD
@@ -631,13 +631,13 @@ $ grep -c  '^## \[0.10.0\]' CHANGELOG.md          # 1 (older history intact)
 
 ### NFR1 cycle-time record
 
-- **Dispatch → success wall-clock:** **7m 1s** (run `24852899833`: `2026-04-23T18:49:47Z` → `2026-04-23T18:56:48Z`)
-- **Env-gate approval sub-budget:** 2m 45s (`2026-04-23T18:49:47Z` dispatch → `2026-04-23T18:52:32Z` set-up-job start)
+- **Dispatch → success wall-clock:** **7m 2s** (run `24852899833`: `2026-04-23T18:49:46Z` → `2026-04-23T18:56:48Z`)
+- **Env-gate approval sub-budget:** 2m 46s (`2026-04-23T18:49:46Z` dispatch → `2026-04-23T18:52:32Z` set-up-job start)
 - **Workflow automation sub-budget:** 4m 16s (`2026-04-23T18:52:32Z` → `2026-04-23T18:56:48Z`)
 - **NFR1 target:** 20 min (15 CI + 5 approval)
 - **Status:** within envelope; 13 min of headroom against the 20-min target.
-- **Rolling-10-release window:** 2 / 10 data points collected — `[Story 5.2 rc.3: 5m 4s, Story 5.3 v1.0.0: 7m 1s]`. Both well under NFR1's 20-min target. Stories 5.4 onward continue filling the window.
-- **Story 5.2 retrospective comparison:** Story 5.3 dispatched successfully on the first attempt (7m 1s wall-clock). Story 5.2 took 7 attempts and ~6 hours of cumulative dev-cycle time to discover and fix 5 pipeline defects (Stories 3-4, 3-5, PRs #205 / #207). Story 5.3's first-attempt success is evidence that those fixes landed correctly; the pipeline is now E2E-proven for main-dispatched cuts.
+- **Rolling-10-release window:** 2 / 10 data points collected — `[Story 5.2 rc.3: 5m 4s, Story 5.3 v1.0.0: 7m 2s]`. Both well under NFR1's 20-min target. Stories 5.4 onward continue filling the window.
+- **Story 5.2 retrospective comparison:** Story 5.3 dispatched successfully on the first attempt (7m 2s wall-clock). Story 5.2 took 7 attempts and ~6 hours of cumulative dev-cycle time to discover and fix 5 pipeline defects (Stories 3-4, 3-5, PRs #205 / #207). Story 5.3's first-attempt success is evidence that those fixes landed correctly; the pipeline is now E2E-proven for main-dispatched cuts.
 
 ### NFR6 v1.0.0 immutability activation
 


### PR DESCRIPTION
## Summary

Post-review patches for Story 5.3's Commit 2 (c0b2b67). Adversarial review (Blind Hunter + Edge Case Hunter + Acceptance Auditor) found all 7 priority ACs (1b, 10, 11, 14, 15, 18, 20) clean — these patches address quality-of-prose and consistency issues plus one concretely broken verification snippet.

**13 items actioned:** 2 decisions resolved + 11 patches applied. 11 items deferred (S53-D1..S53-D11). 9 dismissed as noise.

### Decisions resolved

- **SLSA L2 citation added** at `release-audits/v1.0.0-launch-audit.md` — links to npm trusted-publishing → SLSA Build L2 docs to close the evidentiary gap.
- **GitHub Release v1.0.0 body amplified** via `gh release edit v1.0.0 --notes-file …` with the verbatim hand-curated CHANGELOG §[1.0.0] prose + compare-link footer. Release body: 473 → 3844 bytes. Reversible via another `gh release edit`.

### Patches applied — `docs/RELEASING.md`

- Verification snippet `[ $(git rev-parse v1.0.0^{}) = $(git log main -1 --format=%H) ]` replaced with `git merge-base --is-ancestor` (old form was broken on current main tip — returned `393a5a2` vs `8e0919f`).
- Two-gate approval asymmetry clarified: gate 1 approval-only, gate 2 approval OR admin-bypass-merge.
- `--ref main` comment softened from "load-bearing" to "defensive".

### Patches applied — `release-audits/v1.0.0-launch-audit.md`

- H8 Disposition row link updated (same diff renamed the section but left the cross-reference stale).
- Step-27 prose inversion corrected.
- "All 31 steps completed successfully" restated as "30 ran + 1 skipped by design".
- NFR1 dispatch timestamp corrected `18:49:47Z` → `18:49:46Z` (per GitHub API `run_started_at`); derived durations recomputed: env-gate 2m 46s, wall-clock 7m 2s.
- Release-body wording "sparse" → "empty" (aligns with CHANGELOG-block characterisation).
- Illustrative placeholder inside the diff code fence flagged as narrative-only.

### What does not change

No change to npm, the `v1.0.0` tag, provenance, or any externally-observable artifact other than the GitHub Release body (reversible).

## Test plan

- [x] `markdownlint-cli2` clean on both files (via lint-staged)
- [x] Full `npm run test` suite passes (via pre-commit hook)
- [x] Corrected verification snippet (`git merge-base --is-ancestor v1.0.0^{} origin/main`) returns `OK` against current main
- [x] `gh release view v1.0.0 --json body | jq '.body | length'` returns 3844 (post-amplification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)