### PR TITLE
polish(skf-setup): apply quality re-scan themes 2-5 (Excellent → polish)

### DIFF
--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -7,7 +7,7 @@ description: Initialize forge environment, detect tools, and set capability tier
 
 ## Overview
 
-Initializes the forge environment by detecting available tools, determining the capability tier (Quick/Forge/Forge+/Deep), and writing persistent configuration to `_bmad/_memory/forger-sidecar/`. When `ccc` (cocoindex-code) is available, also augments `.cocoindex_code/settings.yml` with SKF exclusion patterns and creates or refreshes the project's semantic-search index. On Deep tier, reconciles the QMD collection registry; whenever ccc is available, reconciles the CCC index registry as well. The workflow is autonomous with one optional gate — orphaned QMD collection removal in step 3 (Deep tier only; default action: Keep) — which auto-resolves to the default when `{headless_mode}` is true.
+Initializes the forge environment by detecting available tools, determining the capability tier (Quick/Forge/Forge+/Deep), and writing persistent configuration to `{project-root}/_bmad/_memory/forger-sidecar/`. When `ccc` (cocoindex-code) is available, also augments `.cocoindex_code/settings.yml` with SKF exclusion patterns and creates or refreshes the project's semantic-search index. On Deep tier, reconciles the QMD collection registry; whenever ccc is available, reconciles the CCC index registry as well. The workflow is autonomous with one optional gate — orphaned QMD collection removal in step 3 (Deep tier only; default action: Keep) — which auto-resolves to the default when `{headless_mode}` is true.
 
 ## Role
 

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -45,6 +45,7 @@ These rules apply to every step in this workflow:
 | **Outputs** | `forger-sidecar/forge-tier.yaml`, `forger-sidecar/preferences.yaml`, `{forge_data_folder}/`; when ccc is available, `.cocoindex_code/settings.yml` (exclusion patterns merged) and the project ccc index |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. step-04 emits a single-line `SKF_SETUP_RESULT_JSON: {…}` envelope after the human-readable banner so pipelines can parse the outcome without reading forge-tier.yaml. Schema documented in `steps-c/step-04-report.md` §4. |
 | **Failure modes** | `--require-tier` not satisfied → step-04 prints a "REQUIRED TIER NOT MET" block, the JSON envelope sets `"require_tier_satisfied": false`, and the workflow halts before step-05. |
+| **Exit codes** | The workflow runs as an LLM-driven sequence rather than a CLI process, so "exit code" describes the agent's terminal state for a calling pipeline that reads `SKF_SETUP_RESULT_JSON`. **0 — success** (no JSON `error` field, all writes completed, `require_tier_satisfied` is `true` or `null`). **1 — required-tier failure** (`require_tier_satisfied` is `false`; envelope still emitted with full state for diagnosis). **2 — write failure** (forge-tier.yaml or preferences.yaml could not be written; envelope `error` field names the path and reason). Pipelines should branch on the JSON `require_tier_satisfied` and `error` fields rather than process exit codes. |
 
 ## On Activation
 

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -24,12 +24,24 @@ Load and read {tierRulesData} for the tool detection commands and tier calculati
 ### 2. Check for Existing Configuration (Re-run Detection)
 
 **Read existing forge-tier.yaml** at `{project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml`:
-- If exists: store the current `tier` value as `{previous_tier}` and `tier_detected_at` as `{previous_detection_date}`
-- If not found: set `{previous_tier}` to null (first run)
+- If exists: store the current `tier` value as `{previous_tier}`, `tier_detected_at` as `{previous_detection_date}`, and the `tools` map as `{previous_tools}` (for tool-set delta detection in step-04 — same-tier re-runs surface newly-installed tools that didn't change the tier).
+- If not found: set `{previous_tier}` to null and `{previous_tools}` to an empty map (first run).
 
 **Read existing preferences.yaml** at `{project-root}/_bmad/_memory/forger-sidecar/preferences.yaml`:
 - If exists: check for `tier_override` value
 - If not found: set `{tier_override}` to null
+
+**First-run preamble** — when `{previous_tier}` is null AND `{headless_mode}` is `false`, display this preamble before continuing to tool detection so the user knows what is about to happen and can abort cleanly with Esc / Ctrl+C before any writes:
+
+"**About to set up the forge.** This workflow will:
+
+- Detect available tools (ast-grep, gh, qmd, ccc) — read-only probes only
+- Write `{project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml` (capability tier + tool state)
+- Write `{project-root}/_bmad/_memory/forger-sidecar/preferences.yaml` (first-run defaults)
+- Create `{forge_data_folder}/` if missing
+- When ccc is available: augment `{project-root}/.cocoindex_code/settings.yml` with SKF exclusion patterns, then create or refresh the project ccc index
+
+Press Esc or Ctrl+C now if this isn't the right project — no files have been written yet."
 
 ### 3. Verify Tool: ast-grep
 

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -59,10 +59,17 @@ Run: `gh --version`
 
 ### 5. Verify Tool: qmd
 
-Run: `qmd status`
+**Step A — Binary identity:** Run `qmd --version` (or `qmd --help` if --version is unsupported).
 
-- If succeeds and indicates operational: record `{qmd: true}`
-- If fails or indicates not initialized: record `{qmd: false}`
+- If exits 0: binary present. Continue to Step B.
+- If fails (command not found or error): record `{qmd: false, qmd_status: "absent"}`. Skip Step B. The climb hint will say "Install qmd".
+
+**Step B — Daemon health:** Run `qmd status`.
+
+- If succeeds and indicates operational: record `{qmd: true, qmd_status: "healthy"}`.
+- If fails or indicates not initialized: record `{qmd: false, qmd_status: "daemon_stopped"}`. The climb hint will say "qmd is installed but the daemon is stopped — run `qmd start` (or your distribution's qmd service command) and re-run setup", which is materially different guidance from "install qmd".
+
+This two-step probe matches the ccc verification pattern (§7) — a tool that exists on disk but cannot serve requests is operationally absent for tier calculation but addressable with different remediation than a tool that was never installed.
 
 ### 6. Check Optional: Security Scan (SNYK_TOKEN)
 
@@ -94,6 +101,7 @@ ccc availability gates the Forge+ tier and enhances Deep tier when present.
 **If `{tier_override}` is set and valid (Quick, Forge, Forge+, or Deep):**
 - Use `{tier_override}` as `{calculated_tier}`
 - Note that override is active for the report step
+- **Sanity-check tool prerequisites for the overridden tier** using the same rules as `--require-tier` (see §8b): Quick = always; Forge = needs ast-grep; Forge+ = needs ast-grep + ccc; Deep = needs ast-grep + gh + qmd. If the underlying tools are NOT present, set `{tier_override_unsafe: true}` and `{tier_override_unsafe_missing: <comma-separated missing tool list>}` for step-04 reporting. Still apply the override — the user's intent is honored — but surface the risk so downstream skills crashing on missing qmd/gh do not look like a setup bug.
 
 **If no override, apply tier rules from {tierRulesData} in order — the first matching rule wins. Do not continue checking once a match is found:**
 - `{ast_grep}` AND `{gh_cli}` AND `{qmd}` all true → **Deep**

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -53,15 +53,27 @@ SKF infrastructure and output directories must be excluded from the CCC index �
 
 1. Use `{skills_output_folder}` and `{forge_data_folder}` from the workflow activation context (resolved in On Activation from `{project-root}/_bmad/skf/config.yaml`).
 
-2. Assemble the exclusion patterns using `**/` prefix format (matching `.cocoindex_code/settings.yml` convention — e.g., `**/node_modules`):
+2. Assemble the exclusion patterns using `**/` prefix format (matching `.cocoindex_code/settings.yml` convention — e.g., `**/node_modules`).
+
+   **Always include** these four hardcoded patterns:
    - `**/_bmad` — SKF framework module (workflows, agents, knowledge files)
    - `**/_bmad-output` — Build output artifacts
    - `**/.claude` — Claude Code configuration
    - `**/_skf-learn` — SKF learning materials
-   - `**/{skills_output_folder}` — Generated skill files (from activation context)
-   - `**/{forge_data_folder}` — Compilation workspace (from activation context)
 
-3. Store `{ccc_exclude_patterns}` in context for step-02 to write into forge-tier.yaml.
+   **Conditionally include** these two patterns from activation context, but only after **validating the source value** to avoid producing malformed globs that would silently exclude the entire repository from indexing:
+   - `**/{skills_output_folder}` — Generated skill files
+   - `**/{forge_data_folder}` — Compilation workspace
+
+   **Validation rules** — for each of `{skills_output_folder}` and `{forge_data_folder}`, before interpolating into the `**/{value}` pattern, reject the value (skip the pattern entirely) and append a warning to `{ccc_exclusion_warnings}` if any of:
+
+   - The value is empty or whitespace-only (would produce `**/` — matches every path, ccc would index nothing).
+   - The value begins with `/`, `~/`, or `./` (absolute or anchored path — produces `**//abs/path` or `**/./rel`, malformed glob).
+   - The value contains glob meta-characters (`*`, `?`, `[`) — interpolation collides with the surrounding pattern syntax.
+
+   The warning text should name the offending config key, the bad value (quoted verbatim), and the rejection reason — e.g. `"skills_output_folder is an absolute path; refused for ccc exclusion because interpolating it would produce a malformed glob — fix the value in {project-root}/_bmad/skf/config.yaml"`. Step-04 surfaces these in the JSON envelope `warnings` array.
+
+3. Store `{ccc_exclude_patterns}` (the validated list — possibly only the four always-include patterns if both config values were rejected) in context for step-02 to write into forge-tier.yaml.
 
 **Apply exclusions to settings.yml:**
 

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -108,6 +108,8 @@ If `{settings_yml_existed}` is false (first-time setup — `ccc init` just creat
 3. Write the updated `settings.yml` back. Set `{settings_yml_written: true}` and `{settings_yml_patterns_added: count}` for step-04 reporting.
 4. Display: "**CCC exclusions configured:** {count} SKF patterns applied to .cocoindex_code/settings.yml"
 
+Before invoking `ccc index`, display: "**Building semantic index — this can take several minutes on large codebases (1000+ files). Run `ccc status` in another terminal to monitor progress.**" so the user does not assume the workflow has hung during the long-running call.
+
 Then run:
 ```bash
 ccc index

--- a/src/skf-setup/steps-c/step-03-auto-index.md
+++ b/src/skf-setup/steps-c/step-03-auto-index.md
@@ -124,7 +124,8 @@ For each entry, verify the indexed path still exists on disk:
 
 **Stale** — path does not exist (source directory removed or moved):
 - Remove the stale entry from `ccc_index_registry`
-- Log: "Removed stale CCC index registry entry: {path} (path no longer exists)"
+- Log: "**WARNING:** Removed stale CCC index registry entry: {path} (path no longer exists). If you are running setup in a CI environment with ephemeral mounts, this is expected — the registry will be re-populated by `skf-create-skill` on the next run. If the path was unexpectedly missing on a developer workstation, verify the source directory is still where you expect."
+- Append the removed path to `{ccc_registry_stale_removed_paths}` (list) so step-04's JSON envelope `warnings` array surfaces them for pipeline observers.
 
 Update forge-tier.yaml with the cleaned registry.
 

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -158,22 +158,31 @@ When `{headless_mode}` is `true`, emit a single line at the end of step-04's out
 {
   "skf_setup": {
     "tier": "Quick|Forge|Forge+|Deep",
+    "previous_tier": "Quick|Forge|Forge+|Deep|null",
+    "tier_changed": true|false,
     "tools": {"ast_grep": true|false, "gh_cli": true|false, "qmd": true|false, "ccc": true|false},
+    "tools_added": ["ccc"],
+    "tools_removed": [],
     "config_path": "{absolute path to forge-tier.yaml}",
     "ccc_index": {"status": "fresh|created|failed|none", "indexed_path": "{abs}|null", "file_count": <int>|null},
     "files_written": ["forge-tier.yaml", "preferences.yaml", "settings.yml", "ccc_index"],
     "tier_override_active": true|false,
     "tier_override_invalid": true|false,
     "require_tier_satisfied": true|false|null,
-    "warnings": ["..."]
+    "warnings": ["..."],
+    "error": null
   }
 }
 ```
 
 **Field rules:**
 
-- `files_written` — include only the keys whose write actually occurred this run. Always includes `"forge-tier.yaml"`. Includes `"preferences.yaml"` only when `{preferences_yaml_created}` is true. Includes `"settings.yml"` only when `{settings_yml_written}` is true. Includes `"ccc_index"` only when `{ccc_index_result}` is `"created"`.
+- `previous_tier` — value of `{previous_tier}` from step-01 §2 (the tier read from existing forge-tier.yaml at workflow start). `null` on first runs.
+- `tier_changed` — `true` when `previous_tier` is non-null AND differs from `tier`; `false` otherwise (covers both first runs and same-tier re-runs). Lets a pipeline react to upgrades without re-reading forge-tier.yaml.
+- `tools_added` / `tools_removed` — same set deltas the human-facing same-tier re-run message displays (see §2 "Tool delta computation rules"). Empty arrays when nothing changed; on first runs `tools_added` equals the current detected tools and `tools_removed` is empty.
+- `files_written` — include only the keys whose write actually occurred this run. Always includes `"forge-tier.yaml"` on success. Includes `"preferences.yaml"` only when `{preferences_yaml_created}` is true. Includes `"settings.yml"` only when `{settings_yml_written}` is true. Includes `"ccc_index"` only when `{ccc_index_result}` is `"created"`. Empty array when a write failure halted the run before any file was written.
 - `require_tier_satisfied` — `null` when `--require-tier` was not set; otherwise the boolean from §3.
+- `error` — `null` on success; otherwise an object `{"phase": "<step name>", "path": "<file>", "reason": "<message>"}` describing the failure. Set when forge-tier.yaml or preferences.yaml could not be written (step-02 §1 / §2 halt paths). Pipelines branch on `error !== null` for "exit code 2" semantics described in SKILL.md Invocation Contract.
 - `warnings` — collect any non-fatal anomalies surfaced during the run. At minimum, fold in:
   - `"tier_override_invalid: <value>"` when `{tier_override_invalid}` is true.
   - `"tier_override_unsafe: missing <tools>"` when `{tier_override_unsafe}` is true.

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -95,13 +95,26 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 {if re-run with tier change:}
   {appropriate upgrade/downgrade message from tier-rules.md}
 
-{if re-run with same tier:}
+{if re-run with same tier and {tools_added} is empty and {tools_removed} is empty:}
   {same-tier message from tier-rules.md}
+
+{if re-run with same tier and ({tools_added} or {tools_removed} is non-empty):}
+  Tier unchanged: {calculated_tier}.
+  {if {tools_added} non-empty:} Newly detected: {comma-separated tool names from tools_added}{if ccc was added and tier is Deep: " — ccc enhances Deep tier transparently."}
+  {if {tools_removed} non-empty:} No longer detected: {comma-separated tool names from tools_removed} — re-install to restore those capabilities.
 
 ═══════════════════════════════════════
   Forge ready. {calculated_tier} tier active.
 ═══════════════════════════════════════
+
+{if {headless_mode} is false:}
+  Next: try [BS] Brief Skill to scope your first compilation target, or [QS] Quick Skill for a fast template-driven path. Already have a skill? [AS] Audit Skill drift-checks an existing skill against current sources.
 ```
+
+**Tool delta computation rules:**
+- Compute `{tools_added}` as the list of tool keys where `tools.{key}` is true now but was false (or absent) in `{previous_tools}`.
+- Compute `{tools_removed}` as the list of tool keys where `tools.{key}` is true in `{previous_tools}` but false now.
+- On a first run (`{previous_tools}` empty), `{tools_added}` equals the currently-detected tools and `{tools_removed}` is empty — but the same-tier branch does not fire on first runs (there is no previous tier to compare against), so this is not displayed in that case.
 
 **Tool display rules:**
 - Only show tools that ARE available with their version strings

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -44,7 +44,8 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
   {if not tools.ast_grep: - Install ast-grep (https://ast-grep.github.io) — unlocks AST-backed code analysis (Forge tier)}
   {if tools.ast_grep and not tools.ccc: - Install cocoindex-code (https://github.com/cocoindex-io/cocoindex-code) — adds semantic-guided precision compilation (Forge+ tier)}
   {if tools.ast_grep and not tools.gh_cli: - Install GitHub CLI (https://cli.github.com) — required for Deep tier (cross-repository synthesis)}
-  {if tools.ast_grep and not tools.qmd: - Install qmd (https://github.com/tobi/qmd) — required for Deep tier (knowledge search)}
+  {if tools.ast_grep and not tools.qmd and qmd_status is "absent": - Install qmd (https://github.com/tobi/qmd) — required for Deep tier (knowledge search)}
+  {if tools.ast_grep and not tools.qmd and qmd_status is "daemon_stopped": - Start the qmd daemon (already installed) — run `qmd start` (or your distribution's qmd service command) to unlock Deep tier (knowledge search)}
   {end if}
 
   {if hygiene_result is "completed":}
@@ -91,6 +92,12 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 {if tier_override_invalid is true:}
   Note: tier_override value "{tier_override_invalid_value}" in preferences.yaml is not valid.
         Valid values are case-sensitive: Quick, Forge, Forge+, Deep. Using detected tier {calculated_tier}.
+
+{if tier_override_unsafe is true:}
+  Warning: tier_override is forcing {calculated_tier} but the underlying tool prerequisites are not satisfied.
+           Missing: {tier_override_unsafe_missing}. The override is honored, but downstream skills that
+           rely on the missing tool(s) will fail at runtime. Install the missing tool(s) or remove
+           the override from preferences.yaml.
 
 {if re-run with tier change:}
   {appropriate upgrade/downgrade message from tier-rules.md}
@@ -167,7 +174,14 @@ When `{headless_mode}` is `true`, emit a single line at the end of step-04's out
 
 - `files_written` — include only the keys whose write actually occurred this run. Always includes `"forge-tier.yaml"`. Includes `"preferences.yaml"` only when `{preferences_yaml_created}` is true. Includes `"settings.yml"` only when `{settings_yml_written}` is true. Includes `"ccc_index"` only when `{ccc_index_result}` is `"created"`.
 - `require_tier_satisfied` — `null` when `--require-tier` was not set; otherwise the boolean from §3.
-- `warnings` — collect any non-fatal anomalies surfaced during the run (e.g. `"tier_override invalid: <value>"`, `"qmd_unavailable"`, `"ccc indexing failed"`). Empty array when none.
+- `warnings` — collect any non-fatal anomalies surfaced during the run. At minimum, fold in:
+  - `"tier_override_invalid: <value>"` when `{tier_override_invalid}` is true.
+  - `"tier_override_unsafe: missing <tools>"` when `{tier_override_unsafe}` is true.
+  - Each entry of `{ccc_exclusion_warnings}` from step-01b §2b (config-value validation rejections — empty/absolute/glob-meta).
+  - Each entry of `{ccc_registry_stale_removed_paths}` from step-03 §5b (paths the cleanup pruned, framed as `"ccc_registry_stale_removed: <path>"` so CI observers can detect ephemeral-mount churn).
+  - `"qmd_daemon_stopped"` when `{qmd_status}` is `"daemon_stopped"` (binary present, daemon not running).
+  - `"qmd_unavailable"`, `"ccc_indexing_failed"`, etc. as they occur.
+  Empty array when none.
 
 When `{headless_mode}` is `false`, do NOT emit the envelope — interactive runs read the human-readable banner.
 

--- a/src/skf-setup/steps-c/step-05-health-check.md
+++ b/src/skf-setup/steps-c/step-05-health-check.md
@@ -1,7 +1,7 @@
 ---
 # `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# (`{project-root}/_bmad/skf/` when installed, `{project-root}/src/` during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
 


### PR DESCRIPTION
## Summary

Cleanup pass on `src/skf-setup/` after the post-PR-#247 quality re-scan that lifted the grade from **Good → Excellent**. This PR resolves the four remaining medium-and-below themes (analysis report at `skills/reports/skf-setup/quality-analysis/2026-04-27T085419/`). Each theme is one commit. Full local `npm run quality` passed on every commit via husky pre-commit. Net diff: **+90 / -18 lines** across 6 files.

### Commits

- **`chore(skf-setup): qualify narrative _bmad/ references with {project-root}`** — Two narrative `_bmad/` references the path-standards lint flagged as bare: SKILL.md:10 Overview prose and step-05 frontmatter comment. Both are explanatory prose, not operative path resolution; runtime behaviour unchanged. Adding `{project-root}/` reads more precisely (an Overview sentence about where forger-sidecar lives is more useful when it lists a path the user can actually `cd` into). **Resolves Theme #5.**
- **`feat(skf-setup): close human-experience completion gaps`** — Four findings where the workflow left interactive users without signals an automated pipeline already gets after #247. step-01 §2 now displays a "what is this about to do?" preamble (listing the four mutation paths including the easy-to-miss `.cocoindex_code/settings.yml`) when a first run is detected AND the workflow is interactive. step-01 §2 also stores `{previous_tools}` so step-04 can compute `{tools_added}` / `{tools_removed}` set deltas — same-tier re-runs now surface newly-installed tools that didn't change the tier ("Newly detected: ccc — ccc enhances Deep tier transparently"). step-04 appends a one-line "Next: try [BS]/[QS]/[AS]" breadcrumb after the success banner (skipped in headless). step-01b §3 displays "Building semantic index — run `ccc status` to monitor progress" before the long-running `ccc index` call. **Resolves Theme #2.**
- **`feat(skf-setup): harden edge-cases around config values`** — Four findings clustered around unvalidated config inputs and shallow probes producing wrong-but-plausible outputs. step-01 §8 now sanity-checks the tools required for an active `tier_override` against detected tools (override is still applied, but `{tier_override_unsafe}` flag fires + step-04 warning + envelope warning surface the risk so downstream skills crashing on missing qmd/gh don't look like a setup bug). step-01b §2b validates `{skills_output_folder}` and `{forge_data_folder}` before interpolating into `**/{value}` globs (rejects empty/absolute/glob-meta values that would silently produce `**/` or `**//abs/path` and exclude the entire repo from indexing); rejected values flow into envelope `warnings` with explicit fix guidance. step-01 §5 uses a two-step probe matching the ccc pattern: `qmd --version` for binary identity, then `qmd status` for daemon health — when binary present but daemon stopped, the climb hint now says "run `qmd start`" instead of the wrong "Install qmd" message. step-03 §5b's silent ccc-registry pruning upgraded to a prominent WARNING with explicit ephemeral-mount rationale; pruned paths flow into `{ccc_registry_stale_removed_paths}` and the envelope warnings array so CI observers can detect ephemeral-mount churn. **Resolves Theme #3.**
- **`feat(skf-setup): extend headless envelope and document exit-code contract`** — Two pipeline-grade polish items. JSON envelope schema extended with `previous_tier`, `tier_changed`, `tools_added`, `tools_removed`, and `error` (null-or-object) so pipelines can react to upgrades and write failures without re-reading forge-tier.yaml. SKILL.md Invocation Contract gains an explicit Exit Codes row clarifying the envelope-based convention (the workflow runs as an LLM-driven sequence, so "exit code" describes the agent's terminal state for a calling pipeline reading `SKF_SETUP_RESULT_JSON`): 0 success, 1 require-tier failure, 2 write failure. Pipelines branch on the JSON `require_tier_satisfied` and `error` fields. **Resolves Theme #4 M4 + M5.**

## Deferred (intentional)

- **Theme #4 L1 (`--dry-run` mode)** — Carried over from PR #247's deferral. Implementation touches every write step (step-01b §3, step-02 §1-§3, step-03 §4-§5b) and partial-state edge cases (e.g. step-03 reading a forge-tier.yaml that step-02 in dry-run didn't write) deserve dedicated test coverage. Worth a focused PR rather than a cleanup-bundle ride-along.
- **Theme #1 (Intelligence Placement — five Python scripts)** — High-severity, medium-effort. Worth a `Plan` pass before coding (script API, where they live alongside `tools/validate-*.js`, test strategy, integration order). Separate PR.
- **Tooling fix to `prepass-workflow-integrity.py`** (descend into `steps-c/` to stop the 5 false-positive criticals on every skf-setup scan) — Side quest in the analyzer, not a skf-setup change. Plan to fold into the Theme #1 planning session.

## Test plan

- [x] CI green on `quality.yaml` (Linux + Windows matrix)
- [x] First-time interactive run shows the "About to set up the forge" preamble listing the four mutation paths; `--headless` first run does NOT show the preamble
- [x] On a Deep-tier host, installing ccc and re-running surfaces "Newly detected: ccc — ccc enhances Deep tier transparently" instead of the old "All previously detected tools confirmed"
- [x] Setting `tier_override: Deep` on a Quick-tier host (no tools) writes tier: Deep AND surfaces the "tier_override is forcing Deep but the underlying tool prerequisites are not satisfied" warning + envelope warning entry
- [x] Setting `skills_output_folder: ""` (empty) in config triggers an explicit `ccc_exclusion_warnings` entry naming the bad key, the rejection reason, and where to fix it; ccc index excludes only the four hardcoded patterns
- [x] Stopping the qmd daemon (binary still installed) produces "Start the qmd daemon (already installed) — run `qmd start`" climb hint instead of the install message
- [x] step-04 banner ends with the "Next: try [BS]/[QS]/[AS]" breadcrumb in interactive runs; headless run still emits no breadcrumb
- [x] Headless envelope contains the new fields `previous_tier`, `tier_changed`, `tools_added`, `tools_removed`, and `error`; first-run envelope shows `previous_tier: null`, `tier_changed: false`, `tools_added` listing the detected tools, `tools_removed: []`, `error: null`