### PR TITLE
polish(skf-setup): apply quality-analysis themes 2-5

### DIFF
--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -29,7 +29,7 @@ These rules apply to every step in this workflow:
 | # | Step | File | Auto-proceed |
 |---|------|------|--------------|
 | 1 | Detect Tools & Set Tier | steps-c/step-01-detect-and-tier.md | Yes |
-| 1b | CCC Index | steps-c/step-01b-ccc-index.md | Yes |
+| 1b | CCC Index (only when ccc is available) | steps-c/step-01b-ccc-index.md | Yes |
 | 2 | Write Config | steps-c/step-02-write-config.md | Yes |
 | 3 | QMD + CCC Registry Hygiene | steps-c/step-03-auto-index.md | Yes |
 | 4 | Report | steps-c/step-04-report.md | Yes |

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -40,9 +40,11 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | (none) |
+| **Flags** | `--headless` / `-H` (skip prompts, auto-resolve gates to defaults); `--require-tier=<Quick\|Forge\|Forge+\|Deep>` (halt with failure if calculated tier does not satisfy the requirement) |
 | **Gates** | One optional: orphaned QMD collection removal (step 3, Deep tier only; default: Keep) |
 | **Outputs** | `forger-sidecar/forge-tier.yaml`, `forger-sidecar/preferences.yaml`, `{forge_data_folder}/`; when ccc is available, `.cocoindex_code/settings.yml` (exclusion patterns merged) and the project ccc index |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. step-04 emits a single-line `SKF_SETUP_RESULT_JSON: {…}` envelope after the human-readable banner so pipelines can parse the outcome without reading forge-tier.yaml. Schema documented in `steps-c/step-04-report.md` §4. |
+| **Failure modes** | `--require-tier` not satisfied → step-04 prints a "REQUIRED TIER NOT MET" block, the JSON envelope sets `"require_tier_satisfied": false`, and the workflow halts before step-05. |
 
 ## On Activation
 
@@ -52,4 +54,6 @@ These rules apply to every step in this workflow:
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
-3. Load, read the full file, and then execute `./steps-c/step-01-detect-and-tier.md` to begin the workflow.
+3. **Resolve `{require_tier}`**: parse `--require-tier=<value>` from the invocation arguments. Accept exactly `Quick`, `Forge`, `Forge+`, or `Deep` (case-sensitive). If absent or unparseable, leave as null (no tier requirement).
+
+4. Load, read the full file, and then execute `./steps-c/step-01-detect-and-tier.md` to begin the workflow.

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -7,7 +7,7 @@ description: Initialize forge environment, detect tools, and set capability tier
 
 ## Overview
 
-Initializes the forge environment by detecting available tools, determining the capability tier (Quick/Forge/Forge+/Deep), writing persistent configuration, and optionally indexing the project for deep search. The workflow is autonomous with one optional gate — orphaned QMD collection removal in step 3 (Deep tier only; default action: Keep) — which auto-resolves to the default when `{headless_mode}` is true.
+Initializes the forge environment by detecting available tools, determining the capability tier (Quick/Forge/Forge+/Deep), and writing persistent configuration to `_bmad/_memory/forger-sidecar/`. When `ccc` (cocoindex-code) is available, also augments `.cocoindex_code/settings.yml` with SKF exclusion patterns and creates or refreshes the project's semantic-search index. On Deep tier, reconciles the QMD collection registry; whenever ccc is available, reconciles the CCC index registry as well. The workflow is autonomous with one optional gate — orphaned QMD collection removal in step 3 (Deep tier only; default action: Keep) — which auto-resolves to the default when `{headless_mode}` is true.
 
 ## Role
 
@@ -31,7 +31,7 @@ These rules apply to every step in this workflow:
 | 1 | Detect Tools & Set Tier | steps-c/step-01-detect-and-tier.md | Yes |
 | 1b | CCC Index | steps-c/step-01b-ccc-index.md | Yes |
 | 2 | Write Config | steps-c/step-02-write-config.md | Yes |
-| 3 | QMD Hygiene | steps-c/step-03-auto-index.md | Yes |
+| 3 | QMD + CCC Registry Hygiene | steps-c/step-03-auto-index.md | Yes |
 | 4 | Report | steps-c/step-04-report.md | Yes |
 | 5 | Workflow Health Check | steps-c/step-05-health-check.md | Yes |
 
@@ -41,7 +41,7 @@ These rules apply to every step in this workflow:
 |--------|--------|
 | **Inputs** | (none) |
 | **Gates** | One optional: orphaned QMD collection removal (step 3, Deep tier only; default: Keep) |
-| **Outputs** | forge-tier.yaml, preferences.yaml, forge-data directories |
+| **Outputs** | `forger-sidecar/forge-tier.yaml`, `forger-sidecar/preferences.yaml`, `{forge_data_folder}/`; when ccc is available, `.cocoindex_code/settings.yml` (exclusion patterns merged) and the project ccc index |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
 
 ## On Activation

--- a/src/skf-setup/references/tier-rules.md
+++ b/src/skf-setup/references/tier-rules.md
@@ -7,7 +7,7 @@
 | ast-grep | `ast-grep --version` | Returns version string without error |
 | gh | `gh --version` | Returns version string without error |
 | qmd | `qmd status` | Returns status indicating initialized and operational |
-| ccc | Step A: `ccc --help` Step B: `ccc doctor` | Step A: exits 0 AND help output contains the `CocoIndex Code` identity marker (rejects unrelated `ccc`-named binaries shadowing PATH, e.g. an alias to `code2prompt`). Step B: daemon running, version string, model check OK |
+| ccc | Step A: `ccc --help` Step B: `ccc doctor` | Step A: exits 0 AND help output identifies the binary as cocoindex-code. Step B: daemon healthy. See `steps-c/step-01-detect-and-tier.md` §7 for the full identity-marker procedure. |
 
 **Important:** Use verification commands, not existence checks (`which`, `command -v`). A tool must be functional, not just present on PATH. For daemon-based tools (ccc), verify both binary identity and daemon health — a binary with the right name but the wrong implementation is a false positive, not a tool.
 

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -17,8 +17,6 @@ Verify availability of the four forge tools (ast-grep, gh, qmd, ccc), read any e
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Tier Rules
 
 Load and read {tierRulesData} for the tool detection commands and tier calculation logic.
@@ -95,18 +93,5 @@ ccc availability gates the Forge+ tier and enhances Deep tier when present.
 
 ### 9. Auto-Proceed
 
-"**Proceeding to CCC index check...**"
-
-#### Menu Handling Logic:
-
-- After tier calculation is complete, immediately load, read entire file, then execute {nextStepFile}
-
-#### EXECUTION RULES:
-
-- This is an auto-proceed step with no user choices
-- Proceed directly to next step after detection and calculation
-
-## CRITICAL STEP COMPLETION NOTE
-
-ONLY WHEN all 4 core tools have been verified, optional security scan checked, and the tier calculated will you load and read fully `{nextStepFile}` to execute the CCC index check step.
+After all 4 core tools have been verified, the optional security scan checked, and the tier calculated, display "**Proceeding to CCC index check...**", then load `{nextStepFile}`, read it fully, and execute it.
 

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -89,7 +89,7 @@ ccc availability gates the Forge+ tier and enhances Deep tier when present.
 - `{ast_grep}` true (regardless of ccc/gh/qmd) → **Forge**
 - Otherwise → **Quick**
 
-**If `{tier_override}` is set but invalid:** ignore it, use detected tier, flag for warning in report.
+**If `{tier_override}` is set but invalid (any value other than the case-sensitive `Quick`, `Forge`, `Forge+`, or `Deep`):** ignore it, use detected tier. Set `{tier_override_invalid: true}` and `{tier_override_invalid_value: <the bad value>}` in context for step-04 reporting.
 
 ### 9. Auto-Proceed
 

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -91,6 +91,24 @@ ccc availability gates the Forge+ tier and enhances Deep tier when present.
 
 **If `{tier_override}` is set but invalid (any value other than the case-sensitive `Quick`, `Forge`, `Forge+`, or `Deep`):** ignore it, use detected tier. Set `{tier_override_invalid: true}` and `{tier_override_invalid_value: <the bad value>}` in context for step-04 reporting.
 
+### 8b. Evaluate `--require-tier` (when set)
+
+If `{require_tier}` is set (resolved in On Activation), check whether the available tools satisfy the requested tier — independent of which tier was *named* — using the tool prerequisites from `{tierRulesData}`:
+
+- `Quick` — always satisfied.
+- `Forge` — satisfied iff `{ast_grep}` is true.
+- `Forge+` — satisfied iff `{ast_grep}` AND `{ccc}` are both true.
+- `Deep` — satisfied iff `{ast_grep}` AND `{gh_cli}` AND `{qmd}` are all true.
+
+This is a tool-prerequisite check, not a tier-name comparison. Deep does not subsume Forge+ (Deep does not require ccc), so a `Deep` calculation with no ccc still fails `--require-tier=Forge+`.
+
+Set the following context flags for step-04:
+
+- `{require_tier_satisfied: true|false}`
+- `{require_tier_failure_missing_tools: <comma-separated list of missing tools, e.g. "gh, qmd">}` (only when not satisfied)
+
+If `{require_tier}` is null (not set), set `{require_tier_satisfied: null}` so step-04 knows to skip the failure block entirely.
+
 ### 9. Auto-Proceed
 
 After all 4 core tools have been verified, the optional security scan checked, and the tier calculated, display "**Proceeding to CCC index check...**", then load `{nextStepFile}`, read it fully, and execute it.

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -71,8 +71,8 @@ If `{settings_yml_existed}` is true (from a previous `ccc init` run):
 
 1. Read `settings.yml`
 2. For each pattern in `{ccc_exclude_patterns}`: if the pattern is NOT already present in `exclude_patterns`, append it and set `{exclusions_changed: true}`
-3. If `{exclusions_changed}`: write the updated `settings.yml` back, set `{needs_reindex: true}` (new exclusions require re-indexing), display: "**CCC exclusions configured:** {count} SKF patterns applied to .cocoindex_code/settings.yml"
-4. If no new patterns needed: display nothing (exclusions already configured)
+3. If `{exclusions_changed}`: write the updated `settings.yml` back, set `{needs_reindex: true}` (new exclusions require re-indexing), set `{settings_yml_written: true}` and `{settings_yml_patterns_added: count}` for step-04 reporting, display: "**CCC exclusions configured:** {count} SKF patterns applied to .cocoindex_code/settings.yml"
+4. If no new patterns needed: display nothing (exclusions already configured); set `{settings_yml_written: false}`
 
 This preserves any existing user customizations and default exclusions while ensuring SKF directories are filtered out.
 
@@ -104,8 +104,8 @@ ccc init
 If `{settings_yml_existed}` is false (first-time setup — `ccc init` just created it), apply exclusions now:
 
 1. Read `{project-root}/.cocoindex_code/settings.yml` (created by `ccc init`)
-2. For each pattern in `{ccc_exclude_patterns}`: if the pattern is NOT already present in `exclude_patterns`, append it
-3. Write the updated `settings.yml` back
+2. For each pattern in `{ccc_exclude_patterns}`: if the pattern is NOT already present in `exclude_patterns`, append it (track `{count}` of patterns added)
+3. Write the updated `settings.yml` back. Set `{settings_yml_written: true}` and `{settings_yml_patterns_added: count}` for step-04 reporting.
 4. Display: "**CCC exclusions configured:** {count} SKF patterns applied to .cocoindex_code/settings.yml"
 
 Then run:

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -19,8 +19,6 @@ For Quick and Forge tiers, or when ccc is unavailable, skip silently and proceed
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Eligibility
 
 Read `{ccc}` from step-01 context.
@@ -129,18 +127,5 @@ ccc index
 
 ### 4. Auto-Proceed
 
-"**Proceeding to write configuration...**"
-
-#### Menu Handling Logic:
-
-- After ccc index check completes (or is skipped), immediately load, read entire file, then execute {nextStepFile}
-
-#### EXECUTION RULES:
-
-- This is an auto-proceed step with no user choices
-- Proceed directly to next step after ccc index verification
-
-## CRITICAL STEP COMPLETION NOTE
-
-ONLY WHEN ccc index verification is complete (or step is skipped for ccc unavailable) will you load and read fully `{nextStepFile}` to execute the configuration write step.
+After ccc index verification is complete (or skipped because ccc is unavailable), display "**Proceeding to write configuration...**", then load `{nextStepFile}`, read it fully, and execute it.
 

--- a/src/skf-setup/steps-c/step-02-write-config.md
+++ b/src/skf-setup/steps-c/step-02-write-config.md
@@ -95,12 +95,14 @@ compact_greeting: false
 
 **If it DOES exist:** Do not modify. Preserve entirely.
 
+Store `{preferences_yaml_created: true|false}` in context (true when this run created the file, false when it pre-existed). step-04 uses this flag in the "Files written" disclosure.
+
 ### 3. Ensure forge-data/ Directory
 
 Check if `{forge_data_folder}` directory exists:
 
-- If missing: create it
-- If exists: skip silently
+- If missing: create it. Store `{forge_data_dir_created: true}` in context.
+- If exists: skip silently. Store `{forge_data_dir_created: false}` in context.
 
 ### 4. Auto-Proceed
 

--- a/src/skf-setup/steps-c/step-02-write-config.md
+++ b/src/skf-setup/steps-c/step-02-write-config.md
@@ -17,8 +17,6 @@ Write the detected tool availability and calculated tier to forge-tier.yaml, cre
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Write forge-tier.yaml
 
 Write to `{project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml`:
@@ -106,18 +104,5 @@ Check if `{forge_data_folder}` directory exists:
 
 ### 4. Auto-Proceed
 
-"**Proceeding to QMD collection hygiene...**"
-
-#### Menu Handling Logic:
-
-- After all file operations complete successfully, immediately load, read entire file, then execute {nextStepFile}
-
-#### EXECUTION RULES:
-
-- This is an auto-proceed step with no user choices
-- Proceed directly to next step after configuration is written
-
-## CRITICAL STEP COMPLETION NOTE
-
-ONLY WHEN forge-tier.yaml has been written successfully and preferences.yaml exists (created or pre-existing) will you load and read fully `{nextStepFile}` to execute the QMD hygiene step.
+After forge-tier.yaml has been written successfully and preferences.yaml exists (created or pre-existing), display "**Proceeding to QMD collection hygiene...**", then load `{nextStepFile}`, read it fully, and execute it.
 

--- a/src/skf-setup/steps-c/step-03-auto-index.md
+++ b/src/skf-setup/steps-c/step-03-auto-index.md
@@ -20,8 +20,6 @@ For Quick and Forge tiers, skip silently and proceed (QMD is not available at th
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Tier
 
 Read `{calculated_tier}` from context.
@@ -146,19 +144,5 @@ Store in context for step-04 reporting:
 {ccc_registry_stale_cleaned: count}
 ```
 
-"**Proceeding to forge status report...**"
-
-#### Menu Handling Logic:
-
-- After hygiene completes (or is skipped), immediately load, read entire file, then execute {nextStepFile}
-
-#### EXECUTION RULES:
-
-- This step has one optional user interaction (orphan removal prompt)
-- If no orphans found, this is an auto-proceed step
-- Proceed directly to next step after hygiene or skip
-
-## CRITICAL STEP COMPLETION NOTE
-
-ONLY WHEN the hygiene check has been performed (or skipped for non-Deep tiers) will you load and read fully `{nextStepFile}` to execute the report step.
+After the hygiene check has been performed (or skipped for non-Deep tiers), display "**Proceeding to forge status report...**", then load `{nextStepFile}`, read it fully, and execute it.
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -19,8 +19,6 @@ Display the forge status report with positive capability framing and report tier
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Capability Descriptions
 
 Load and read {tierRulesData} for the tier capability descriptions and re-run messages.
@@ -84,9 +82,5 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 
 ### 3. Chain to Health Check
 
-ONLY WHEN the forge status report has been displayed will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.
-
-## CRITICAL STEP COMPLETION NOTE
-
-This step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the setup workflow is fully done.
+After the forge status report has been displayed, load `{nextStepFile}`, read it fully, and execute it. The health-check step is the true terminal step — do not stop here even though the report reads as final. step-05 in turn delegates to `shared/health-check.md`; after that returns, the setup workflow is fully done.
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -37,6 +37,15 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 
   Tools Detected:
   {for each tool that is available, show: tool name — version}
+  {if no tools are available: (none yet — see "Climb to next tier" below)}
+
+  {if calculated_tier is not Deep:}
+  Climb to next tier:
+  {if not tools.ast_grep: - Install ast-grep (https://ast-grep.github.io) — unlocks AST-backed code analysis (Forge tier)}
+  {if tools.ast_grep and not tools.ccc: - Install cocoindex-code (https://github.com/cocoindex-io/cocoindex-code) — adds semantic-guided precision compilation (Forge+ tier)}
+  {if tools.ast_grep and not tools.gh_cli: - Install GitHub CLI (https://cli.github.com) — required for Deep tier (cross-repository synthesis)}
+  {if tools.ast_grep and not tools.qmd: - Install qmd (https://github.com/tobi/qmd) — required for Deep tier (knowledge search)}
+  {end if}
 
   {if hygiene_result is "completed":}
   QMD Registry:
@@ -78,6 +87,10 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 
 {if tier_override is active:}
   Note: Tier override active (set in preferences.yaml)
+
+{if tier_override_invalid is true:}
+  Note: tier_override value "{tier_override_invalid_value}" in preferences.yaml is not valid.
+        Valid values are case-sensitive: Quick, Forge, Forge+, Deep. Using detected tier {calculated_tier}.
 
 {if re-run with tier change:}
   {appropriate upgrade/downgrade message from tier-rules.md}

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -61,6 +61,21 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
   {if ccc_index_result is "failed": indexing failed — semantic discovery unavailable this session}
   {end if}
 
+  Files written this run:
+  - forge-tier.yaml — {project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml
+  {if preferences_yaml_created is true:}
+  - preferences.yaml — {project-root}/_bmad/_memory/forger-sidecar/preferences.yaml (first-run defaults)
+  {end if}
+  {if forge_data_dir_created is true:}
+  - {forge_data_folder}/ (directory created)
+  {end if}
+  {if settings_yml_written is true:}
+  - .cocoindex_code/settings.yml — {project-root}/.cocoindex_code/settings.yml ({settings_yml_patterns_added} SKF exclusion pattern(s) merged)
+  {end if}
+  {if ccc_index_result is "created":}
+  - .cocoindex_code/ ccc index — {ccc_file_count} files indexed
+  {end if}
+
 {if tier_override is active:}
   Note: Tier override active (set in preferences.yaml)
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -108,7 +108,57 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 - Do NOT list unavailable tools
 - Do NOT show a "missing" column or section
 
-### 3. Chain to Health Check
+### 3. Display Required-Tier Failure Block (when applicable)
 
-After the forge status report has been displayed, load `{nextStepFile}`, read it fully, and execute it. The health-check step is the true terminal step — do not stop here even though the report reads as final. step-05 in turn delegates to `shared/health-check.md`; after that returns, the setup workflow is fully done.
+If `{require_tier_satisfied}` is `false`, display this block immediately after the status report and BEFORE the JSON envelope:
+
+```
+═══════════════════════════════════════
+  REQUIRED TIER NOT MET
+═══════════════════════════════════════
+
+  Required:  {require_tier}
+  Detected:  {calculated_tier}
+  Missing:   {require_tier_failure_missing_tools}
+
+  Install the missing tool(s) and re-run, or relax `--require-tier`.
+  See "Climb to next tier" above for install URLs.
+═══════════════════════════════════════
+```
+
+This block exists to make pipeline failures visible without the operator parsing the JSON envelope.
+
+### 4. Emit Headless JSON Envelope (when `{headless_mode}` is true)
+
+When `{headless_mode}` is `true`, emit a single line at the end of step-04's output (after the human-readable banner and any required-tier failure block) using the literal prefix `SKF_SETUP_RESULT_JSON: ` followed by a one-line JSON document. This lets a CI pipeline grep one line out of the workflow log without parsing ASCII-art and without racing the forge-tier.yaml writer.
+
+**Schema (one line, no embedded newlines):**
+
+```json
+{
+  "skf_setup": {
+    "tier": "Quick|Forge|Forge+|Deep",
+    "tools": {"ast_grep": true|false, "gh_cli": true|false, "qmd": true|false, "ccc": true|false},
+    "config_path": "{absolute path to forge-tier.yaml}",
+    "ccc_index": {"status": "fresh|created|failed|none", "indexed_path": "{abs}|null", "file_count": <int>|null},
+    "files_written": ["forge-tier.yaml", "preferences.yaml", "settings.yml", "ccc_index"],
+    "tier_override_active": true|false,
+    "tier_override_invalid": true|false,
+    "require_tier_satisfied": true|false|null,
+    "warnings": ["..."]
+  }
+}
+```
+
+**Field rules:**
+
+- `files_written` — include only the keys whose write actually occurred this run. Always includes `"forge-tier.yaml"`. Includes `"preferences.yaml"` only when `{preferences_yaml_created}` is true. Includes `"settings.yml"` only when `{settings_yml_written}` is true. Includes `"ccc_index"` only when `{ccc_index_result}` is `"created"`.
+- `require_tier_satisfied` — `null` when `--require-tier` was not set; otherwise the boolean from §3.
+- `warnings` — collect any non-fatal anomalies surfaced during the run (e.g. `"tier_override invalid: <value>"`, `"qmd_unavailable"`, `"ccc indexing failed"`). Empty array when none.
+
+When `{headless_mode}` is `false`, do NOT emit the envelope — interactive runs read the human-readable banner.
+
+### 5. Chain to Health Check
+
+After the forge status report (and any failure block + JSON envelope) has been displayed, load `{nextStepFile}`, read it fully, and execute it — UNLESS `{require_tier_satisfied}` is `false`, in which case halt the workflow here without chaining to step-05. The health-check step is the true terminal step on success — do not stop after the report on a passing run even though it reads as final. step-05 in turn delegates to `shared/health-check.md`; after that returns, the setup workflow is fully done.
 


### PR DESCRIPTION
## Summary

Applies four of the seven quality-analysis themes for `src/skf-setup/` (analysis report at `skills/reports/skf-setup/quality-analysis/2026-04-27T081141/`). Each theme is a standalone commit. Full local `npm run quality` passed on every commit via husky pre-commit. Net diff: **+115 / -80 lines** across 7 files.

### Commits

- **`refactor(skf-setup): trim repeated boilerplate across step files`** — Removes three patterns of defensive padding repeated identically across the five non-delegating step files: the per-step `**CRITICAL:** Follow this sequence exactly...` line (already covered by SKILL.md Workflow Rules), the trailing `## CRITICAL STEP COMPLETION NOTE` blocks that exact-restated the in-section Auto-Proceed paragraph immediately above them, and the `#### Menu Handling Logic` / `#### EXECUTION RULES` sub-headers in non-menu steps. Net -67 lines. The load-bearing "do not stop at the report — chain to step-05" warning in step-04 §3 is preserved. **Resolves Theme #2 M1, M2, M3.**
- **`refactor(skf-setup): consolidate ccc identity-marker reference to a pointer`** — `references/tier-rules.md` row for ccc restated the full identity-marker procedure that already lives in step-01 §7. Shrunk to a one-line summary + pointer; step-01 is the sole source of truth. **Resolves Theme #2 M4.**
- **`docs(skf-setup): expand SKILL.md scope and add files-written disclosure`** — SKILL.md Overview previously omitted step-01b's `.cocoindex_code/settings.yml` mutation and step-03 §5b's CCC index registry hygiene. Overview, Stages row, and Outputs row now name them explicitly. step-04 gains a "Files written this run" section listing absolute paths of every file mutated, conditional on the actual writes. step-02 and step-01b store small flags (`{preferences_yaml_created}`, `{forge_data_dir_created}`, `{settings_yml_written}`, `{settings_yml_patterns_added}`) feeding the conditional disclosure. **Resolves Theme #3 cohesion M1, M2, enhancement #4.**
- **`feat(skf-setup): close tier communication gaps in status report`** — Five related findings: dead-end Quick tier with no climb hint, empty "Tools Detected:" looking like a bug, invalid `tier_override` warning declared but never displayed, undocumented case-sensitivity contract, undocumented 1b conditional sub-stage. step-04 now renders a "Climb to next tier" block when below Deep (only suggests installs that actually move the user forward, with install URLs and "what this unlocks" framing — keeps positive-framing rule); empty Tools Detected gets a placeholder; step-01 §8 sets explicit `{tier_override_invalid}` / `{tier_override_invalid_value}` flags consumed by a matching step-04 branch; SKILL.md Stages row 1b annotated as conditional. **Resolves Theme #4 enhancement #1, #10, #12, cohesion L1, L5.**
- **`feat(skf-setup): add headless JSON envelope and --require-tier enforcement`** — Closes the two pipeline-grade gaps that left skf-setup at 95% headless-ready. step-04 §4 emits a single-line `SKF_SETUP_RESULT_JSON: {…}` envelope after the human-readable banner whenever `{headless_mode}` is true, with tier, per-tool availability, absolute config path, ccc index state, files actually written, override status, and a warnings array. SKILL.md Invocation Contract documents the new `--require-tier=<tier>` flag; On Activation §3 parses it; step-01 §8b evaluates with a tool-prerequisite check (Deep does NOT subsume Forge+ — Deep doesn't require ccc); step-04 §3 prints a "REQUIRED TIER NOT MET" block, §5 halts the workflow before step-05 in the failure path so a pipeline observer sees a clean stop. **Resolves Theme #5 enhancement #3 + headless assessment.**

## Deferred (intentional)

- **Theme #5 enhancement #5 (`--dry-run` mode)** — Implementation touches every write step (step-01b §3, step-02 §1-§3, step-03 §4-§5b) and risks partial-state behaviour if any step skips a write a downstream step assumes. Documenting a flag that does not work would be worse UX than not mentioning it. Tracked as a separate follow-up PR.
- **Themes #6 and #7** (defensive write-failure handling, gh/SNYK depth checks) — low-severity findings, kept out of this PR to stay focused on documentation/UX themes. Easy follow-up.
- **Theme #1 — Intelligence Placement** (two consolidated Python scripts replacing ~70% of step-01 prose) — high-severity but medium-effort. Worth a `Plan` pass before coding. Separate PR.

## Test plan

- [x] CI green on `quality.yaml` (Linux + Windows matrix)
- [x] First-time Quick-tier run shows the climb hint with ast-grep listed first; "Tools Detected:" shows the placeholder rather than appearing empty
- [x] `--require-tier=Deep` on a Forge tier project produces the REQUIRED TIER NOT MET block, halts before step-05, and (with `--headless`) the JSON envelope reports `"require_tier_satisfied": false`
- [x] `--require-tier=Forge+` on a Deep tier project WITHOUT ccc fails (verifies Deep does not subsume Forge+)
- [x] Headless run produces a single `SKF_SETUP_RESULT_JSON: {...}` line after the banner; interactive run does not emit it
- [x] Setting `tier_override: forge+` (lowercase) in preferences.yaml triggers the invalid-override warning naming the bad value