### PR TITLE
docs(readme): add animated hero logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="website/public/img/skf-logo.svg" alt="Skill Forge Logo" width="120" />
+<img src="website/public/img/skf-logo-animated.svg" alt="Skill Forge Logo" width="120" />
 
 # Skill Forge (SKF)
 

--- a/website/public/img/skf-logo-animated.svg
+++ b/website/public/img/skf-logo-animated.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" role="img" aria-label="Skill Forge — hammer forging on anvil">
+  <defs>
+    <filter id="skfGlow" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="0.6" result="b"/>
+      <feMerge>
+        <feMergeNode in="b"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <style>
+      :root { --skf-cycle: 2.6s; }
+
+      .skf-hammer {
+        transform-box: fill-box;
+        transform-origin: 50% 97%;
+        animation: skf-swing var(--skf-cycle) cubic-bezier(.55,0,.2,1) infinite;
+        will-change: transform;
+      }
+      @keyframes skf-swing {
+        0%, 30%  { transform: rotate(-24deg); }
+        42%      { transform: rotate(-31deg); }
+        50%      { transform: rotate(2deg);  animation-timing-function: cubic-bezier(.7,0,.3,1); }
+        54%      { transform: rotate(-5deg); }
+        58%      { transform: rotate(0deg); }
+        100%     { transform: rotate(-24deg); }
+      }
+
+      .skf-spark {
+        transform-box: fill-box;
+        transform-origin: 50% 50%;
+        opacity: 0;
+        will-change: transform, opacity;
+      }
+      .skf-spark-L { animation: skf-spark-l var(--skf-cycle) ease-out infinite; }
+      .skf-spark-R { animation: skf-spark-r var(--skf-cycle) ease-out infinite; }
+      .skf-spark-C { animation: skf-spark-c var(--skf-cycle) ease-out infinite; }
+      @keyframes skf-spark-l {
+        0%, 49%  { opacity: 0; transform: translate(0,0) scale(.2); }
+        53%      { opacity: 1; transform: translate(-.6px,-.5px) scale(1.25); }
+        72%      { opacity: 0; transform: translate(-3.2px,-2.8px) scale(1.75); }
+        100%     { opacity: 0; transform: translate(-3.2px,-2.8px) scale(1.75); }
+      }
+      @keyframes skf-spark-r {
+        0%, 49%  { opacity: 0; transform: translate(0,0) scale(.2); }
+        53%      { opacity: 1; transform: translate(.6px,-.5px) scale(1.2); }
+        74%      { opacity: 0; transform: translate(3.6px,-2.2px) scale(1.65); }
+        100%     { opacity: 0; transform: translate(3.6px,-2.2px) scale(1.65); }
+      }
+      @keyframes skf-spark-c {
+        0%, 49%  { opacity: 0; transform: translate(0,0) scale(.2); }
+        53%      { opacity: 1; transform: translate(0,-.4px) scale(1.35); }
+        76%      { opacity: 0; transform: translate(0,-3.8px) scale(1.85); }
+        100%     { opacity: 0; transform: translate(0,-3.8px) scale(1.85); }
+      }
+
+      .skf-flash {
+        opacity: 0;
+        animation: skf-flash var(--skf-cycle) ease-out infinite;
+      }
+      @keyframes skf-flash {
+        0%, 49%  { opacity: 0; }
+        52%      { opacity: .8; }
+        60%      { opacity: .28; }
+        72%      { opacity: 0; }
+        100%     { opacity: 0; }
+      }
+
+      .skf-ember {
+        opacity: .3;
+        animation: skf-ember 3.4s ease-in-out infinite;
+      }
+      @keyframes skf-ember {
+        0%, 100% { opacity: .28; }
+        50%      { opacity: .58; }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .skf-hammer,
+        .skf-spark-L, .skf-spark-R, .skf-spark-C,
+        .skf-flash, .skf-ember { animation: none; }
+        .skf-spark { opacity: 1; }
+        .skf-ember { opacity: .35; }
+      }
+    </style>
+  </defs>
+
+  <!-- Anvil body -->
+  <path d="M8 28 L32 28 L34 32 L6 32 Z" fill="#D97706" />
+  <!-- Anvil top (horn + face) -->
+  <path d="M4 24 Q4 20 10 20 L30 20 Q34 20 34 24 L34 28 L8 28 L4 24 Z" fill="#F59E0B" />
+  <!-- Anvil horn -->
+  <path d="M4 24 Q2 22 4 20 Q4 20 10 20 L10 24 Z" fill="#FBBF24" />
+
+  <!-- Continuous ember heat on anvil face -->
+  <ellipse class="skf-ember" cx="20" cy="19.8" rx="7" ry="1.1" fill="#FDE68A" filter="url(#skfGlow)" />
+  <!-- Impact flash on strike -->
+  <ellipse class="skf-flash" cx="20" cy="19.8" rx="8.5" ry="1.7" fill="#FEF3C7" filter="url(#skfGlow)" />
+
+  <!-- Hammer (pivots near grip, bottom-center of group) -->
+  <g class="skf-hammer">
+    <rect x="18" y="4"  width="3"  height="14" rx="1"   fill="#92400E" />
+    <rect x="13" y="4"  width="13" height="5"  rx="1.5" fill="#D97706" />
+  </g>
+
+  <!-- Sparks burst outward on impact -->
+  <circle class="skf-spark skf-spark-L" cx="11" cy="16" r="1.2" fill="#FCD34D" filter="url(#skfGlow)" />
+  <circle class="skf-spark skf-spark-R" cx="28" cy="14" r="1"   fill="#FCD34D" filter="url(#skfGlow)" />
+  <circle class="skf-spark skf-spark-C" cx="20" cy="12" r=".8"  fill="#FDE68A" filter="url(#skfGlow)" />
+</svg>


### PR DESCRIPTION
## Summary

- Replaces the static README hero logo with a new `skf-logo-animated.svg` that renders a short forging loop: hammer wind-up + strike, spark burst, anvil impact flash, and a continuous ember pulse on the anvil face.
- Falls back to the original static composition under `prefers-reduced-motion: reduce`. Adds `role="img"` + `aria-label` for a11y.
- Original `skf-logo.svg` is untouched on purpose — the Starlight docs-site header (`website/astro.config.mjs`) still points at the static logo so the persistent page chrome stays calm at its small render size.

## Why two logo files

At the README hero (120px) the craft details of the animation read clearly. At the Starlight header (~28px) the sparks would collapse to sub-pixel dust while the motion still competes for reader attention on every page load. Keeping two files lets each surface get the right treatment.

## Test plan

- [x] Open the rendered README on GitHub and confirm the animation loops smoothly (hammer swing → spark burst → settle).
- [x] Toggle OS "Reduce motion" and reload — verify the hero renders as the original static composition.
- [x] Confirm docs site header logo on https://armelhbobdad.github.io/bmad-module-skill-forge/ is unchanged (still the static `skf-logo.svg`).
- [x] npm package page shows a graceful degradation (npm strips `<style>`; the composition still renders as the static anvil + hammer + sparks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)