### PR TITLE
fix(release): unbreak release.yaml dispatch (empty ${expr} literal)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,8 +147,9 @@ jobs:
           # the invariant is upheld atomically on every version bump.
           #
           # Targeted sed: matches ONLY a top-level `skf_version: "X.Y.Z"` line. The
-          # VERSION value is passed via env (not ${{ }} interpolation into the script
-          # body) to avoid shell-injection on inputs per Story 5.4 defense-in-depth.
+          # VERSION value is passed via env (not via GitHub-Actions expression
+          # interpolation into the script body) to avoid shell-injection on inputs
+          # per Story 5.4 defense-in-depth.
           sed -i.bak -E 's/^skf_version: "[^"]*"$/skf_version: "'"$VERSION"'"/' docs/_data/pinned.yaml
           rm -f docs/_data/pinned.yaml.bak
           # Sanity check: the written version matches what we set.


### PR DESCRIPTION
## Summary

Hotfix for an unmergeable-by-dispatch state of `.github/workflows/release.yaml`. PR #226 introduced a shell comment containing the literal token `\${{ }}` (line 150 of release.yaml). GitHub Actions's expression parser scans `run:` block contents for `\${{` and tries to evaluate the enclosed expression — an empty pair raises:

```
failed to parse workflow: (Line: 143, Col: 14): An expression was expected
```

`gh workflow run release.yaml -f version_bump=minor --ref main` returns HTTP 422 — and every push to `main` since `197c3fc` has produced a parse-failure run (visible as `event: push` failures with no jobs in the Actions tab; you can spot them retroactively at run ids `24916605187`, `24918215292`, `24918281370`, `24918851826`, `24918903240`).

## Why it slipped past review

`release.yaml` is `workflow_dispatch:`-only — no PR check exercises it, so the regression sat latent on `main` until the next release dispatch. The `quality.yaml` checks all pass against the broken file because they don't parse it; they only validate JS / Python / markdown / lint.

## Fix

Rewrite the comment on line 150 to describe expression interpolation in prose without using the literal `\${{` token:

- Before: `# VERSION value is passed via env (not \${{ }} interpolation into the script body)`
- After: `# VERSION value is passed via env (not via GitHub-Actions expression interpolation into the script body)`

Comment semantic is preserved — the reader is still told VERSION is passed via env, not interpolated into the shell body, with the Story 5.4 defense-in-depth rationale intact.

## Verification

- Local YAML parse via PyYAML succeeds.
- Repo-wide grep for similar landmines: only this one `\${{ *\}\}` occurrence existed across `.github/workflows/`.
- Full `npm test` suite passed via the pre-commit hook.
- Once merged, the next release-workflow dispatch should succeed.

## Test plan

- [ ] CI green on this PR (no surprises — only the comment changed).
- [ ] After merge, `gh workflow run release.yaml --ref main -f version_bump=minor` returns a run id (not HTTP 422). The actual release run is the test of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)