### PR TITLE
feat(release): add post-publish install smoke workflow (Story 5.4)

### DIFF
--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -1,0 +1,66 @@
+# Post-publish install smoke test (NFR9 cross-platform verification).
+#
+# Purpose: verify a published `bmad-module-skill-forge` version resolves and
+# executes cleanly on ubuntu-latest + windows-latest + macos-latest by running
+# `npx --yes bmad-module-skill-forge@<version> --version` on each runner.
+#
+# Trigger: `workflow_dispatch` — run manually after a release (e.g. `latest`,
+# `rc`, `alpha`, or an explicit version like `1.0.0`). NOT coupled to
+# `release.yaml`; runs against the published npm tarball, not the repo source.
+#
+# Expected use: the maintainer dispatches this workflow within 1 hour after a
+# cut per NFR9; results feed the matching release audit artifact's
+# `## Story <N> Post-Publish Verification § Matrix results` table.
+#
+# Why `--version` and not `install` / `status`: the interactive `install`
+# subcommand multiselect prompt is not pipe-able from CI stdin (issue #211);
+# `status` and `uninstall` depend on prior install state. `--version` is the
+# maximum-portable smoke check — it proves the npm tarball resolves, the
+# `bin` wrapper (`tools/skf-npx-wrapper.js`) is executable with the correct
+# shebang, Node can load the CLI entrypoint, commander dispatch works, and
+# `package.json.version` is readable at runtime. That covers the common
+# cross-platform regression vectors (tarball corruption, shebang issues,
+# bin-wrapper bugs, filesystem case-sensitivity) without TTY simulation.
+#
+# Node version coupling: `node-version: '22'` is hardcoded to match
+# `.nvmrc`. If `.nvmrc` advances to Node 23+, update this workflow in
+# lockstep.
+
+name: Install Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "npm dist-tag (latest / rc / alpha) or explicit version (e.g. 1.0.0)"
+        required: true
+        type: string
+        default: "latest"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run npx bmad-module-skill-forge --version
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT="$(npx --yes "bmad-module-skill-forge@${{ inputs.version }}" --version)"
+          echo "stdout: ${OUTPUT}"
+          if [ -z "${OUTPUT}" ]; then
+            echo "::error::--version produced empty stdout"
+            exit 1
+          fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -634,3 +634,13 @@ For the `release` environment, a deletion+restore similarly uses the two-call pa
   **NFR6 immutability activation** is the `npm publish --tag latest` success timestamp for `1.0.0`, recorded verbatim in `release-audits/v1.0.0-launch-audit.md § Story 5.3 v1.0.0 Final Cut § NFR6 v1.0.0 immutability activation`. For Story 5.3's dispatch, that instant was **2026-04-23T18:56:39Z**. From that moment, `v1.0.0` is forever-burned — `npm deprecate` + ship-forward is the only rollback path.
 
   The `release` environment + bot PR approval-or-admin-bypass-merge pattern is the canonical flow for all main-dispatched cuts since Story 3.4 ([GitHub issue #198](https://github.com/armelhbobdad/bmad-module-skill-forge/issues/198), [PR #199](https://github.com/armelhbobdad/bmad-module-skill-forge/pull/199)): the release commit is pushed to a temp branch `release/bot/vX.Y.Z-<run_id>`, a bot PR is opened against `main`, the 7 required status checks are force-triggered against the temp branch via `workflow_dispatch`, and the merge is gated behind maintainer approval at both the `release` environment gate and the PR review-decision gate. Non-main dispatches (feature-branch alpha cuts) skip the PR dance entirely and keep the legacy tag-only behavior.
+
+#### Post-publish verification (NFR9)
+
+Cross-platform install verification for any cut is performed by the [`install-smoke.yaml`](../.github/workflows/install-smoke.yaml) workflow, not by `release.yaml` itself. Dispatch it within 1 hour of publish per NFR9:
+
+```bash
+gh workflow run install-smoke.yaml -f version=latest --ref main
+```
+
+The workflow fans a `workflow_dispatch` input over `ubuntu-latest`, `windows-latest`, and `macos-latest`, running `npx --yes bmad-module-skill-forge@<version> --version` on each runner. A clean three-leg run is the canonical post-publish evidence — its run URL + matrix table belong in the release audit artifact's `## Story <N> Post-Publish Verification` section. Any failing leg routes through the `Rollback Playbook § Scenario B` (deprecate + ship `vX.Y.Z+1`).


### PR DESCRIPTION
## Summary

- Authors `.github/workflows/install-smoke.yaml` — a permanent reusable `workflow_dispatch` workflow running `npx --yes bmad-module-skill-forge@<version> --version` across `ubuntu-latest`, `windows-latest`, and `macos-latest` to satisfy NFR9's cross-platform install-verification obligation.
- Appends `#### Post-publish verification (NFR9)` subheading to `docs/RELEASING.md § Cutting v1.0.0 under --tag latest`, pointing at the new workflow as the canonical NFR9 verification vehicle (closes `deferred-work.md § S53-D6` gap).
- Zero repo-source code changes (per Story 5.4 AC 14).

## Scope

- **AC 1a** — subject `feat(release): add post-publish install smoke workflow (Story 5.4)`; touches exactly 2 files.
- **AC 3** — workflow shape: `workflow_dispatch` with `version` input (default `latest`), `permissions: { contents: read }`, matrix `{ os: [ubuntu-latest, windows-latest, macos-latest], fail-fast: false }`, `actions/setup-node@v4` with `node-version: '22'` (matching `.nvmrc`), single `npx --yes` step. No checkout — smoke runs against the published npm tarball.
- **AC 10** — `npm run quality` green (all 13 subcommands) before PR.
- **AC 11** — branched off `origin/main@55f40d0`; self-approve OR admin-bypass-merge.
- **AC 14** — zero changes to `tools/`, `src/`, `test/`, `package.json`, `CHANGELOG.md`, `.claude-plugin/marketplace.json`, `.nvmrc`, or any canonical release workflow.

## Files

| File | Change | Purpose |
|------|--------|---------|
| `.github/workflows/install-smoke.yaml` | A | NEW reusable post-publish smoke workflow (permanent, re-dispatchable every release) |
| `docs/RELEASING.md` | M | Appends NFR9 cross-reference subheading pointing at install-smoke.yaml |

## Follow-up

After merge: dispatch `gh workflow run install-smoke.yaml -f version=latest --ref main` — the 3-leg matrix result plus NFR9 elapsed-time bucket feeds the Commit 2 audit append (`release-audits/v1.0.0-launch-audit.md § Story 5.4 Post-Publish Verification`).

## Test plan

- [x] 7 required status checks pass on this PR (eslint, markdownlint, prettier, validate ubuntu+windows, python ubuntu+windows)
- [x] `.github/workflows/install-smoke.yaml` appears in GitHub Actions UI after merge
- [x] `gh workflow run install-smoke.yaml -f version=latest --ref main` dispatches successfully against `main`