### PR TITLE
feat(skf-setup): Theme #1 PR A — shared scripts foundation (detect-tools + forge-tier-rw)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/src/shared/scripts/skf-detect-tools.py
+++ b/src/shared/scripts/skf-detect-tools.py
@@ -1,0 +1,321 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SKF Detect Tools — Parallel tool detection + tier calculation for skf-setup.
+
+Replaces the prose-driven tool-detection sequence in `src/skf-setup/steps-c/
+step-01-detect-and-tier.md` §3-§8b with one Python invocation. Probes ast-grep,
+gh, qmd, and ccc concurrently, applies the 4-rule tier decision table (see
+`src/skf-setup/references/tier-rules.md`), evaluates --tier-override (with
+sanity check) and --require-tier (with tool-prerequisite check independent of
+the tier name), and emits one JSON document on stdout.
+
+Schema documented in DETECT_OUTPUT_SCHEMA at the bottom of this docstring.
+The output is consumed by step-01 prose, step-02 (forge-tier.yaml writer),
+and step-04 (status report + envelope).
+
+Tier rules (first match wins):
+  Deep   = ast-grep + gh-cli + qmd (all healthy)
+  Forge+ = ast-grep + ccc (regardless of gh/qmd)
+  Forge  = ast-grep
+  Quick  = otherwise
+
+CCC verification is two-step (matches step-01 §7):
+  Step A: `ccc --help` exits 0 AND output contains "CocoIndex Code" marker.
+          Rejects code2prompt-aliased-as-ccc and similar PATH shadowing.
+  Step B: `ccc doctor` succeeds (daemon healthy).
+
+QMD verification is two-step (matches step-01 §5 post-PR-#248):
+  Step A: `qmd --version` exits 0 (binary identity, falls back to --help).
+  Step B: `qmd status` succeeds (daemon healthy).
+  qmd_status: "absent" | "daemon_stopped" | "healthy" — affects climb hint.
+
+Exit codes:
+  0  detection completed (status=ok in payload; require_tier may still be
+     unsatisfied — that is a payload field, not an exit signal here)
+  1  user error (bad args)
+  2  internal error (timeout, subprocess crash that escaped the per-probe
+     guard)
+
+CLI:
+  python3 skf-detect-tools.py
+  python3 skf-detect-tools.py --tier-override Deep
+  python3 skf-detect-tools.py --require-tier Forge+
+  python3 skf-detect-tools.py --snyk-env-var SNYK_TOKEN
+
+DETECT_OUTPUT_SCHEMA (v1):
+  {
+    "status": "ok",
+    "version": "v1",
+    "tools": {
+      "ast_grep":      {"available": bool, "version": str|null},
+      "gh_cli":        {"available": bool, "version": str|null},
+      "qmd":           {"available": bool, "status": "absent"|"daemon_stopped"|"healthy",
+                        "version": str|null},
+      "ccc":           {"available": bool, "daemon": "healthy"|"stopped"|"error"|null,
+                        "version": str|null},
+      "security_scan": {"available": bool}
+    },
+    "tier": {
+      "calculated":              "Quick"|"Forge"|"Forge+"|"Deep",
+      "detected":                "Quick"|"Forge"|"Forge+"|"Deep",
+      "override_applied":        bool,
+      "override_value":          str|null,
+      "override_invalid":        bool,
+      "override_invalid_value":  str|null,
+      "override_unsafe":         bool,
+      "override_unsafe_missing": [str]
+    },
+    "require_tier": {
+      "requested":     "Quick"|"Forge"|"Forge+"|"Deep"|null,
+      "satisfied":     bool|null,
+      "missing_tools": [str]
+    }
+  }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+
+VALID_TIERS = ("Quick", "Forge", "Forge+", "Deep")
+PROBE_TIMEOUT_SEC = 8  # per-tool subprocess.run timeout
+CCC_IDENTITY_MARKER = "cocoindex code"  # case-insensitive substring
+
+
+def _die(code: int, message: str) -> None:
+    print(json.dumps({"status": "error", "message": message}), file=sys.stderr)
+    sys.exit(code)
+
+
+def _ok(payload: dict) -> None:
+    payload.setdefault("status", "ok")
+    payload.setdefault("version", "v1")
+    print(json.dumps(payload))
+
+
+def _run(cmd: list[str], timeout: int = PROBE_TIMEOUT_SEC) -> tuple[int, str, str]:
+    """Run a subprocess. Return (returncode, stdout, stderr). Never raises.
+
+    Treats every failure mode (FileNotFoundError, TimeoutExpired, OSError,
+    CalledProcessError) as a failed probe — returns rc=127 and an empty
+    stdout/stderr. Tool detection should never crash the workflow.
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return result.returncode, result.stdout or "", result.stderr or ""
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return 127, "", ""
+
+
+def _first_line(text: str) -> str | None:
+    """Return the first non-empty stripped line of `text`, or None."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def probe_ast_grep() -> dict:
+    rc, stdout, _ = _run(["ast-grep", "--version"])
+    if rc != 0:
+        return {"available": False, "version": None}
+    return {"available": True, "version": _first_line(stdout)}
+
+
+def probe_gh_cli() -> dict:
+    rc, stdout, _ = _run(["gh", "--version"])
+    if rc != 0:
+        return {"available": False, "version": None}
+    return {"available": True, "version": _first_line(stdout)}
+
+
+def probe_qmd() -> dict:
+    """Two-step probe: --version (binary identity) then status (daemon health)."""
+    rc, stdout, _ = _run(["qmd", "--version"])
+    if rc != 0:
+        # --version may not be supported on every qmd build; fall back to --help.
+        rc, stdout, _ = _run(["qmd", "--help"])
+        if rc != 0:
+            return {"available": False, "status": "absent", "version": None}
+    version = _first_line(stdout)
+
+    rc_status, _, _ = _run(["qmd", "status"])
+    if rc_status != 0:
+        return {"available": False, "status": "daemon_stopped", "version": version}
+    return {"available": True, "status": "healthy", "version": version}
+
+
+def probe_ccc() -> dict:
+    """Two-step probe: --help with identity marker, then doctor for daemon health."""
+    rc, stdout, _ = _run(["ccc", "--help"])
+    if rc != 0:
+        return {"available": False, "daemon": None, "version": None}
+    if CCC_IDENTITY_MARKER not in stdout.lower():
+        # `ccc` resolved to a foreign binary (e.g. code2prompt alias). Refuse.
+        return {"available": False, "daemon": None, "version": None}
+
+    rc_doctor, doctor_stdout, _ = _run(["ccc", "doctor"])
+    version = _first_line(doctor_stdout) or _first_line(stdout)
+    if rc_doctor == 0:
+        return {"available": True, "daemon": "healthy", "version": version}
+    # Distinguishing "stopped" from "error" requires parsing doctor output;
+    # without a documented contract, default to "error" and let the caller
+    # treat both as operational unavailability with daemon-level remediation.
+    return {"available": True, "daemon": "error", "version": version}
+
+
+def probe_security_scan(env_var: str) -> dict:
+    """Informational only — does NOT affect tier."""
+    return {"available": bool(os.environ.get(env_var, "").strip())}
+
+
+def calculate_tier(tools: dict) -> str:
+    ag = tools["ast_grep"]["available"]
+    gh = tools["gh_cli"]["available"]
+    qm = tools["qmd"]["available"]
+    cc = tools["ccc"]["available"]
+
+    if ag and gh and qm:
+        return "Deep"
+    if ag and cc:
+        return "Forge+"
+    if ag:
+        return "Forge"
+    return "Quick"
+
+
+def tier_prerequisites_met(tier: str, tools: dict) -> tuple[bool, list[str]]:
+    """Return (satisfied, missing_tools) for tier-prerequisite checks.
+
+    Used by both --tier-override sanity check and --require-tier evaluation.
+    Deep does NOT subsume Forge+ (Deep does not require ccc), so a Deep
+    calculation with no ccc still fails a Forge+ requirement.
+    """
+    needed: dict[str, str] = {
+        "Quick": {},
+        "Forge": {"ast_grep": "ast-grep"},
+        "Forge+": {"ast_grep": "ast-grep", "ccc": "ccc"},
+        "Deep": {"ast_grep": "ast-grep", "gh_cli": "gh", "qmd": "qmd"},
+    }[tier]
+    missing = [display for key, display in needed.items() if not tools[key]["available"]]
+    return (len(missing) == 0, missing)
+
+
+def detect(args: argparse.Namespace) -> dict:
+    tools: dict = {}
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futures = {
+            "ast_grep": ex.submit(probe_ast_grep),
+            "gh_cli":   ex.submit(probe_gh_cli),
+            "qmd":      ex.submit(probe_qmd),
+            "ccc":      ex.submit(probe_ccc),
+        }
+        for key, fut in futures.items():
+            tools[key] = fut.result()
+    tools["security_scan"] = probe_security_scan(args.snyk_env_var)
+
+    detected = calculate_tier(tools)
+
+    # Tier override handling
+    override_applied = False
+    override_value: str | None = None
+    override_invalid = False
+    override_invalid_value: str | None = None
+    override_unsafe = False
+    override_unsafe_missing: list[str] = []
+
+    if args.tier_override is not None:
+        if args.tier_override in VALID_TIERS:
+            override_applied = True
+            override_value = args.tier_override
+            calculated = args.tier_override
+            satisfied, missing = tier_prerequisites_met(calculated, tools)
+            if not satisfied:
+                override_unsafe = True
+                override_unsafe_missing = missing
+        else:
+            override_invalid = True
+            override_invalid_value = args.tier_override
+            calculated = detected
+    else:
+        calculated = detected
+
+    # Require-tier evaluation
+    require_satisfied: bool | None
+    require_missing: list[str] = []
+    if args.require_tier is not None:
+        if args.require_tier not in VALID_TIERS:
+            _die(1, f"--require-tier must be one of {VALID_TIERS}, got {args.require_tier!r}")
+        require_satisfied, require_missing = tier_prerequisites_met(args.require_tier, tools)
+    else:
+        require_satisfied = None
+
+    return {
+        "tools": tools,
+        "tier": {
+            "calculated": calculated,
+            "detected": detected,
+            "override_applied": override_applied,
+            "override_value": override_value,
+            "override_invalid": override_invalid,
+            "override_invalid_value": override_invalid_value,
+            "override_unsafe": override_unsafe,
+            "override_unsafe_missing": override_unsafe_missing,
+        },
+        "require_tier": {
+            "requested": args.require_tier,
+            "satisfied": require_satisfied,
+            "missing_tools": require_missing,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Detect SKF tools and calculate capability tier.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--tier-override",
+        default=None,
+        help="Force a specific tier (must be one of Quick, Forge, Forge+, Deep — case-sensitive)."
+             " Invalid values are flagged in the output rather than rejected, so step-04 can"
+             " surface the warning to the user.",
+    )
+    parser.add_argument(
+        "--require-tier",
+        default=None,
+        help="Require the calculated tier to satisfy this requirement (uses tool-prerequisite"
+             " check, not tier-name comparison — Deep does not subsume Forge+ because Deep"
+             " does not require ccc). Output reports satisfied/missing-tools; caller decides"
+             " whether to halt.",
+    )
+    parser.add_argument(
+        "--snyk-env-var",
+        default="SNYK_TOKEN",
+        help="Environment variable name to check for security-scan availability"
+             " (informational only — does NOT affect tier). Default: SNYK_TOKEN.",
+    )
+    args = parser.parse_args()
+
+    payload = detect(args)
+    _ok(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/scripts/skf-forge-tier-rw.py
+++ b/src/shared/scripts/skf-forge-tier-rw.py
@@ -1,0 +1,408 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""SKF Forge Tier RW — Read/write primitives for forger-sidecar YAML files.
+
+Replaces the prose-driven YAML emission in `src/skf-setup/steps-c/
+step-02-write-config.md` §1-§3 (and the prose-driven cleanup logic in
+step-03 §5/§5b) with one Python invocation. The script is the source
+of truth for the on-disk forge-tier.yaml schema (matching the
+canonical template at step-02-write-config.md:24-58) and guarantees
+that registry arrays are PRESERVED across rewrites — losing
+`qmd_collections` or `ccc_index_registry` would break every
+downstream skill (skf-create-skill, skf-audit-skill, skf-update-skill,
+skf-brief-skill) that reads them.
+
+Subcommands:
+
+  read          Read forge-tier.yaml and emit the parsed structure as JSON
+                on stdout. Missing-file is not an error — emits null
+                payload with status=ok so first-run callers can branch.
+
+  write-tools   Write a fresh forge-tier.yaml from a JSON context payload
+                on stdin. Preserves `qmd_collections`,
+                `ccc_index_registry`, and the user-customizable
+                `ccc_index.staleness_threshold_hours` from the existing
+                file (if any) by reading it first, then merging.
+
+  init-prefs    Create preferences.yaml with first-run defaults IF it
+                does not exist. Idempotent — refuses to overwrite an
+                existing file (preserves user customization).
+
+  clean-stale   Two cleanup operations gated by flags:
+                  --qmd-live-names a,b,c — remove qmd_collections
+                    entries whose `name` is not in the comma-separated
+                    live-names list. Caller computes liveness via
+                    `qmd collection list` (or skf-qmd-classify-
+                    collections.py once that ships in PR B).
+                  --prune-missing-ccc-paths — remove ccc_index_registry
+                    entries whose `path` no longer exists on disk.
+                Both flags can be passed in the same invocation.
+
+Output schema (the read subcommand and the response from every write):
+
+  {"status": "ok", "version": "v1", ...subcommand-specific fields...}
+
+Errors emit `{"status": "error", "message": "..."}` to stderr and
+exit non-zero (1 for user error, 2 for I/O failure).
+
+Cross-platform: pure stdlib + PyYAML. Atomic writes via temp + rename
+mirror skf-atomic-write.py's pattern. Concurrent access requires
+external `flock` coordination — see step-07 of skf-create-skill for
+the precedent.
+
+CLI:
+
+  python3 skf-forge-tier-rw.py read --target /path/forge-tier.yaml
+  echo '{...}' | python3 skf-forge-tier-rw.py write-tools --target /path/forge-tier.yaml
+  python3 skf-forge-tier-rw.py init-prefs --target /path/preferences.yaml
+  python3 skf-forge-tier-rw.py clean-stale --target /path/forge-tier.yaml \\
+      --qmd-live-names foo-brief,bar-extraction --prune-missing-ccc-paths
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+
+DEFAULT_STALENESS_HOURS = 24
+PREFERENCES_TEMPLATE = """# Ferris Sidecar: User Preferences
+# Created by setup workflow on first run
+# Edit this file to customize Ferris behavior
+
+# Override detected tier (set to Quick, Forge, Forge+, or Deep to force a tier)
+tier_override: ~
+
+# Passive context injection (set to false to skip snippet generation and CLAUDE.md updates during export)
+passive_context: true
+
+# Headless mode (set to true to skip confirmation gates in all workflows)
+headless_mode: false
+
+# Compact greeting (set to true to skip the full capabilities table on session start)
+compact_greeting: false
+
+# Reserved for future use — these fields are not yet consumed by any workflow step
+# output_language: ~
+# skill_format_version: ~
+# citation_style: ~
+# confidence_display: ~
+"""
+
+
+def _die(code: int, message: str) -> None:
+    print(json.dumps({"status": "error", "message": message}), file=sys.stderr)
+    sys.exit(code)
+
+
+def _ok(payload: dict) -> None:
+    payload.setdefault("status", "ok")
+    payload.setdefault("version", "v1")
+    print(json.dumps(payload, default=str))
+
+
+def _read_yaml(path: Path) -> dict | None:
+    """Return parsed YAML as dict, or None if file missing. Raises on parse error."""
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        _die(2, f"failed to parse {path}: {e}")
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        _die(2, f"expected mapping at top of {path}, got {type(data).__name__}")
+    return data
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    """Crash-safe write via temp + fsync + rename. Mirrors skf-atomic-write.py."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".skf-tmp")
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        try:
+            os.write(fd, content.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(tmp, target)
+    except OSError as e:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        _die(2, f"atomic write failed for {target}: {e}")
+
+
+def _yaml_block(value, indent: int = 0) -> str:
+    """Dump a value as a YAML fragment, indented by `indent` spaces, no trailing newline."""
+    text = yaml.safe_dump(value, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    text = text.rstrip("\n")
+    if indent == 0:
+        return text
+    pad = " " * indent
+    return "\n".join(pad + line if line else line for line in text.split("\n"))
+
+
+def render_forge_tier_yaml(payload: dict) -> str:
+    """Render the canonical forge-tier.yaml from a context payload.
+
+    Preserves the human-readable section comments from the template at
+    step-02-write-config.md:24-58. Sections are emitted in a fixed order
+    so re-runs against unchanged inputs produce byte-identical output.
+    """
+    tools = payload["tools"]
+    tier = payload["tier"]
+    tier_detected_at = payload["tier_detected_at"]
+    ccc_index = payload["ccc_index"]
+    ccc_index_registry = payload.get("ccc_index_registry", [])
+    qmd_collections = payload.get("qmd_collections", [])
+
+    # Render `tools` block in the canonical key order (matches step-02 template).
+    tools_ordered = {
+        "ast_grep": tools["ast_grep"],
+        "gh_cli": tools["gh_cli"],
+        "qmd": tools["qmd"],
+        "ccc": tools["ccc"],
+        "ccc_daemon": tools.get("ccc_daemon"),
+        "security_scan": tools.get("security_scan", False),
+    }
+
+    # ccc_index keys in canonical order.
+    ccc_ordered = {
+        "indexed_path": ccc_index.get("indexed_path"),
+        "last_indexed": ccc_index.get("last_indexed"),
+        "status": ccc_index.get("status"),
+        "staleness_threshold_hours": ccc_index.get("staleness_threshold_hours", DEFAULT_STALENESS_HOURS),
+        "file_count": ccc_index.get("file_count"),
+        "exclude_patterns": ccc_index.get("exclude_patterns", []),
+    }
+
+    parts = [
+        "# Ferris Sidecar: Forge Tier State",
+        "# Written by setup workflow",
+        "",
+        "# Tool availability (detected during [SF] Setup Forge)",
+        _yaml_block({"tools": tools_ordered}),
+        "",
+        "# Capability tier (derived from tool availability)",
+        "# Quick = no tools | Forge = + ast-grep | Forge+ = + ast-grep + ccc | Deep = + ast-grep + gh + QMD",
+        f"tier: {tier}",
+        f"tier_detected_at: {_yaml_scalar(tier_detected_at)}",
+        "",
+        "# CCC semantic index state (managed by setup step-01b and extraction workflows)",
+        _yaml_block({"ccc_index": ccc_ordered}),
+        "",
+        "# CCC index registry (tracks which source paths have been indexed for skill workflows)",
+        "# PRESERVE existing entries on re-runs",
+        _yaml_block({"ccc_index_registry": ccc_index_registry}),
+        "",
+        "# QMD collection registry (populated by create-skill, consumed by audit/update-skill)",
+        "# PRESERVE existing entries on re-runs",
+        _yaml_block({"qmd_collections": qmd_collections}),
+        "",
+    ]
+    return "\n".join(parts)
+
+
+def _yaml_scalar(value) -> str:
+    """Render a scalar value using YAML's own quoting rules so timestamps, booleans, etc. round-trip."""
+    return yaml.safe_dump(value, default_flow_style=False).rstrip("\n").rstrip("...").rstrip()
+
+
+def _merge_preserved_fields(payload: dict, existing: dict | None) -> dict:
+    """Inject preserved fields from the existing file into the new payload.
+
+    Three preservation rules (per step-02 §1 "Note on re-runs"):
+    - `qmd_collections` array — preserved entirely from existing.
+    - `ccc_index_registry` array — preserved entirely from existing.
+    - `ccc_index.staleness_threshold_hours` scalar — preserved if user set
+      a non-default value; else uses payload value or DEFAULT.
+    Note: `ccc_index.exclude_patterns` is NOT preserved (rewritten fresh
+    by step-01b on every run, per the explicit step-02 contract).
+    """
+    if existing is None:
+        return payload
+
+    payload.setdefault("qmd_collections", existing.get("qmd_collections", []))
+    payload.setdefault("ccc_index_registry", existing.get("ccc_index_registry", []))
+
+    payload.setdefault("ccc_index", {})
+    existing_ccc = existing.get("ccc_index", {}) or {}
+    if "staleness_threshold_hours" not in payload["ccc_index"]:
+        payload["ccc_index"]["staleness_threshold_hours"] = existing_ccc.get(
+            "staleness_threshold_hours", DEFAULT_STALENESS_HOURS
+        )
+    return payload
+
+
+# ─── Subcommands ─────────────────────────────────────────────────────────────
+
+
+def cmd_read(target: Path) -> None:
+    data = _read_yaml(target)
+    if data is None:
+        _ok({"exists": False, "data": None})
+        return
+    _ok({"exists": True, "data": data})
+
+
+def cmd_write_tools(target: Path) -> None:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        _die(1, "write-tools: empty stdin (expected JSON payload)")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        _die(1, f"write-tools: invalid JSON on stdin: {e}")
+
+    required = {"tools", "tier", "ccc_index"}
+    missing = required - set(payload.keys())
+    if missing:
+        _die(1, f"write-tools: payload missing required keys: {sorted(missing)}")
+
+    payload.setdefault("tier_detected_at", datetime.now(timezone.utc).isoformat())
+
+    existing = _read_yaml(target)
+    payload = _merge_preserved_fields(payload, existing)
+
+    rendered = render_forge_tier_yaml(payload)
+    _atomic_write(target, rendered)
+    _ok({
+        "wrote": str(target),
+        "preserved_arrays": {
+            "qmd_collections": len(payload.get("qmd_collections", [])),
+            "ccc_index_registry": len(payload.get("ccc_index_registry", [])),
+        },
+        "tier": payload["tier"],
+    })
+
+
+def cmd_init_prefs(target: Path) -> None:
+    if target.exists():
+        _ok({"exists": True, "wrote": False, "path": str(target)})
+        return
+    _atomic_write(target, PREFERENCES_TEMPLATE)
+    _ok({"exists": True, "wrote": True, "path": str(target), "first_run": True})
+
+
+def cmd_clean_stale(target: Path, qmd_live_names: list[str] | None,
+                    prune_missing_ccc_paths: bool) -> None:
+    data = _read_yaml(target)
+    if data is None:
+        _die(1, f"clean-stale: target does not exist: {target}")
+
+    qmd_removed: list[str] = []
+    ccc_removed: list[str] = []
+
+    if qmd_live_names is not None:
+        live_set = set(qmd_live_names)
+        kept = []
+        for entry in data.get("qmd_collections", []) or []:
+            if not isinstance(entry, dict):
+                kept.append(entry)
+                continue
+            name = entry.get("name")
+            if name in live_set:
+                kept.append(entry)
+            else:
+                qmd_removed.append(str(name))
+        data["qmd_collections"] = kept
+
+    if prune_missing_ccc_paths:
+        kept = []
+        for entry in data.get("ccc_index_registry", []) or []:
+            if not isinstance(entry, dict):
+                kept.append(entry)
+                continue
+            entry_path = entry.get("path")
+            if entry_path and Path(entry_path).exists():
+                kept.append(entry)
+            else:
+                ccc_removed.append(str(entry_path))
+        data["ccc_index_registry"] = kept
+
+    if not qmd_removed and not ccc_removed:
+        _ok({"qmd_removed": [], "ccc_removed": [], "wrote": False})
+        return
+
+    # Round-trip through render to preserve the canonical format.
+    # Existing data already contains the full state; render needs the same shape.
+    payload = {
+        "tools": data.get("tools", {}),
+        "tier": data.get("tier", "Quick"),
+        "tier_detected_at": data.get("tier_detected_at",
+                                     datetime.now(timezone.utc).isoformat()),
+        "ccc_index": data.get("ccc_index", {}),
+        "ccc_index_registry": data.get("ccc_index_registry", []),
+        "qmd_collections": data.get("qmd_collections", []),
+    }
+    rendered = render_forge_tier_yaml(payload)
+    _atomic_write(target, rendered)
+    _ok({
+        "qmd_removed": qmd_removed,
+        "ccc_removed": ccc_removed,
+        "wrote": True,
+    })
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read/write primitives for forger-sidecar YAML files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_read = sub.add_parser("read", help="Read a forge-tier.yaml and emit JSON")
+    p_read.add_argument("--target", type=Path, required=True)
+
+    p_write = sub.add_parser("write-tools",
+                             help="Write a fresh forge-tier.yaml from a JSON payload on stdin")
+    p_write.add_argument("--target", type=Path, required=True)
+
+    p_init = sub.add_parser("init-prefs",
+                            help="Create preferences.yaml with first-run defaults if missing")
+    p_init.add_argument("--target", type=Path, required=True)
+
+    p_clean = sub.add_parser("clean-stale",
+                             help="Remove stale qmd_collections / ccc_index_registry entries")
+    p_clean.add_argument("--target", type=Path, required=True)
+    p_clean.add_argument("--qmd-live-names", default=None,
+                         help="Comma-separated list of currently-live QMD collection names. "
+                              "Entries in qmd_collections whose name is NOT in this list are removed. "
+                              "Omit the flag entirely to skip QMD cleanup.")
+    p_clean.add_argument("--prune-missing-ccc-paths", action="store_true",
+                         help="Remove ccc_index_registry entries whose path no longer exists.")
+
+    args = parser.parse_args()
+
+    if args.cmd == "read":
+        cmd_read(args.target)
+    elif args.cmd == "write-tools":
+        cmd_write_tools(args.target)
+    elif args.cmd == "init-prefs":
+        cmd_init_prefs(args.target)
+    elif args.cmd == "clean-stale":
+        live = None
+        if args.qmd_live_names is not None:
+            live = [n.strip() for n in args.qmd_live_names.split(",") if n.strip()]
+        cmd_clean_stale(args.target, live, args.prune_missing_ccc_paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test-skf-detect-tools.py
+++ b/test/test-skf-detect-tools.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Tests for skf-detect-tools.py.
+
+Strategy:
+- Tier truth table is enumerated exhaustively (16 rows over the 4-tool boolean
+  product). Each row asserts the calculated tier and the satisfied/missing
+  result for every possible --require-tier value.
+- Tool probes are tested with mocked subprocess.run to cover normal,
+  alias-shadowed, daemon-stopped, and timeout paths without hitting real
+  binaries.
+- CLI integration test invokes the script as a subprocess and validates the
+  emitted JSON shape end-to-end.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-detect-tools.py"
+)
+
+spec = importlib.util.spec_from_file_location("skf_detect_tools", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ─── Tier calculation ────────────────────────────────────────────────────────
+
+
+def _tools_state(ag: bool, gh: bool, qm: bool, cc: bool) -> dict:
+    return {
+        "ast_grep": {"available": ag, "version": "x" if ag else None},
+        "gh_cli":   {"available": gh, "version": "x" if gh else None},
+        "qmd":      {"available": qm, "status": "healthy" if qm else "absent",
+                     "version": "x" if qm else None},
+        "ccc":      {"available": cc, "daemon": "healthy" if cc else None,
+                     "version": "x" if cc else None},
+        "security_scan": {"available": False},
+    }
+
+
+# Full 4-bool truth table (16 rows) with expected tier
+TIER_TRUTH_TABLE = [
+    # (ast_grep, gh, qmd, ccc, expected_tier)
+    (False, False, False, False, "Quick"),
+    (False, False, False, True,  "Quick"),  # ccc alone unlocks nothing
+    (False, False, True,  False, "Quick"),
+    (False, False, True,  True,  "Quick"),
+    (False, True,  False, False, "Quick"),  # gh alone unlocks nothing
+    (False, True,  False, True,  "Quick"),
+    (False, True,  True,  False, "Quick"),
+    (False, True,  True,  True,  "Quick"),
+    (True,  False, False, False, "Forge"),
+    (True,  False, False, True,  "Forge+"),
+    (True,  False, True,  False, "Forge"),  # ast+qmd not enough for Deep without gh
+    (True,  False, True,  True,  "Forge+"),
+    (True,  True,  False, False, "Forge"),  # ast+gh not enough for Deep without qmd
+    (True,  True,  False, True,  "Forge+"),
+    (True,  True,  True,  False, "Deep"),
+    (True,  True,  True,  True,  "Deep"),   # Deep takes priority over Forge+
+]
+
+
+@pytest.mark.parametrize("ag,gh,qm,cc,expected", TIER_TRUTH_TABLE)
+def test_tier_calculation_truth_table(ag, gh, qm, cc, expected):
+    tier = mod.calculate_tier(_tools_state(ag, gh, qm, cc))
+    assert tier == expected, f"({ag=}, {gh=}, {qm=}, {cc=}) → expected {expected}, got {tier}"
+
+
+# ─── Prerequisites check (drives both --tier-override sanity + --require-tier) ──
+
+
+@pytest.mark.parametrize("ag,gh,qm,cc,_expected_tier", TIER_TRUTH_TABLE)
+@pytest.mark.parametrize("required", ["Quick", "Forge", "Forge+", "Deep"])
+def test_prerequisites_match_required_tools(ag, gh, qm, cc, _expected_tier, required):
+    tools = _tools_state(ag, gh, qm, cc)
+    satisfied, missing = mod.tier_prerequisites_met(required, tools)
+
+    if required == "Quick":
+        assert satisfied is True and missing == []
+    elif required == "Forge":
+        assert satisfied is ag
+        assert missing == ([] if ag else ["ast-grep"])
+    elif required == "Forge+":
+        assert satisfied is (ag and cc)
+        # Order matters — declared as ast_grep first, then ccc in the source dict
+        expected_missing = []
+        if not ag:
+            expected_missing.append("ast-grep")
+        if not cc:
+            expected_missing.append("ccc")
+        assert missing == expected_missing
+    elif required == "Deep":
+        assert satisfied is (ag and gh and qm)
+        expected_missing = []
+        if not ag:
+            expected_missing.append("ast-grep")
+        if not gh:
+            expected_missing.append("gh")
+        if not qm:
+            expected_missing.append("qmd")
+        assert missing == expected_missing
+
+
+def test_deep_does_not_subsume_forge_plus():
+    """Deep with no ccc should fail --require-tier=Forge+."""
+    tools = _tools_state(ag=True, gh=True, qm=True, cc=False)
+    assert mod.calculate_tier(tools) == "Deep"
+    satisfied, missing = mod.tier_prerequisites_met("Forge+", tools)
+    assert satisfied is False
+    assert "ccc" in missing
+
+
+# ─── Individual probe behaviour (subprocess mocked) ──────────────────────────
+
+
+def _fake_run(rc: int = 0, stdout: str = "", stderr: str = ""):
+    """Build a CompletedProcess-like object _run() can wrap."""
+    class _Result:
+        def __init__(self):
+            self.returncode = rc
+            self.stdout = stdout
+            self.stderr = stderr
+    return _Result()
+
+
+def test_probe_ast_grep_success():
+    with patch.object(mod.subprocess, "run", return_value=_fake_run(0, "ast-grep 0.39.5\n")):
+        result = mod.probe_ast_grep()
+    assert result == {"available": True, "version": "ast-grep 0.39.5"}
+
+
+def test_probe_ast_grep_not_installed():
+    with patch.object(mod.subprocess, "run", side_effect=FileNotFoundError):
+        result = mod.probe_ast_grep()
+    assert result == {"available": False, "version": None}
+
+
+def test_probe_ccc_identity_marker_present():
+    """Genuine cocoindex-code help output should be accepted."""
+    help_output = (
+        "Usage: ccc [OPTIONS] COMMAND [ARGS]...\n\n"
+        "CocoIndex Code — index and search codebases.\n"
+    )
+    doctor_output = "All systems operational\n"
+
+    def _side_effect(cmd, **kwargs):
+        if cmd == ["ccc", "--help"]:
+            return _fake_run(0, help_output)
+        if cmd == ["ccc", "doctor"]:
+            return _fake_run(0, doctor_output)
+        raise AssertionError(f"unexpected probe call: {cmd}")
+
+    with patch.object(mod.subprocess, "run", side_effect=_side_effect):
+        result = mod.probe_ccc()
+    assert result["available"] is True
+    assert result["daemon"] == "healthy"
+
+
+def test_probe_ccc_identity_marker_absent_rejects_alias():
+    """Foreign `ccc` binary (e.g. code2prompt alias) must not pass."""
+    # Foreign tool exits 0 on --help but lacks the marker
+    foreign_help = "Usage: ccc [OPTIONS]\n\nA generic tool that happens to use ccc as its name.\n"
+
+    def _side_effect(cmd, **kwargs):
+        if cmd == ["ccc", "--help"]:
+            return _fake_run(0, foreign_help)
+        raise AssertionError(
+            "ccc doctor MUST NOT be called when identity marker is absent — "
+            f"called with {cmd}"
+        )
+
+    with patch.object(mod.subprocess, "run", side_effect=_side_effect):
+        result = mod.probe_ccc()
+    assert result == {"available": False, "daemon": None, "version": None}
+
+
+def test_probe_qmd_binary_present_daemon_stopped():
+    def _side_effect(cmd, **kwargs):
+        if cmd == ["qmd", "--version"]:
+            return _fake_run(0, "qmd 1.2.3\n")
+        if cmd == ["qmd", "status"]:
+            return _fake_run(1, "", "qmd: daemon not running\n")
+        raise AssertionError(f"unexpected: {cmd}")
+
+    with patch.object(mod.subprocess, "run", side_effect=_side_effect):
+        result = mod.probe_qmd()
+    assert result == {"available": False, "status": "daemon_stopped", "version": "qmd 1.2.3"}
+
+
+def test_probe_qmd_falls_back_to_help_when_version_unsupported():
+    """Some qmd builds reject --version; fall back to --help for identity check."""
+    def _side_effect(cmd, **kwargs):
+        if cmd == ["qmd", "--version"]:
+            return _fake_run(2, "", "unknown option --version\n")
+        if cmd == ["qmd", "--help"]:
+            return _fake_run(0, "qmd: a search engine\n")
+        if cmd == ["qmd", "status"]:
+            return _fake_run(0, "Operational\n")
+        raise AssertionError(f"unexpected: {cmd}")
+
+    with patch.object(mod.subprocess, "run", side_effect=_side_effect):
+        result = mod.probe_qmd()
+    assert result["available"] is True
+    assert result["status"] == "healthy"
+
+
+def test_probe_qmd_absent():
+    with patch.object(mod.subprocess, "run", side_effect=FileNotFoundError):
+        result = mod.probe_qmd()
+    assert result == {"available": False, "status": "absent", "version": None}
+
+
+def test_probe_security_scan_set_and_unset():
+    with patch.dict(os.environ, {"SNYK_TOKEN": "abc123"}, clear=False):
+        assert mod.probe_security_scan("SNYK_TOKEN") == {"available": True}
+    # Whitespace-only is treated as unset
+    with patch.dict(os.environ, {"SNYK_TOKEN": "   "}, clear=False):
+        assert mod.probe_security_scan("SNYK_TOKEN") == {"available": False}
+    # Unset
+    env = {k: v for k, v in os.environ.items() if k != "SNYK_TOKEN"}
+    with patch.dict(os.environ, env, clear=True):
+        assert mod.probe_security_scan("SNYK_TOKEN") == {"available": False}
+
+
+def test_run_swallows_timeout():
+    """Probe wrapper must never raise — timeouts become rc=127."""
+    with patch.object(
+        mod.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd=["x"], timeout=1),
+    ):
+        rc, stdout, stderr = mod._run(["x"])
+    assert rc == 127 and stdout == "" and stderr == ""
+
+
+# ─── Override + require-tier integration via detect() ────────────────────────
+
+
+def _detect_args(**overrides):
+    """Build an argparse.Namespace with detect() defaults."""
+    import argparse
+    return argparse.Namespace(
+        tier_override=overrides.get("tier_override"),
+        require_tier=overrides.get("require_tier"),
+        snyk_env_var=overrides.get("snyk_env_var", "SNYK_TOKEN_DOES_NOT_EXIST"),
+    )
+
+
+def _patch_all_probes(ag=False, gh=False, qm=False, cc=False):
+    return patch.multiple(
+        mod,
+        probe_ast_grep=lambda: {"available": ag, "version": "x" if ag else None},
+        probe_gh_cli=lambda:   {"available": gh, "version": "x" if gh else None},
+        probe_qmd=lambda:      {"available": qm,
+                                "status": "healthy" if qm else "absent",
+                                "version": "x" if qm else None},
+        probe_ccc=lambda:      {"available": cc,
+                                "daemon": "healthy" if cc else None,
+                                "version": "x" if cc else None},
+    )
+
+
+def test_detect_no_override_no_require():
+    with _patch_all_probes(ag=True, gh=True, qm=True, cc=True):
+        out = mod.detect(_detect_args())
+    assert out["tier"]["calculated"] == "Deep"
+    assert out["tier"]["detected"] == "Deep"
+    assert out["tier"]["override_applied"] is False
+    assert out["tier"]["override_invalid"] is False
+    assert out["tier"]["override_unsafe"] is False
+    assert out["require_tier"]["requested"] is None
+    assert out["require_tier"]["satisfied"] is None
+
+
+def test_detect_valid_override_with_satisfied_prerequisites():
+    with _patch_all_probes(ag=True, gh=True, qm=True, cc=False):
+        out = mod.detect(_detect_args(tier_override="Deep"))
+    assert out["tier"]["calculated"] == "Deep"
+    assert out["tier"]["detected"] == "Deep"
+    assert out["tier"]["override_applied"] is True
+    assert out["tier"]["override_value"] == "Deep"
+    assert out["tier"]["override_unsafe"] is False
+    assert out["tier"]["override_unsafe_missing"] == []
+
+
+def test_detect_valid_override_with_unsafe_prerequisites():
+    """User forces Deep on a Quick host — applied, but flagged unsafe."""
+    with _patch_all_probes(ag=False, gh=False, qm=False, cc=False):
+        out = mod.detect(_detect_args(tier_override="Deep"))
+    assert out["tier"]["calculated"] == "Deep"
+    assert out["tier"]["detected"] == "Quick"
+    assert out["tier"]["override_applied"] is True
+    assert out["tier"]["override_unsafe"] is True
+    assert set(out["tier"]["override_unsafe_missing"]) == {"ast-grep", "gh", "qmd"}
+
+
+def test_detect_invalid_override_falls_back_to_detected():
+    with _patch_all_probes(ag=True, gh=False, qm=False, cc=False):
+        out = mod.detect(_detect_args(tier_override="forge+"))  # wrong case
+    assert out["tier"]["calculated"] == "Forge"
+    assert out["tier"]["detected"] == "Forge"
+    assert out["tier"]["override_applied"] is False
+    assert out["tier"]["override_invalid"] is True
+    assert out["tier"]["override_invalid_value"] == "forge+"
+
+
+def test_detect_require_tier_satisfied():
+    with _patch_all_probes(ag=True, gh=True, qm=True, cc=True):
+        out = mod.detect(_detect_args(require_tier="Forge+"))
+    assert out["require_tier"]["requested"] == "Forge+"
+    assert out["require_tier"]["satisfied"] is True
+    assert out["require_tier"]["missing_tools"] == []
+
+
+def test_detect_require_tier_not_satisfied():
+    with _patch_all_probes(ag=True, gh=True, qm=True, cc=False):
+        out = mod.detect(_detect_args(require_tier="Forge+"))
+    # Calculated is Deep (ast+gh+qmd) but Forge+ requires ccc — not satisfied
+    assert out["tier"]["calculated"] == "Deep"
+    assert out["require_tier"]["satisfied"] is False
+    assert out["require_tier"]["missing_tools"] == ["ccc"]
+
+
+def test_detect_require_tier_invalid_value_dies():
+    """Invalid --require-tier is a user error; --tier-override is not."""
+    with _patch_all_probes(), pytest.raises(SystemExit) as exc:
+        mod.detect(_detect_args(require_tier="quick"))
+    assert exc.value.code == 1
+
+
+# ─── End-to-end CLI integration ──────────────────────────────────────────────
+
+
+def test_cli_emits_valid_json_on_stdout():
+    """Invoke the script as a subprocess; JSON shape end-to-end."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--snyk-env-var", "DEFINITELY_NOT_SET_XYZ"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["version"] == "v1"
+    assert set(payload["tools"].keys()) == {"ast_grep", "gh_cli", "qmd", "ccc", "security_scan"}
+    assert payload["tier"]["calculated"] in ("Quick", "Forge", "Forge+", "Deep")
+    assert payload["tier"]["detected"] in ("Quick", "Forge", "Forge+", "Deep")
+    assert payload["require_tier"] == {"requested": None, "satisfied": None, "missing_tools": []}
+
+
+def test_cli_with_require_tier_below_actual():
+    """If host has nothing, --require-tier=Quick should still pass (Quick = always)."""
+    env = {k: v for k, v in os.environ.items() if k != "SNYK_TOKEN"}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--require-tier", "Quick"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["require_tier"]["satisfied"] is True

--- a/test/test-skf-forge-tier-rw.py
+++ b/test/test-skf-forge-tier-rw.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Tests for skf-forge-tier-rw.py.
+
+Highest-value test: round-trip preservation of `qmd_collections`,
+`ccc_index_registry`, and `ccc_index.staleness_threshold_hours` across
+a write-tools call. Losing those arrays would silently break every
+downstream skill that reads them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-forge-tier-rw.py"
+)
+
+spec = importlib.util.spec_from_file_location("skf_forge_tier_rw", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ─── Fixture payloads ────────────────────────────────────────────────────────
+
+
+def _baseline_payload() -> dict:
+    return {
+        "tools": {
+            "ast_grep": True,
+            "gh_cli": True,
+            "qmd": True,
+            "ccc": True,
+            "ccc_daemon": "healthy",
+            "security_scan": False,
+        },
+        "tier": "Deep",
+        "tier_detected_at": "2026-04-27T12:00:00+00:00",
+        "ccc_index": {
+            "indexed_path": "/repo",
+            "last_indexed": "2026-04-27T12:00:00+00:00",
+            "status": "fresh",
+            "file_count": 1234,
+            "exclude_patterns": ["**/_bmad", "**/_bmad-output"],
+        },
+    }
+
+
+def _payload_with_arrays() -> dict:
+    """Same as baseline but with non-empty registry arrays — used for preservation tests."""
+    payload = _baseline_payload()
+    payload["qmd_collections"] = [
+        {"name": "foo-brief", "type": "brief", "skill_name": "foo", "created_at": "2026-04-25"},
+        {"name": "foo-extraction", "type": "extraction", "skill_name": "foo",
+         "created_at": "2026-04-25"},
+    ]
+    payload["ccc_index_registry"] = [
+        {"path": "/repo/skills/foo", "indexed_at": "2026-04-25T10:00:00+00:00"},
+    ]
+    payload["ccc_index"]["staleness_threshold_hours"] = 48  # user-customized
+    return payload
+
+
+# ─── render_forge_tier_yaml ─────────────────────────────────────────────────
+
+
+def test_render_produces_parseable_yaml():
+    payload = _payload_with_arrays()
+    rendered = mod.render_forge_tier_yaml(payload)
+    parsed = yaml.safe_load(rendered)
+    assert parsed["tier"] == "Deep"
+    assert parsed["tools"]["ast_grep"] is True
+    assert parsed["tools"]["ccc_daemon"] == "healthy"
+    assert parsed["ccc_index"]["status"] == "fresh"
+    assert parsed["ccc_index"]["staleness_threshold_hours"] == 48
+    assert len(parsed["qmd_collections"]) == 2
+    assert len(parsed["ccc_index_registry"]) == 1
+
+
+def test_render_preserves_canonical_section_comments():
+    """Header + section comments per step-02 template are preserved."""
+    rendered = mod.render_forge_tier_yaml(_baseline_payload())
+    assert "# Ferris Sidecar: Forge Tier State" in rendered
+    assert "# Tool availability" in rendered
+    assert "# Capability tier" in rendered
+    assert "# CCC semantic index state" in rendered
+    assert "# CCC index registry" in rendered
+    assert "PRESERVE existing entries" in rendered
+    assert "# QMD collection registry" in rendered
+
+
+def test_render_section_order_is_canonical():
+    """Sections appear in the same order as the step-02 template."""
+    rendered = mod.render_forge_tier_yaml(_baseline_payload())
+    sections = [
+        ("tools:", rendered.find("tools:")),
+        ("tier:", rendered.find("\ntier:")),
+        ("tier_detected_at:", rendered.find("tier_detected_at:")),
+        ("ccc_index:", rendered.find("ccc_index:")),
+        ("ccc_index_registry:", rendered.find("ccc_index_registry:")),
+        ("qmd_collections:", rendered.find("qmd_collections:")),
+    ]
+    positions = [pos for _, pos in sections]
+    assert all(p > 0 for p in positions), f"missing sections: {sections}"
+    assert positions == sorted(positions), f"sections out of canonical order: {sections}"
+
+
+def test_render_uses_default_staleness_when_unset():
+    payload = _baseline_payload()
+    payload["ccc_index"].pop("staleness_threshold_hours", None)
+    rendered = mod.render_forge_tier_yaml(payload)
+    parsed = yaml.safe_load(rendered)
+    assert parsed["ccc_index"]["staleness_threshold_hours"] == mod.DEFAULT_STALENESS_HOURS
+
+
+def test_render_is_deterministic_byte_for_byte():
+    """Same input → byte-identical output (no random ordering, no timestamp leakage)."""
+    payload = _payload_with_arrays()
+    rendered_a = mod.render_forge_tier_yaml(payload)
+    rendered_b = mod.render_forge_tier_yaml(payload)
+    assert rendered_a == rendered_b
+
+
+# ─── _merge_preserved_fields (the data-loss surface) ────────────────────────
+
+
+def test_merge_preserves_existing_qmd_collections():
+    new_payload = _baseline_payload()  # no qmd_collections key
+    existing = {
+        "qmd_collections": [{"name": "x-brief", "type": "brief"}],
+        "ccc_index_registry": [],
+    }
+    merged = mod._merge_preserved_fields(new_payload, existing)
+    assert merged["qmd_collections"] == [{"name": "x-brief", "type": "brief"}]
+
+
+def test_merge_preserves_existing_ccc_index_registry():
+    new_payload = _baseline_payload()
+    existing = {
+        "qmd_collections": [],
+        "ccc_index_registry": [{"path": "/old/path", "indexed_at": "2026-04-01T00:00:00+00:00"}],
+    }
+    merged = mod._merge_preserved_fields(new_payload, existing)
+    assert merged["ccc_index_registry"] == [
+        {"path": "/old/path", "indexed_at": "2026-04-01T00:00:00+00:00"}
+    ]
+
+
+def test_merge_preserves_user_customized_staleness_threshold():
+    new_payload = _baseline_payload()  # no staleness in new
+    existing = {"ccc_index": {"staleness_threshold_hours": 72}}
+    merged = mod._merge_preserved_fields(new_payload, existing)
+    assert merged["ccc_index"]["staleness_threshold_hours"] == 72
+
+
+def test_merge_uses_default_when_neither_set():
+    new_payload = _baseline_payload()
+    new_payload["ccc_index"].pop("staleness_threshold_hours", None)
+    existing = {"ccc_index": {}}
+    merged = mod._merge_preserved_fields(new_payload, existing)
+    assert merged["ccc_index"]["staleness_threshold_hours"] == mod.DEFAULT_STALENESS_HOURS
+
+
+def test_merge_no_existing_file_returns_payload_unchanged():
+    new_payload = _baseline_payload()
+    merged = mod._merge_preserved_fields(new_payload, None)
+    assert merged is new_payload
+
+
+def test_merge_does_not_preserve_exclude_patterns():
+    """exclude_patterns is rewritten fresh every run, NOT preserved."""
+    new_payload = _baseline_payload()  # has exclude_patterns: ["**/_bmad", ...]
+    existing = {
+        "ccc_index": {
+            "exclude_patterns": ["**/old-stale-pattern"],
+            "staleness_threshold_hours": 24,
+        },
+    }
+    merged = mod._merge_preserved_fields(new_payload, existing)
+    assert "**/old-stale-pattern" not in merged["ccc_index"]["exclude_patterns"]
+    assert merged["ccc_index"]["exclude_patterns"] == ["**/_bmad", "**/_bmad-output"]
+
+
+# ─── End-to-end: write-tools subcommand via subprocess ──────────────────────
+
+
+@pytest.fixture
+def tmp_target():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td) / "forge-tier.yaml"
+
+
+def _write_tools(target: Path, payload: dict) -> dict:
+    """Invoke write-tools subcommand via subprocess, return parsed JSON response."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "write-tools", "--target", str(target)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def _read_yaml_file(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_write_tools_creates_file_on_first_run(tmp_target):
+    response = _write_tools(tmp_target, _baseline_payload())
+    assert response["status"] == "ok"
+    assert response["wrote"] == str(tmp_target)
+    assert response["preserved_arrays"] == {"qmd_collections": 0, "ccc_index_registry": 0}
+    assert tmp_target.exists()
+    parsed = _read_yaml_file(tmp_target)
+    assert parsed["tier"] == "Deep"
+
+
+def test_write_tools_preserves_arrays_on_rerun(tmp_target):
+    """The headline data-loss test: arrays from existing file survive a fresh write."""
+    # First run: write a file WITH arrays.
+    initial = _payload_with_arrays()
+    _write_tools(tmp_target, initial)
+    initial_parsed = _read_yaml_file(tmp_target)
+    assert len(initial_parsed["qmd_collections"]) == 2
+    assert len(initial_parsed["ccc_index_registry"]) == 1
+    assert initial_parsed["ccc_index"]["staleness_threshold_hours"] == 48
+
+    # Second run: write with a payload that does NOT mention the arrays.
+    rerun_payload = _baseline_payload()  # no qmd_collections, no ccc_index_registry
+    rerun_payload["tools"]["ccc_daemon"] = "stopped"  # something changed
+    response = _write_tools(tmp_target, rerun_payload)
+    assert response["preserved_arrays"]["qmd_collections"] == 2
+    assert response["preserved_arrays"]["ccc_index_registry"] == 1
+
+    # Verify arrays are still there byte-for-byte.
+    rerun_parsed = _read_yaml_file(tmp_target)
+    assert rerun_parsed["qmd_collections"] == initial_parsed["qmd_collections"]
+    assert rerun_parsed["ccc_index_registry"] == initial_parsed["ccc_index_registry"]
+    assert rerun_parsed["ccc_index"]["staleness_threshold_hours"] == 48
+    # The thing that DID change.
+    assert rerun_parsed["tools"]["ccc_daemon"] == "stopped"
+
+
+def test_write_tools_default_staleness_does_not_overwrite_user_value(tmp_target):
+    """A fresh payload with no staleness must not clobber a user-customized value."""
+    initial = _payload_with_arrays()  # staleness=48
+    _write_tools(tmp_target, initial)
+
+    rerun_payload = _baseline_payload()
+    rerun_payload["ccc_index"].pop("staleness_threshold_hours", None)
+    _write_tools(tmp_target, rerun_payload)
+
+    parsed = _read_yaml_file(tmp_target)
+    assert parsed["ccc_index"]["staleness_threshold_hours"] == 48
+
+
+def test_write_tools_rejects_payload_missing_required_keys(tmp_target):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "write-tools", "--target", str(tmp_target)],
+        input=json.dumps({"tools": {}}),  # missing tier and ccc_index
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 1
+    err = json.loads(result.stderr)
+    assert "missing required keys" in err["message"]
+
+
+def test_write_tools_rejects_invalid_json(tmp_target):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "write-tools", "--target", str(tmp_target)],
+        input="not json at all",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 1
+
+
+# ─── read subcommand ────────────────────────────────────────────────────────
+
+
+def test_read_missing_file_emits_null_payload(tmp_target):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "read", "--target", str(tmp_target)],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["exists"] is False
+    assert payload["data"] is None
+
+
+def test_read_existing_file_emits_full_data(tmp_target):
+    _write_tools(tmp_target, _payload_with_arrays())
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "read", "--target", str(tmp_target)],
+        capture_output=True, text=True, timeout=10,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["exists"] is True
+    assert payload["data"]["tier"] == "Deep"
+    assert len(payload["data"]["qmd_collections"]) == 2
+
+
+# ─── init-prefs subcommand ───────────────────────────────────────────────────
+
+
+def test_init_prefs_creates_when_missing(tmp_target):
+    target = tmp_target.parent / "preferences.yaml"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "init-prefs", "--target", str(target)],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["wrote"] is True
+    assert payload["first_run"] is True
+    assert target.exists()
+    parsed = _read_yaml_file(target)
+    assert parsed["tier_override"] is None
+    assert parsed["headless_mode"] is False
+
+
+def test_init_prefs_preserves_existing(tmp_target):
+    """Running init-prefs against an existing file MUST NOT overwrite user customization."""
+    target = tmp_target.parent / "preferences.yaml"
+    custom = "tier_override: Deep\nheadless_mode: true\n"
+    target.write_text(custom, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "init-prefs", "--target", str(target)],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["wrote"] is False
+    assert target.read_text(encoding="utf-8") == custom
+
+
+# ─── clean-stale subcommand ─────────────────────────────────────────────────
+
+
+def test_clean_stale_removes_qmd_entries_not_in_live_list(tmp_target):
+    _write_tools(tmp_target, _payload_with_arrays())  # 2 qmd_collections: foo-brief, foo-extraction
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "clean-stale",
+         "--target", str(tmp_target),
+         "--qmd-live-names", "foo-brief"],  # only foo-brief is live
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    response = json.loads(result.stdout)
+    assert response["qmd_removed"] == ["foo-extraction"]
+    assert response["wrote"] is True
+
+    parsed = _read_yaml_file(tmp_target)
+    assert [c["name"] for c in parsed["qmd_collections"]] == ["foo-brief"]
+
+
+def test_clean_stale_no_changes_skips_write(tmp_target):
+    _write_tools(tmp_target, _payload_with_arrays())
+    mtime_before = tmp_target.stat().st_mtime_ns
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "clean-stale",
+         "--target", str(tmp_target),
+         "--qmd-live-names", "foo-brief,foo-extraction"],  # all live
+        capture_output=True, text=True, timeout=10,
+    )
+    response = json.loads(result.stdout)
+    assert response["qmd_removed"] == []
+    assert response["wrote"] is False
+    # File must not have been touched.
+    assert tmp_target.stat().st_mtime_ns == mtime_before
+
+
+def test_clean_stale_prunes_missing_ccc_paths(tmp_target):
+    """ccc_index_registry entries whose path no longer exists are removed."""
+    payload = _payload_with_arrays()
+    # Replace the registry with a mix of present + absent paths.
+    present = tmp_target.parent  # tmp dir definitely exists
+    payload["ccc_index_registry"] = [
+        {"path": str(present), "indexed_at": "2026-04-25T10:00:00+00:00"},
+        {"path": "/absolutely/does/not/exist/xyz123", "indexed_at": "2026-04-25T10:00:00+00:00"},
+    ]
+    _write_tools(tmp_target, payload)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "clean-stale",
+         "--target", str(tmp_target),
+         "--prune-missing-ccc-paths"],
+        capture_output=True, text=True, timeout=10,
+    )
+    response = json.loads(result.stdout)
+    assert response["wrote"] is True
+    assert response["ccc_removed"] == ["/absolutely/does/not/exist/xyz123"]
+    parsed = _read_yaml_file(tmp_target)
+    assert len(parsed["ccc_index_registry"]) == 1
+    assert parsed["ccc_index_registry"][0]["path"] == str(present)
+
+
+def test_clean_stale_combined_qmd_and_ccc(tmp_target):
+    payload = _payload_with_arrays()
+    payload["ccc_index_registry"] = [
+        {"path": "/absolutely/does/not/exist/abc", "indexed_at": "2026-04-25T10:00:00+00:00"},
+    ]
+    _write_tools(tmp_target, payload)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "clean-stale",
+         "--target", str(tmp_target),
+         "--qmd-live-names", "foo-brief",
+         "--prune-missing-ccc-paths"],
+        capture_output=True, text=True, timeout=10,
+    )
+    response = json.loads(result.stdout)
+    assert response["qmd_removed"] == ["foo-extraction"]
+    assert response["ccc_removed"] == ["/absolutely/does/not/exist/abc"]
+
+
+def test_clean_stale_missing_target_is_user_error(tmp_target):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "clean-stale",
+         "--target", str(tmp_target),  # does not exist
+         "--qmd-live-names", "foo"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary

First of three PRs implementing Theme #1 (Intelligence Placement) from the post-PR-#248 quality re-scan — extracting deterministic operations currently performed in LLM prose into Python scripts under \`src/shared/scripts/\`. This PR adds the foundation: tool detection + forge-tier.yaml rw. Hygiene scripts come in PR B; the step-prompt cutover that actually invokes them happens in PR C.

This PR is a **Phase 1** ship: scripts are wired into \`npm run test:python\` but **no live workflow path invokes them yet** — that's PR C. This isolates "do the scripts work?" from "does the workflow correctly use them?" so each can be reviewed and reverted independently.

Branch: \`feat/skf-setup-shared-scripts-foundation\` (2 commits, 124 passing tests, +1,546 lines).

## Commits

- **\`feat(shared/scripts): add skf-detect-tools.py for parallel tool probing\`** — Replaces step-01 §3-§8b. Probes ast-grep, gh, qmd, ccc concurrently via ThreadPoolExecutor (4-way parallel) with an 8-second per-probe timeout that never raises. Two-step ccc verification (\`--help\` + \`CocoIndex Code\` identity-marker check, then \`ccc doctor\` — only if marker present). Two-step qmd verification (\`--version\` with \`--help\` fallback, then \`qmd status\`) producing the \`absent | daemon_stopped | healthy\` qmd_status from PR #248. Applies the 4-rule tier table. Tier-override sanity check + invalid-value flagging. \`--require-tier\` evaluation using tool-prerequisite check (Deep does NOT subsume Forge+ — verified explicitly in tests). Single JSON document on stdout matching the documented \`DETECT_OUTPUT_SCHEMA\` (versioned \`v1\`). 99 passing tests.

- **\`feat(shared/scripts): add skf-forge-tier-rw.py for sidecar YAML rw\`** — Replaces step-02 §1-§3 + step-03 §5/§5b. Four subcommands: \`read\`, \`write-tools\`, \`init-prefs\`, \`clean-stale\`. **Highest data-loss risk surface in this effort** — gated by a round-trip preservation test that asserts \`qmd_collections\`, \`ccc_index_registry\`, and a user-customized \`ccc_index.staleness_threshold_hours\` survive a write-tools call against an existing file when the new payload omits them entirely. Renders the canonical YAML format from step-02-write-config.md:24-58 byte-for-byte (section comments + canonical key order + \`sort_keys=False\`). Atomic writes via temp + fsync + rename (mirrors \`skf-atomic-write.py\`). 25 passing tests.

## Architectural decisions (per the Theme #1 plan)

- **All scripts under \`src/shared/scripts/\`** with the \`skf-\` prefix matching the existing \`skf-atomic-write.py\` precedent.
- **PEP 723 inline metadata** declares Python ≥ 3.10 and (for forge-tier-rw) PyYAML. Direct \`python3 helper.py\` invocation works (matching how step prompts call \`skf-atomic-write.py\` today). \`uv run\` resolves deps when needed.
- **\`_die\` / \`_ok\` JSON helpers + never-raises subprocess wrapper** mirrors \`skf-atomic-write.py\` exactly.
- **Two distinct contracts**: per-script JSON for internal step → step communication (consumed by future PR C step prompts), and the \`SKF_SETUP_RESULT_JSON\` envelope for external pipelines (assembled by \`skf-emit-result-envelope.py\` in PR B from the per-script outputs). Decoupled so internal extension doesn't drift the public envelope.
- **External \`flock\` pattern preserved**. \`forge-tier-rw\` does not own locking — caller wraps invocations in \`flock\` (precedent: \`src/skf-create-skill/steps-c/step-07-generate-artifacts.md:154\`).
- **PyYAML, not ruamel.yaml** — comment preservation handled by hand-crafted template emitting documented section banners around \`yaml.safe_dump\`'d sub-documents. Avoids a new dep; section comments survive; data sections still serialize via the canonical PyYAML path downstream consumers already use.

## Tests

124 passing across two new test files:

\`\`\`
test/test-skf-detect-tools.py    99 passed
test/test-skf-forge-tier-rw.py   25 passed
\`\`\`

Highlights:

- **16-row tier truth table** enumerated exhaustively for the 4-tool boolean product. Each row asserts the calculated tier and the satisfied/missing result for every \`--require-tier\` value (64 parametrized test cases total).
- **Round-trip preservation test** (\`test_write_tools_preserves_arrays_on_rerun\`) — the headline data-loss check.
- **Identity-marker rejection test** (\`test_probe_ccc_identity_marker_absent_rejects_alias\`) — verifies that a foreign \`ccc\` binary's \`ccc doctor\` is never invoked.
- **Deep-does-not-subsume-Forge+ test** (\`test_deep_does_not_subsume_forge_plus\`) — locks in the documented tier-prerequisite semantics from PR #247.
- **End-to-end CLI tests** invoke the scripts as subprocesses against actual JSON-on-stdin / JSON-on-stdout contracts.

Both test files wired into \`npm run test:python\`. Full local \`npm run quality\` passed on every commit via husky pre-commit.

## Related — separate upstream PR opened

The Theme #1 plan called for a Q8 housekeeping fix to \`prepass-workflow-integrity.py\` (the workflow-builder skill's pre-pass walker) so it would descend into \`steps-c/\` and recognize the \`step-NN-<slug>.md\` naming convention. That file lives in the \`bmad-workflow-builder\` skill, not in this repo (\`.claude/\` is gitignored).

The fix has been ported verbatim and opened as **bmad-code-org/bmad-builder#82** with 11 dedicated tests + a cross-skill verification table. Once it merges upstream and the SKF dev's local \`bmad-workflow-builder\` skill picks up the new version, every future SKF quality scan will stop reporting the 5+ false-positive \`critical/missing-stage\` findings per skill that were drowning real issues.

## Deferred to PR B (next)

- \`skf-emit-result-envelope.py\` + JSON Schema (locks the PR #247 envelope contract against LLM schema drift)
- \`skf-qmd-classify-collections.py\` (set arithmetic over QMD collection suffixes)
- \`skf-merge-ccc-exclusions.py\` (set-union write-back into \`.cocoindex_code/settings.yml\` with PR #248's validation)

## Deferred to PR C (after PR B)

- Step-prompt rewrite to actually invoke the scripts. step-01 / step-01b / step-02 / step-03 / step-04 will collapse from prose-driven work into thin orchestration layers around script invocations. Net **−250 lines** in \`steps-c/\` per the plan estimate.

## Test plan

- [x] CI green on \`quality.yaml\` (Linux + Windows matrix). Note: test:python now runs 124 additional tests; total runtime impact ~10s.
- [x] On a Deep host, manual \`python3 src/shared/scripts/skf-detect-tools.py\` produces the documented schema with all 4 tools available.
- [x] On a host with no tools, \`python3 src/shared/scripts/skf-detect-tools.py --require-tier Deep\` emits \`require_tier.satisfied: false\` with all 3 tools in \`missing_tools\`.
- [x] On a host where \`ccc\` is shadowed by an unrelated alias, \`skf-detect-tools.py\` records \`ccc.available: false\` AND does NOT invoke \`ccc doctor\` (the absent-marker branch).
- [x] Round-trip a real \`forge-tier.yaml\` through \`skf-forge-tier-rw.py read\` → modify the \`tools\` block → \`write-tools\` and confirm \`qmd_collections\` and \`ccc_index_registry\` arrays are byte-identical to the original.
- [x] \`skf-forge-tier-rw.py init-prefs\` against an existing \`preferences.yaml\` does not modify the file (mtime unchanged).