### PR TITLE
fix(skf-setup): health-check fixes for #243, #244, #245

### DIFF
--- a/src/knowledge/ccc-bridge.md
+++ b/src/knowledge/ccc-bridge.md
@@ -48,7 +48,7 @@ Returns: list of `{file, score, snippet}` entries ranked by semantic relevance t
 ### `ccc_bridge.status()`
 
 **Resolves to:** Two-step verification:
-1. `ccc --help` — confirms binary exists (exit 0)
+1. `ccc --help` — confirms binary exists (exit 0) AND output contains the `CocoIndex Code` identity marker (rejects unrelated `ccc`-named binaries shadowing PATH)
 2. `ccc doctor` — confirms daemon is running, extracts version string, validates embedding model
 
 **Usage context:** Called exclusively by setup step-01 during tool detection. Downstream workflows read the result from forge-tier.yaml — they do not re-verify.

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -7,7 +7,7 @@ description: Initialize forge environment, detect tools, and set capability tier
 
 ## Overview
 
-Initializes the forge environment by detecting available tools, determining the capability tier (Quick/Forge/Forge+/Deep), writing persistent configuration, and optionally indexing the project for deep search. This is a fully autonomous workflow — no user interaction is required during execution.
+Initializes the forge environment by detecting available tools, determining the capability tier (Quick/Forge/Forge+/Deep), writing persistent configuration, and optionally indexing the project for deep search. The workflow is autonomous with one optional gate — orphaned QMD collection removal in step 3 (Deep tier only; default action: Keep) — which auto-resolves to the default when `{headless_mode}` is true.
 
 ## Role
 
@@ -17,7 +17,7 @@ You are a system executor performing environment resolution. Run each step in se
 
 These rules apply to every step in this workflow:
 
-- Fully autonomous — all steps auto-proceed with no user interaction until the final report
+- Autonomous with one optional gate (step 3 orphan-removal prompt; default: Keep) — all other steps auto-proceed with no user interaction until the final report
 - Read each step file completely before taking any action
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -39,7 +39,7 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | (none — fully autonomous) |
+| **Inputs** | (none) |
 | **Gates** | One optional: orphaned QMD collection removal (step 3, Deep tier only; default: Keep) |
 | **Outputs** | forge-tier.yaml, preferences.yaml, forge-data directories |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |

--- a/src/skf-setup/references/tier-rules.md
+++ b/src/skf-setup/references/tier-rules.md
@@ -7,9 +7,9 @@
 | ast-grep | `ast-grep --version` | Returns version string without error |
 | gh | `gh --version` | Returns version string without error |
 | qmd | `qmd status` | Returns status indicating initialized and operational |
-| ccc | Step A: `ccc --help` Step B: `ccc doctor` | Step A: exits 0 (binary exists). Step B: daemon running, version string, model check OK |
+| ccc | Step A: `ccc --help` Step B: `ccc doctor` | Step A: exits 0 AND help output contains the `CocoIndex Code` identity marker (rejects unrelated `ccc`-named binaries shadowing PATH, e.g. an alias to `code2prompt`). Step B: daemon running, version string, model check OK |
 
-**Important:** Use verification commands, not existence checks (`which`, `command -v`). A tool must be functional, not just present on PATH. For daemon-based tools (ccc), verify both binary existence and daemon health.
+**Important:** Use verification commands, not existence checks (`which`, `command -v`). A tool must be functional, not just present on PATH. For daemon-based tools (ccc), verify both binary identity and daemon health — a binary with the right name but the wrong implementation is a false positive, not a tool.
 
 ## Tier Calculation
 

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -65,9 +65,10 @@ This is informational only — security scan availability does NOT affect the ti
 
 ### 7. Verify Tool: ccc (cocoindex-code)
 
-**Step A — Binary existence:** Run `ccc --help`
+**Step A — Binary identity:** Run `ccc --help`
 
-- If exits 0: binary confirmed. Continue to Step B.
+- If exits 0 AND the help output contains the identity marker `CocoIndex Code` (case-insensitive substring match — present in the genuine cocoindex-code CLI banner): identity confirmed. Continue to Step B.
+- If exits 0 BUT the marker is absent (e.g. `ccc` is shadowed by an alias for an unrelated tool such as `code2prompt`): record `{ccc: false}`. Skip Step B. Do not run `ccc doctor` against a foreign binary — its exit code says nothing about cocoindex-code health.
 - If fails (command not found or error): record `{ccc: false}`. Skip Step B.
 
 **Step B — Daemon health:** Run `ccc doctor`

--- a/src/skf-setup/steps-c/step-03-auto-index.md
+++ b/src/skf-setup/steps-c/step-03-auto-index.md
@@ -49,13 +49,24 @@ qmd collection list
 
 ### 3. Cross-Reference and Classify
 
-Compare the two lists:
+**Apply the forge-namespace filter first.** QMD is a shared daemon — other tools (memory-bank systems, ad-hoc indexers, unrelated workflows) may own collections in the same QMD instance. Never enumerate, display, or propose for removal a collection the forge does not own.
 
-**Healthy** — collection exists in both registry AND QMD:
+A collection is **forge-owned** only if its name ends with one of the forge collection-type suffixes set by producers `skf-brief-skill` and `skf-create-skill` (see `src/knowledge/qmd-registry.md` § Collection Types):
+
+- `-brief`
+- `-temporal`
+- `-docs`
+- `-extraction`
+
+Live collections whose name does NOT end with one of these suffixes are **foreign** — silently exclude them from `{live_collections}` for the rest of this section. Do not log them, do not surface them in any prompt, do not call `qmd collection remove` on them under any branch.
+
+Then compare the filtered `{live_collections}` against `{registry_collections}`:
+
+**Healthy** — forge-owned collection exists in both registry AND QMD:
 - Mark as verified
 - No action needed
 
-**Orphaned** — collection exists in QMD but NOT in registry:
+**Orphaned** — forge-owned collection exists in QMD but NOT in registry:
 - These may be leftover from prior auto-indexing or manual indexing
 - Flag for user-prompted removal
 

--- a/src/skf-setup/steps-c/step-03-auto-index.md
+++ b/src/skf-setup/steps-c/step-03-auto-index.md
@@ -78,7 +78,9 @@ Then compare the filtered `{live_collections}` against `{registry_collections}`:
 
 **If orphaned collections found:**
 
-Display to user:
+**Headless gate.** If `{headless_mode}` is true, auto-resolve to the default action **Keep** without prompting: log `"Auto-decision (headless): kept {count} orphaned forge collection(s)"` and skip the prompt branch entirely. This matches the workflow contract (`Headless: All gates auto-resolve with default action when {headless_mode} is true`) declared in the Invocation Contract.
+
+**If `{headless_mode}` is false**, display to user:
 "**QMD Hygiene: Found {count} orphaned collection(s) not tracked in the forge registry:**
 
 {list orphaned collection names}
@@ -86,7 +88,7 @@ Display to user:
 These collections exist in QMD but are not managed by any skill workflow. They may be from a previous auto-index run or manual creation.
 
 **[R]emove** orphaned collections — clean up QMD
-**[K]eep** orphaned collections — leave them as-is"
+**[K]eep** orphaned collections — leave them as-is (default)"
 
 **If user selects R (Remove):**
 For each orphaned collection:


### PR DESCRIPTION
## Summary

Three bug-fix commits + one consistency-cleanup commit, all surgical and scoped to `skf-setup`. Each issue-bound commit links to one health-check report. Full local `npm run quality` passed on every commit via husky pre-commit.

- **`fix(skf-setup): verify ccc binary identity to reject foreign tools`** — Step-01 §7 Step A now requires the `CocoIndex Code` identity marker in `ccc --help` output before continuing to `ccc doctor`. Prevents the `code2prompt`-aliased-as-`ccc` false-positive that was satisfying the "binary works but daemon has issues" branch and forcing Forge+ tier on a host that should have stayed Deep. **Fixes #243**
- **`fix(skf-setup): scope orphan detection to forge-managed collections`** — Step-03 §3 now filters live QMD collections to those matching the forge naming convention (suffix one of `-brief`, `-temporal`, `-docs`, `-extraction`) before classifying orphans. Foreign collections owned by other tools sharing the QMD daemon (e.g. Hindsight memory banks) are silently excluded and never reach the `[R]emove / [K]eep` prompt or `qmd collection remove`. Removes the data-loss footgun where `[R]` on a fresh-setup run with 48 unrelated collections present would have destroyed every one. **Fixes #244**
- **`fix(skf-setup): reconcile autonomy claim with step-03 orphan prompt`** — SKILL.md Overview + Workflow Rules updated from "fully autonomous" to "autonomous with one optional gate" (orphan removal, default Keep). Step-03 §4 explicitly headless-gated to auto-resolve to Keep when `{headless_mode}` is true, matching the Invocation Contract that already promised this behaviour. **Fixes #245**
- **`chore(skf-setup): align secondary references to ccc identity + autonomy gate`** — Two stale phrasings that drifted out of sync with the new contracts: `src/knowledge/ccc-bridge.md` §status() step 1 was missing the identity-marker requirement; SKILL.md Invocation Contract `Inputs` row still carried "fully autonomous" qualifier. Kept separate from the issue-bound commits so those stay surgical.

### Cross-cutting impact review

- No tests reference `"Fully autonomous"`, `"Binary existence"`, or any of the changed phrasings.
- Other `ccc --help` call-sites (`progressive-capability.md:40`, `tool-resolution.md:13`) only show the command name in summary tables — no behavioural assertion to update.
- Other `qmd collection list` consumer (`skf-brief-skill/step-05:131`) runs it for single-name verification, not enumeration — not affected by the namespace filter.
- Namespace filter is non-breaking: existing producers (`skf-brief-skill`, `skf-create-skill`) already use the suffix convention being filtered on (verified against `qmd-registry.md` § Collection Types).

## Test plan

- [x] CI green on `quality.yaml` (Linux + Windows matrix)
- [x] On a host where `ccc` is shadowed by an unrelated alias, setup records `{ccc: false}` instead of pulling the workflow into Forge+ tier
- [x] On a Deep-tier host with foreign QMD collections present, step-03 §3 enumerates only `*-brief|-temporal|-docs|-extraction` candidates in the orphan prompt
- [x] With `--headless`, step-03 §4 logs `Auto-decision (headless): kept N orphaned forge collection(s)` and never displays the prompt

Fixes #243
Fixes #244
Fixes #245