### PR TITLE
fix(release): lock pinned.yaml.skf_version to package.json.version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,6 +137,26 @@ jobs:
             echo "::error::marketplace.json version write failed: expected $VERSION, got $WROTE"; exit 1
           fi
 
+      - name: Update docs/_data/pinned.yaml skf_version
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          # Keep docs/_data/pinned.yaml.skf_version locked to package.json.version —
+          # pinned.yaml's own header declares this as an invariant and tools/validate-docs-drift.js
+          # enforces it at pre-commit time. This step enforces it at release time so
+          # the invariant is upheld atomically on every version bump.
+          #
+          # Targeted sed: matches ONLY a top-level `skf_version: "X.Y.Z"` line. The
+          # VERSION value is passed via env (not ${{ }} interpolation into the script
+          # body) to avoid shell-injection on inputs per Story 5.4 defense-in-depth.
+          sed -i.bak -E 's/^skf_version: "[^"]*"$/skf_version: "'"$VERSION"'"/' docs/_data/pinned.yaml
+          rm -f docs/_data/pinned.yaml.bak
+          # Sanity check: the written version matches what we set.
+          WROTE=$(grep -E '^skf_version:' docs/_data/pinned.yaml | sed -E 's/^skf_version: "([^"]*)"$/\1/')
+          if [ "$WROTE" != "$VERSION" ]; then
+            echo "::error::docs/_data/pinned.yaml skf_version write failed: expected $VERSION, got $WROTE"; exit 1
+          fi
+
       - name: Update CHANGELOG.md
         run: |
           npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s
@@ -203,7 +223,7 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git add package.json .claude-plugin/marketplace.json CHANGELOG.md
+          git add package.json .claude-plugin/marketplace.json docs/_data/pinned.yaml CHANGELOG.md
           git commit -m "release: bump to v${{ steps.version.outputs.new_version }}"
 
       - name: Generate release notes

--- a/docs/_data/pinned.yaml
+++ b/docs/_data/pinned.yaml
@@ -22,8 +22,11 @@
 # File ignored by Astro/Starlight content collections because the parent
 # directory starts with `_`. It is purely a build-time / CI-time anchor.
 
-# SKF package version — matches the `version` field in package.json
-skf_version: "0.10.0"
+# SKF package version — matches the `version` field in package.json.
+# Enforced two ways: (1) release.yaml bumps this line in the same commit
+# as package.json + marketplace.json on every release; (2) validate-docs-drift.js
+# cross-checks this value against package.json.version and fails on mismatch.
+skf_version: "1.0.0"
 
 # Path to the oh-my-skills repo, resolved relative to this repo's root.
 # Override at runtime with the OMS environment variable if oh-my-skills

--- a/tools/validate-docs-drift.js
+++ b/tools/validate-docs-drift.js
@@ -5,6 +5,9 @@
  * every version number, commit SHA, and library reference the docs cite.
  *
  * What it checks:
+ * - The anchor `skf_version` matches `package.json.version` (self-reference invariant
+ *   declared in pinned.yaml's header; enforced here at CI/pre-commit time AND bumped
+ *   by release.yaml on every release)
  * - Every skill listed in `docs/_data/pinned.yaml` actually exists at the
  *   claimed version and commit in $OMS/skills/<name>/<version>/<name>/metadata.json
  * - The metadata.json `version` field matches the anchor `version`
@@ -32,6 +35,7 @@ const yaml = require('js-yaml');
 const SKF_ROOT = path.resolve(__dirname, '..');
 const DOCS_DIR = path.join(SKF_ROOT, 'docs');
 const ANCHORS_PATH = path.join(DOCS_DIR, '_data', 'pinned.yaml');
+const PACKAGE_JSON_PATH = path.join(SKF_ROOT, 'package.json');
 
 function loadAnchors() {
   if (!fs.existsSync(ANCHORS_PATH)) {
@@ -44,6 +48,38 @@ function loadAnchors() {
     console.error(`error: could not parse ${ANCHORS_PATH}: ${error.message}`);
     process.exit(2);
   }
+}
+
+function checkSkfVersionAgainstPackageJson(anchors) {
+  const errors = [];
+  if (!fs.existsSync(PACKAGE_JSON_PATH)) {
+    errors.push(`CRITICAL: package.json not found at ${PACKAGE_JSON_PATH}`);
+    return errors;
+  }
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
+  } catch (error) {
+    errors.push(`CRITICAL: could not parse ${PACKAGE_JSON_PATH}: ${error.message}`);
+    return errors;
+  }
+  const anchorVersion = anchors.skf_version;
+  const packageVersion = pkg.version;
+  if (!anchorVersion) {
+    errors.push(`MISSING_ANCHOR: pinned.yaml has no skf_version key`);
+    return errors;
+  }
+  if (!packageVersion) {
+    errors.push(`MISSING_PKG_VERSION: package.json has no version field`);
+    return errors;
+  }
+  if (anchorVersion !== packageVersion) {
+    errors.push(
+      `SKF_VERSION_DRIFT: pinned.yaml skf_version "${anchorVersion}" !== package.json version "${packageVersion}" ` +
+        `— bump pinned.yaml or check that release.yaml's "Update pinned.yaml skf_version" step fired`,
+    );
+  }
+  return errors;
 }
 
 function resolveOmsPath(anchors) {
@@ -172,7 +208,11 @@ function main() {
   const anchors = loadAnchors();
   const omsPath = resolveOmsPath(anchors);
 
-  const errors = [...checkCanonicalFiles(anchors, omsPath), ...checkDocsForStaleVersions(anchors)];
+  const errors = [
+    ...checkSkfVersionAgainstPackageJson(anchors),
+    ...checkCanonicalFiles(anchors, omsPath),
+    ...checkDocsForStaleVersions(anchors),
+  ];
 
   if (errors.length > 0) {
     console.error('DRIFT DETECTED:\n');
@@ -186,7 +226,7 @@ function main() {
   }
 
   const skillCount = Object.keys(anchors.skills).length;
-  console.log(`OK: ${skillCount} skills checked against ${omsPath}, no drift.`);
+  console.log(`OK: skf_version ${anchors.skf_version} matches package.json; ${skillCount} skills checked against ${omsPath}, no drift.`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

`docs/_data/pinned.yaml:26` carried stale `skf_version: "0.10.0"` while `package.json` and the live v1.0.0 npm release were at `1.0.0`. The file's own header comment declared "matches the \`version\` field in package.json" as an invariant — but nothing enforced it. **Three-layer defense failure**:

- **Story 5.1 pre-v1.0.0 readiness audit** missed the file in its 8-file envelope sibling-sweep.
- **`release.yaml` bump-sync set** included `package.json` + `marketplace.json` but not `pinned.yaml`.
- **`tools/validate-docs-drift.js`** cross-checked `oms-*` skill anchors and the `illustrative_libraries` list but never read `skf_version`.

This PR closes all three layers in one commit.

## Changes

### 1. `docs/_data/pinned.yaml:26` — bump `0.10.0` → `1.0.0`

Reflects current live state (v1.0.0 on npm under `--tag latest` since 2026-04-23T18:56:39Z). Header comment expanded to document the two-layer enforcement introduced below.

### 2. `tools/validate-docs-drift.js` — add `checkSkfVersionAgainstPackageJson()`

Reads `package.json.version` and asserts `anchors.skf_version` matches. Runs as part of `npm run quality` (local + pre-commit hook). Not wired into CI `quality.yaml` because `docs:validate-drift` requires the `oh-my-skills` sibling repo checkout, which CI doesn't have — the pre-commit hook is the right enforcement point for these in-tree cross-references.

Error message is actionable — it points at the `release.yaml` step name that should have fired, so a future drift tells the maintainer exactly which sync-on-write path failed:

```
SKF_VERSION_DRIFT: pinned.yaml skf_version "X.Y.Z" !== package.json version "A.B.C" —
bump pinned.yaml or check that release.yaml's "Update pinned.yaml skf_version" step fired
```

Verified with negative-case probe (inject `9.9.9`, confirm validator exits 1, restore).

### 3. `.github/workflows/release.yaml` — new "Update docs/_data/pinned.yaml skf_version" step

New step inserted after the `Update marketplace.json version` step. Uses `sed` with a top-level-key anchor (`^skf_version: "[^"]*"$`), VERSION passed via `env:` per Story 5.4 shell-injection defense-in-depth (not interpolated into the script body), and a post-write `grep` sanity-check that `::error::`s on mismatch. Also adds `docs/_data/pinned.yaml` to the `git add` list at the release commit step so the bump rides with `package.json` + `marketplace.json` in the same release commit.

## Pattern coverage

Closes **Epic 5 retro Commitment 13(a)** "topology claims go stale when the workflow changes" for this specific invariant. Instantiates **Epic 6 retro Commitment 2** "symbolic anchor / cross-file validation" as a tooling guard (not just a prose convention). The two enforcement angles are complementary:

- **Release-side (sync-on-write)** prevents future drift when the version legitimately changes.
- **Validator-side (CI/pre-commit read-verify)** catches any other path that ever touches the file.

## Test plan

- [x] `node tools/validate-docs-drift.js` positive case — passes with `"skf_version 1.0.0 matches package.json"`.
- [x] Negative-case probe — inject `9.9.9`, confirm validator exits 1 with actionable `SKF_VERSION_DRIFT` message; restore.
- [x] `npm run quality` — all 13 subcommands exit 0.
- [x] Pre-commit + commit-msg hooks pass without `--no-verify`.
- [x] 7 required CI status checks pass on this PR.
- [x] `release.yaml`'s new step will be exercised on the next release cut (v1.0.1 / v1.1.0). Not validated live in this PR — deferred.

## Not bundled

- Any other Epic 5 retro standing flag (P1 rc dist-tag, P2 audit-evidence hardening, P3 NFR9 automation, P7 `package.json.main`).
- Issue #211 (piped-stdin install infeasibility).
- Any other file that might theoretically version-drift — scope is strictly `skf_version` because that's the documented invariant in `pinned.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)