### PR TITLE
chore(release): apply code-review patches (Story 5.4)

### DIFF
--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -56,11 +56,18 @@ jobs:
 
       - name: Run npx bmad-module-skill-forge --version
         shell: bash
+        env:
+          # Pass workflow_dispatch input via env (not `${{ inputs.version }}`
+          # interpolation in `run:`) to prevent GitHub Actions script injection.
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          OUTPUT="$(npx --yes "bmad-module-skill-forge@${{ inputs.version }}" --version)"
+          OUTPUT="$(npx --yes "bmad-module-skill-forge@${VERSION}" --version)"
+          # Strip trailing CR that Windows Git Bash can leave on captured stdout
+          # so the semver assertion below is CR-insensitive.
+          OUTPUT="${OUTPUT//$'\r'/}"
           echo "stdout: ${OUTPUT}"
-          if [ -z "${OUTPUT}" ]; then
-            echo "::error::--version produced empty stdout"
+          if [[ ! "${OUTPUT}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::--version stdout '${OUTPUT}' is not a valid semver — smoke failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Applies 2 of 3 patch-severity findings from the Story 5.4 adversarial code review (Blind Hunter + Edge Case Hunter + Acceptance Auditor, 2026-04-24). All changes scoped to `.github/workflows/install-smoke.yaml`.

### Applied

- **Script-injection hardening.** `${{ inputs.version }}` interpolated directly into the `run:` block was a documented GitHub Actions script-injection footgun. Now routed through `env: VERSION:` and referenced as `\"${VERSION}\"` inside the bash script so shell quoting applies.
- **Version-output assertion + Windows CRLF stripping.** Previous empty-string check could pass a wrong-version resolve or a Windows CRLF-only stdout. Now strips trailing CR and asserts `$OUTPUT` matches a semver regex (with optional prerelease / build-metadata suffixes).

### Skipped (requires judgment)

- **`node-version-file: \".nvmrc\"` swap (finding #2).** The proposed fix contradicts Story 5.4 Dev Notes (E) \"no repo checkout in the smoke workflow\" design decision — switching would require adding an `actions/checkout` step that was explicitly avoided for performance + simplicity. Left as an unchecked item under the story file's `### Review Findings` for follow-up walkthrough.

## Diff

Net: +10 / -3 lines in `.github/workflows/install-smoke.yaml`.

## Test plan

- [ ] 7 required status checks pass on this PR
- [ ] After merge: re-dispatch `gh workflow run install-smoke.yaml -f version=latest --ref main` — the patched smoke should still PASS all 3 matrix legs (changes are defensive; happy path unchanged)
- [ ] Adversarial: dispatch with `version=latest\" && echo pwned` — should now fail the semver regex at the assertion step instead of executing the injection