### PR TITLE
feat(skf-setup): Theme #1 PR B — hygiene scripts (envelope + qmd-classify + ccc-exclusions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py test/test-skf-merge-ccc-exclusions.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/src/shared/scripts/schemas/skf-setup-result-envelope.v1.json
+++ b/src/shared/scripts/schemas/skf-setup-result-envelope.v1.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/armelhbobdad/bmad-module-skill-forge/src/shared/scripts/schemas/skf-setup-result-envelope.v1.json",
+  "title": "SKF_SETUP_RESULT_JSON envelope (v1)",
+  "description": "Single-line JSON document emitted by skf-setup step-04 §4 when {headless_mode} is true, prefixed with the literal 'SKF_SETUP_RESULT_JSON: '. Pipelines grep one line out of the workflow log without parsing ASCII-art and without racing the forge-tier.yaml writer. Schema added in PR #247, extended in PR #248 (header / outputs / failure modes), extended again in this PR with previous_tier / tier_changed / tools_added / tools_removed / error.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["skf_setup"],
+  "properties": {
+    "skf_setup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tier",
+        "previous_tier",
+        "tier_changed",
+        "tools",
+        "tools_added",
+        "tools_removed",
+        "config_path",
+        "ccc_index",
+        "files_written",
+        "tier_override_active",
+        "tier_override_invalid",
+        "require_tier_satisfied",
+        "warnings",
+        "error"
+      ],
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["Quick", "Forge", "Forge+", "Deep"],
+          "description": "Active capability tier this run."
+        },
+        "previous_tier": {
+          "type": ["string", "null"],
+          "enum": ["Quick", "Forge", "Forge+", "Deep", null],
+          "description": "Tier read from the existing forge-tier.yaml at workflow start. Null on first runs."
+        },
+        "tier_changed": {
+          "type": "boolean",
+          "description": "True when previous_tier is non-null AND differs from tier. False on first runs and same-tier re-runs. Lets pipelines react to upgrades without re-reading forge-tier.yaml."
+        },
+        "tools": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ast_grep", "gh_cli", "qmd", "ccc"],
+          "properties": {
+            "ast_grep": { "type": "boolean" },
+            "gh_cli": { "type": "boolean" },
+            "qmd": { "type": "boolean" },
+            "ccc": { "type": "boolean" }
+          }
+        },
+        "tools_added": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["ast_grep", "gh_cli", "qmd", "ccc"] },
+          "uniqueItems": true,
+          "description": "Tool keys with available=true that were NOT available in previous_tools. On first runs, equals the currently-detected tools."
+        },
+        "tools_removed": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["ast_grep", "gh_cli", "qmd", "ccc"] },
+          "uniqueItems": true,
+          "description": "Tool keys that were available in previous_tools but are NOT available now."
+        },
+        "config_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the forge-tier.yaml that this run wrote (or attempted to write — see error)."
+        },
+        "ccc_index": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "indexed_path", "file_count"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["fresh", "created", "failed", "none"]
+            },
+            "indexed_path": { "type": ["string", "null"] },
+            "file_count": { "type": ["integer", "null"], "minimum": 0 }
+          }
+        },
+        "files_written": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["forge-tier.yaml", "preferences.yaml", "settings.yml", "ccc_index"]
+          },
+          "uniqueItems": true,
+          "description": "Files actually written this run. Empty array when a write failure halted the run before any file was written."
+        },
+        "tier_override_active": {
+          "type": "boolean",
+          "description": "True when a valid tier_override from preferences.yaml was applied."
+        },
+        "tier_override_invalid": {
+          "type": "boolean",
+          "description": "True when tier_override was set but did not match Quick|Forge|Forge+|Deep (case-sensitive). Detected tier was used as fallback."
+        },
+        "require_tier_satisfied": {
+          "type": ["boolean", "null"],
+          "description": "Null when --require-tier was not set. Otherwise true if the tool prerequisites of the requested tier are met (Deep does NOT subsume Forge+)."
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Non-fatal anomalies surfaced during the run. May include tier_override_invalid, tier_override_unsafe, ccc_exclusion_warnings entries, ccc_registry_stale_removed entries, qmd_daemon_stopped, ccc_indexing_failed, etc. Empty when none."
+        },
+        "error": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["phase", "path", "reason"],
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Step or operation that failed (e.g. 'step-02-write-config:forge-tier.yaml')."
+                },
+                "path": { "type": "string", "minLength": 1, "description": "Absolute path of the file the failed operation targeted." },
+                "reason": { "type": "string", "minLength": 1, "description": "Human-readable error message." }
+              }
+            }
+          ],
+          "description": "Null on success. Object describing the failure when forge-tier.yaml or preferences.yaml could not be written. Pipelines branch on error !== null for 'exit code 2' semantics."
+        }
+      }
+    }
+  }
+}

--- a/src/shared/scripts/skf-emit-result-envelope.py
+++ b/src/shared/scripts/skf-emit-result-envelope.py
@@ -1,0 +1,404 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SKF Emit Result Envelope — Schema-locked headless output for skf-setup.
+
+Replaces the prose-driven envelope assembly in `src/skf-setup/steps-c/
+step-04-report.md` §4 with one Python invocation. The envelope contract
+(SKF_SETUP_RESULT_JSON) was added to step-04 in PR #247, extended in
+PR #248 (header / outputs / failure modes), and extended again in this
+PR (previous_tier, tier_changed, tools_added, tools_removed, error).
+
+LLM-rendered envelopes risk silent schema drift on every invocation —
+a pipeline that grep's `SKF_SETUP_RESULT_JSON: {…}` out of the workflow
+log can break if the model decides to rename a key or rearrange a
+nested structure. This script is the single source of truth: it takes
+a context payload as JSON on stdin, computes derived fields
+deterministically, and emits the envelope in a fixed shape that
+matches the JSON Schema at
+`src/shared/scripts/schemas/skf-setup-result-envelope.v1.json`.
+
+Subcommands:
+
+  emit       Read context payload as JSON on stdin, derive missing
+             fields (tools_added/removed, tier_changed), assemble the
+             envelope, emit `SKF_SETUP_RESULT_JSON: {one-line JSON}`
+             on stdout. Default subcommand.
+
+  validate   Read an envelope (without the prefix) as JSON on stdin
+             and verify it against the documented schema. No stdout
+             on success; non-zero exit + stderr error on failure.
+             Useful for paranoid pipelines that want to validate a
+             received envelope before consuming it.
+
+Context payload shape (consumed by `emit`):
+
+  {
+    "tier":                          "Quick|Forge|Forge+|Deep",
+    "previous_tier":                 "Quick|Forge|Forge+|Deep|null",
+    "tools":                         {"ast_grep": bool, "gh_cli": bool, "qmd": bool, "ccc": bool},
+    "previous_tools":                {…same shape…|null},
+    "config_path":                   "/abs/path/to/forge-tier.yaml",
+    "ccc_index":                     {"status": "...", "indexed_path": "...|null", "file_count": int|null},
+    "files_written":                 ["forge-tier.yaml", ...],
+    "tier_override_active":          bool,
+    "tier_override_invalid":         bool,
+    "tier_override_invalid_value":   "string|null",
+    "tier_override_unsafe":          bool,
+    "tier_override_unsafe_missing":  ["gh", "qmd", ...],
+    "require_tier_satisfied":        bool|null,
+    "require_tier_failure_missing":  ["ccc", ...],
+    "qmd_status":                    "absent|daemon_stopped|healthy",
+    "ccc_exclusion_warnings":        ["string", ...],
+    "ccc_registry_stale_removed":    ["/path", ...],
+    "ccc_indexing_failed_reason":    "string|null",
+    "error":                         null|{"phase","path","reason"}
+  }
+
+Caller does NOT need to compute warnings, tools_added/removed, or
+tier_changed — the script derives them from the inputs above.
+
+Exit codes:
+  0 success
+  1 user error (bad args, malformed JSON, validation failure)
+  2 internal error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+ENVELOPE_PREFIX = "SKF_SETUP_RESULT_JSON: "
+SCHEMA_FILE = Path(__file__).parent / "schemas" / "skf-setup-result-envelope.v1.json"
+TOOL_KEYS = ("ast_grep", "gh_cli", "qmd", "ccc")
+VALID_TIERS = ("Quick", "Forge", "Forge+", "Deep")
+VALID_FILES = ("forge-tier.yaml", "preferences.yaml", "settings.yml", "ccc_index")
+VALID_CCC_STATUS = ("fresh", "created", "failed", "none")
+
+
+def _die(code: int, message: str) -> None:
+    print(json.dumps({"status": "error", "message": message}), file=sys.stderr)
+    sys.exit(code)
+
+
+def _read_stdin_json(label: str) -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        _die(1, f"{label}: empty stdin (expected JSON payload)")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        _die(1, f"{label}: invalid JSON on stdin: {e}")
+
+
+# ─── derive helpers ─────────────────────────────────────────────────────────
+
+
+def _normalize_tools(maybe_tools) -> dict:
+    """Coerce either {key: bool} or {key: {available: bool}} into {key: bool}.
+
+    skf-detect-tools.py emits the second shape; some callers will pass the
+    first. Tolerate both for robustness; missing keys default to False.
+    """
+    if maybe_tools is None:
+        return {k: False for k in TOOL_KEYS}
+    out = {}
+    for k in TOOL_KEYS:
+        v = maybe_tools.get(k)
+        if isinstance(v, dict):
+            out[k] = bool(v.get("available", False))
+        else:
+            out[k] = bool(v)
+    return out
+
+
+def _compute_tool_deltas(current: dict, previous) -> tuple[list[str], list[str]]:
+    """Return (added, removed) tool-key lists, sorted for determinism.
+
+    First-run convention (previous is None or empty): added = currently
+    available tools; removed = []. Matches the documented step-04 §4 rule.
+    """
+    cur = _normalize_tools(current)
+    if not previous:
+        added = sorted(k for k, v in cur.items() if v)
+        return added, []
+    prev = _normalize_tools(previous)
+    added = sorted(k for k in TOOL_KEYS if cur[k] and not prev[k])
+    removed = sorted(k for k in TOOL_KEYS if prev[k] and not cur[k])
+    return added, removed
+
+
+def _assemble_warnings(payload: dict) -> list[str]:
+    """Fold every documented warning source into the envelope's warnings array.
+
+    Matches the field-rules block in step-04 §4 — pipelines should only need
+    to consult `warnings` to surface non-fatal issues.
+    """
+    warnings: list[str] = []
+    if payload.get("tier_override_invalid"):
+        bad = payload.get("tier_override_invalid_value")
+        warnings.append(f"tier_override_invalid: {bad if bad is not None else '<unknown>'}")
+    if payload.get("tier_override_unsafe"):
+        missing = payload.get("tier_override_unsafe_missing", []) or []
+        warnings.append(f"tier_override_unsafe: missing {', '.join(missing) if missing else '<none>'}")
+    for w in payload.get("ccc_exclusion_warnings", []) or []:
+        warnings.append(str(w))
+    for p in payload.get("ccc_registry_stale_removed", []) or []:
+        warnings.append(f"ccc_registry_stale_removed: {p}")
+    if payload.get("qmd_status") == "daemon_stopped":
+        warnings.append("qmd_daemon_stopped")
+    failure_reason = payload.get("ccc_indexing_failed_reason")
+    if failure_reason:
+        warnings.append(f"ccc_indexing_failed: {failure_reason}")
+    if payload.get("require_tier_satisfied") is False:
+        missing = payload.get("require_tier_failure_missing", []) or []
+        warnings.append(
+            f"require_tier_failed: missing {', '.join(missing) if missing else '<none>'}"
+        )
+    return warnings
+
+
+def _normalize_files_written(maybe_files) -> list[str]:
+    """Accept either a list of names or a dict {name: bool}; emit sorted-canonical list."""
+    if maybe_files is None:
+        return []
+    if isinstance(maybe_files, dict):
+        names = [k for k, v in maybe_files.items() if v]
+    elif isinstance(maybe_files, list):
+        names = [str(x) for x in maybe_files]
+    else:
+        _die(1, f"files_written must be list or dict, got {type(maybe_files).__name__}")
+    # Filter to documented names only; preserve canonical order rather than
+    # caller-provided order so two callers with the same files get byte-identical
+    # output.
+    return [name for name in VALID_FILES if name in names]
+
+
+def _normalize_ccc_index(maybe_idx) -> dict:
+    """Coerce caller's ccc_index dict to the envelope shape (drops extras)."""
+    if maybe_idx is None:
+        return {"status": "none", "indexed_path": None, "file_count": None}
+    return {
+        "status": maybe_idx.get("status", "none"),
+        "indexed_path": maybe_idx.get("indexed_path"),
+        "file_count": maybe_idx.get("file_count"),
+    }
+
+
+def _normalize_error(maybe_error) -> dict | None:
+    if maybe_error is None:
+        return None
+    if not isinstance(maybe_error, dict):
+        _die(1, f"error must be null or object, got {type(maybe_error).__name__}")
+    required = {"phase", "path", "reason"}
+    missing = required - set(maybe_error.keys())
+    if missing:
+        _die(1, f"error object missing required keys: {sorted(missing)}")
+    return {
+        "phase":  str(maybe_error["phase"]),
+        "path":   str(maybe_error["path"]),
+        "reason": str(maybe_error["reason"]),
+    }
+
+
+# ─── envelope assembly ──────────────────────────────────────────────────────
+
+
+def assemble_envelope(payload: dict) -> dict:
+    """Build the canonical envelope from a context payload. Pure function."""
+    tier = payload.get("tier")
+    if tier not in VALID_TIERS:
+        _die(1, f"tier must be one of {VALID_TIERS}, got {tier!r}")
+
+    previous_tier = payload.get("previous_tier")
+    if previous_tier is not None and previous_tier not in VALID_TIERS:
+        _die(1, f"previous_tier must be one of {VALID_TIERS} or null, got {previous_tier!r}")
+    tier_changed = previous_tier is not None and previous_tier != tier
+
+    tools = _normalize_tools(payload.get("tools"))
+    tools_added, tools_removed = _compute_tool_deltas(
+        payload.get("tools"), payload.get("previous_tools")
+    )
+
+    config_path = payload.get("config_path")
+    if not isinstance(config_path, str) or not config_path:
+        _die(1, "config_path must be a non-empty string")
+
+    ccc_index = _normalize_ccc_index(payload.get("ccc_index"))
+    if ccc_index["status"] not in VALID_CCC_STATUS:
+        _die(1, f"ccc_index.status must be one of {VALID_CCC_STATUS}, got {ccc_index['status']!r}")
+
+    require_tier_satisfied = payload.get("require_tier_satisfied")
+    if require_tier_satisfied is not None and not isinstance(require_tier_satisfied, bool):
+        _die(1, f"require_tier_satisfied must be bool or null, got {type(require_tier_satisfied).__name__}")
+
+    return {
+        "skf_setup": {
+            "tier": tier,
+            "previous_tier": previous_tier,
+            "tier_changed": tier_changed,
+            "tools": tools,
+            "tools_added": tools_added,
+            "tools_removed": tools_removed,
+            "config_path": config_path,
+            "ccc_index": ccc_index,
+            "files_written": _normalize_files_written(payload.get("files_written")),
+            "tier_override_active": bool(payload.get("tier_override_active", False)),
+            "tier_override_invalid": bool(payload.get("tier_override_invalid", False)),
+            "require_tier_satisfied": require_tier_satisfied,
+            "warnings": _assemble_warnings(payload),
+            "error": _normalize_error(payload.get("error")),
+        }
+    }
+
+
+def emit_envelope_line(envelope: dict) -> str:
+    """Serialize the envelope as one prefixed line. No embedded newlines, sort_keys=True for determinism."""
+    body = json.dumps(envelope, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    if "\n" in body:
+        _die(2, "envelope serialization produced embedded newline (should be impossible)")
+    return ENVELOPE_PREFIX + body
+
+
+# ─── minimal stdlib JSON Schema validator ───────────────────────────────────
+
+
+def _load_schema() -> dict:
+    if not SCHEMA_FILE.exists():
+        _die(2, f"schema file missing: {SCHEMA_FILE}")
+    return json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def _validate_against_schema(value, schema: dict, path: str = "$") -> list[str]:
+    """Return a list of error strings (empty = valid).
+
+    Implements only the subset of Draft 2020-12 features used by our envelope
+    schema: type, enum, oneOf, properties, additionalProperties, required,
+    items, uniqueItems, minLength, minimum. Sufficient to catch every
+    violation our schema can express; not a general-purpose validator.
+    """
+    errors: list[str] = []
+
+    if "oneOf" in schema:
+        matches = sum(1 for sub in schema["oneOf"] if not _validate_against_schema(value, sub, path))
+        if matches != 1:
+            errors.append(f"{path}: matched {matches} of {len(schema['oneOf'])} oneOf branches (expected exactly 1)")
+        return errors
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        if not _matches_type(value, expected_type):
+            errors.append(f"{path}: expected type {expected_type}, got {type(value).__name__}")
+            return errors
+
+    if "enum" in schema:
+        if value not in schema["enum"]:
+            errors.append(f"{path}: value {value!r} not in enum {schema['enum']}")
+
+    if isinstance(value, dict):
+        props = schema.get("properties", {})
+        required = set(schema.get("required", []))
+        present = set(value.keys())
+        missing = required - present
+        for k in sorted(missing):
+            errors.append(f"{path}: missing required property {k!r}")
+        if schema.get("additionalProperties") is False:
+            extra = present - set(props.keys())
+            for k in sorted(extra):
+                errors.append(f"{path}: unexpected property {k!r}")
+        for k, sub in props.items():
+            if k in value:
+                errors.extend(_validate_against_schema(value[k], sub, f"{path}.{k}"))
+
+    if isinstance(value, list):
+        if "items" in schema:
+            for i, item in enumerate(value):
+                errors.extend(_validate_against_schema(item, schema["items"], f"{path}[{i}]"))
+        if schema.get("uniqueItems") and len(value) != len(set(map(_freeze, value))):
+            errors.append(f"{path}: items not unique")
+
+    if isinstance(value, str) and "minLength" in schema:
+        if len(value) < schema["minLength"]:
+            errors.append(f"{path}: string shorter than minLength {schema['minLength']}")
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and "minimum" in schema:
+        if value < schema["minimum"]:
+            errors.append(f"{path}: value {value} below minimum {schema['minimum']}")
+
+    return errors
+
+
+def _matches_type(value, expected) -> bool:
+    """Implement JSON Schema 'type' for a single string OR a list of allowed types."""
+    if isinstance(expected, list):
+        return any(_matches_type(value, t) for t in expected)
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    return False
+
+
+def _freeze(v):
+    """Make a value hashable for uniqueItems checks."""
+    if isinstance(v, dict):
+        return tuple(sorted((k, _freeze(val)) for k, val in v.items()))
+    if isinstance(v, list):
+        return tuple(_freeze(x) for x in v)
+    return v
+
+
+# ─── subcommands ────────────────────────────────────────────────────────────
+
+
+def cmd_emit() -> None:
+    payload = _read_stdin_json("emit")
+    envelope = assemble_envelope(payload)
+    schema = _load_schema()
+    errors = _validate_against_schema(envelope, schema)
+    if errors:
+        _die(2, f"assembled envelope failed schema validation (this is a bug): {errors}")
+    print(emit_envelope_line(envelope))
+
+
+def cmd_validate() -> None:
+    envelope = _read_stdin_json("validate")
+    schema = _load_schema()
+    errors = _validate_against_schema(envelope, schema)
+    if errors:
+        _die(1, "; ".join(errors))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd")
+    sub.add_parser("emit",     help="Build envelope from context payload (default).")
+    sub.add_parser("validate", help="Validate an envelope payload against the schema.")
+    args = parser.parse_args()
+
+    cmd = args.cmd or "emit"
+    if cmd == "emit":
+        cmd_emit()
+    elif cmd == "validate":
+        cmd_validate()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/scripts/skf-merge-ccc-exclusions.py
+++ b/src/shared/scripts/skf-merge-ccc-exclusions.py
@@ -1,0 +1,320 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""SKF Merge CCC Exclusions — Set-union merge of SKF exclusion patterns.
+
+Replaces the prose-driven validation + merge logic in `src/skf-setup/
+steps-c/step-01b-ccc-index.md` §2b with one Python invocation. Reads
+`.cocoindex_code/settings.yml`, applies PR #248's config-value
+validation rules to reject inputs that would silently produce a
+malformed glob (the empty-value-becomes-`**/`-matches-everything bug
+that would silently exclude the entire repo from indexing), and
+performs an idempotent set-union merge of the SKF exclusion list into
+the existing `exclude_patterns` array.
+
+Always-included patterns (4 hardcoded — no config needed):
+
+  **/_bmad           SKF framework module (workflows, agents, knowledge)
+  **/_bmad-output    Build output artifacts
+  **/.claude         Claude Code configuration
+  **/_skf-learn      SKF learning materials
+
+Conditionally-included patterns (2 from config — validated before use):
+
+  **/{skills_output_folder}   Generated skill files
+  **/{forge_data_folder}      Compilation workspace
+
+Validation rules for the 2 conditional values (PR #248):
+
+  - REJECT empty or whitespace-only values
+    → would produce `**/`, matching every path → ccc indexes nothing
+  - REJECT values starting with `/`, `~/`, or `./`
+    → produces `**//abs/path`, `**/~/x`, or `**/./rel` — malformed glob
+  - REJECT values containing glob meta-characters (`*`, `?`, `[`)
+    → interpolation collides with the surrounding pattern syntax
+
+Rejected values are SKIPPED (the pattern is not added) and a warning
+is appended to the output. The 4 always-include patterns are applied
+unconditionally — config-value rejection cannot disable indexing
+entirely.
+
+CLI:
+
+  python3 skf-merge-ccc-exclusions.py \\
+      --project-root /abs/path \\
+      --skills-output-folder skills \\
+      --forge-data-folder _bmad-output/forge-data
+
+Output (single JSON document on stdout):
+
+  {
+    "status": "ok",
+    "version": "v1",
+    "settings_yml_existed":   bool,
+    "settings_yml_path":      "/abs/path/.cocoindex_code/settings.yml",
+    "patterns_added":         int,
+    "patterns_added_list":    ["**/_bmad", ...],
+    "patterns_already_present": int,
+    "written":                bool,
+    "warnings":               ["string", ...]
+  }
+
+`written` is false when no new patterns needed adding (idempotent
+re-run — no I/O wasted). Non-zero `warnings` does NOT prevent the
+write — always-include patterns still merge.
+
+Atomic writes via temp + fsync + rename (mirrors skf-atomic-write.py).
+Concurrent writers must coordinate via external `flock` (the typical
+pattern for shared-file mutation in this module).
+
+Exit codes:
+  0 success (warnings, if any, are still on the success path)
+  1 user error (bad args, missing required flag, malformed settings.yml)
+  2 internal error (write failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ALWAYS_INCLUDE = (
+    "**/_bmad",
+    "**/_bmad-output",
+    "**/.claude",
+    "**/_skf-learn",
+)
+GLOB_META_CHARS = set("*?[")
+
+
+def _die(code: int, message: str) -> None:
+    print(json.dumps({"status": "error", "message": message}), file=sys.stderr)
+    sys.exit(code)
+
+
+def _ok(payload: dict) -> None:
+    payload.setdefault("status", "ok")
+    payload.setdefault("version", "v1")
+    print(json.dumps(payload))
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    """Crash-safe write via temp + fsync + rename. Mirrors skf-atomic-write.py."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".skf-tmp")
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        try:
+            os.write(fd, content.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(tmp, target)
+    except OSError as e:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        _die(2, f"atomic write failed for {target}: {e}")
+
+
+# ─── Config-value validation (PR #248 rules) ────────────────────────────────
+
+
+def validate_config_value(key: str, raw_value: str) -> tuple[str | None, str | None]:
+    """Validate a config value used to interpolate `**/{value}`.
+
+    Returns (cleaned_value, warning_or_None). When cleaned_value is None
+    the value was rejected and the caller MUST NOT add the pattern.
+    """
+    if raw_value is None or not str(raw_value).strip():
+        return None, (
+            f"{key} is empty or whitespace-only; refused for ccc exclusion because "
+            f"interpolating it would produce `**/`, which matches every path and "
+            f"would silently exclude the entire repository from indexing — fix the "
+            f"value in {{project-root}}/_bmad/skf/config.yaml"
+        )
+
+    value = str(raw_value).strip()
+
+    if value.startswith("/") or value.startswith("~/") or value.startswith("./"):
+        return None, (
+            f"{key} is an absolute or anchored path; refused for ccc exclusion "
+            f"because interpolating it would produce a malformed glob — fix the "
+            f"value in {{project-root}}/_bmad/skf/config.yaml to a repo-relative path"
+        )
+
+    if any(ch in GLOB_META_CHARS for ch in value):
+        return None, (
+            f"{key} contains glob meta-character (*, ?, [); refused for ccc "
+            f"exclusion because interpolation collides with the surrounding "
+            f"pattern syntax — fix the value in {{project-root}}/_bmad/skf/config.yaml"
+        )
+
+    return value, None
+
+
+# ─── Pattern assembly ───────────────────────────────────────────────────────
+
+
+def assemble_patterns(skills_output_folder: str, forge_data_folder: str
+                      ) -> tuple[list[str], list[str]]:
+    """Return (validated_patterns_to_add, warnings).
+
+    Validated patterns include the 4 unconditional ones plus any of the
+    2 config-driven ones whose value passed validation.
+    """
+    patterns = list(ALWAYS_INCLUDE)
+    warnings: list[str] = []
+
+    cleaned, warn = validate_config_value("skills_output_folder", skills_output_folder)
+    if cleaned is not None:
+        patterns.append(f"**/{cleaned}")
+    elif warn:
+        warnings.append(warn)
+
+    cleaned, warn = validate_config_value("forge_data_folder", forge_data_folder)
+    if cleaned is not None:
+        patterns.append(f"**/{cleaned}")
+    elif warn:
+        warnings.append(warn)
+
+    return patterns, warnings
+
+
+# ─── settings.yml read / merge / render ─────────────────────────────────────
+
+
+def read_settings_yml(path: Path) -> tuple[dict, bool]:
+    """Return (parsed_dict, existed_before).
+
+    Missing file → ({}, False). Existing file is parsed; non-mapping top-level
+    or YAML errors exit with a clear message.
+    """
+    if not path.exists():
+        return {}, False
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        _die(1, f"failed to parse {path}: {e}")
+    if data is None:
+        return {}, True
+    if not isinstance(data, dict):
+        _die(1, f"expected mapping at top of {path}, got {type(data).__name__}")
+    return data, True
+
+
+def merge_patterns(existing_patterns: list[str], to_add: list[str]
+                   ) -> tuple[list[str], list[str]]:
+    """Append `to_add` entries to `existing_patterns` if not already present.
+
+    Returns (merged_patterns, newly_added_patterns). Order of existing
+    entries is preserved; new entries are appended in the order given.
+    """
+    seen = set(existing_patterns)
+    merged = list(existing_patterns)
+    newly_added: list[str] = []
+    for p in to_add:
+        if p in seen:
+            continue
+        seen.add(p)
+        merged.append(p)
+        newly_added.append(p)
+    return merged, newly_added
+
+
+def render_settings_yml(data: dict, original_text: str | None) -> str:
+    """Render the updated settings dict as YAML.
+
+    For first-time-write (no original text), emit a minimal file with
+    just the exclude_patterns the script controls. For updates, dump the
+    full data structure with PyYAML — this DROPS comments from the
+    original file. The cocoindex CLI is the only consumer of settings.yml
+    contents, and it doesn't care about comments. User-customized
+    exclude_patterns entries are preserved (set-union, not overwrite);
+    other top-level keys (if any) are also preserved.
+    """
+    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def cmd_merge(project_root: Path, skills_output_folder: str, forge_data_folder: str) -> None:
+    target = project_root / ".cocoindex_code" / "settings.yml"
+
+    patterns_to_add, warnings = assemble_patterns(skills_output_folder, forge_data_folder)
+    data, existed = read_settings_yml(target)
+
+    existing_excludes = data.get("exclude_patterns", []) or []
+    if not isinstance(existing_excludes, list):
+        _die(1, f"exclude_patterns in {target} is not a list "
+                f"(got {type(existing_excludes).__name__})")
+    # Normalize entries to strings (cocoindex tolerates non-string entries
+    # but we want byte-identical comparison)
+    existing_excludes = [str(p) for p in existing_excludes]
+
+    merged, newly_added = merge_patterns(existing_excludes, patterns_to_add)
+    patterns_already_present = len(patterns_to_add) - len(newly_added)
+
+    if not newly_added:
+        # Idempotent re-run — no write, no mtime change.
+        _ok({
+            "settings_yml_existed":     existed,
+            "settings_yml_path":        str(target),
+            "patterns_added":           0,
+            "patterns_added_list":      [],
+            "patterns_already_present": patterns_already_present,
+            "written":                  False,
+            "warnings":                 warnings,
+        })
+        return
+
+    data["exclude_patterns"] = merged
+    rendered = render_settings_yml(data, None)
+    _atomic_write(target, rendered)
+
+    _ok({
+        "settings_yml_existed":     existed,
+        "settings_yml_path":        str(target),
+        "patterns_added":           len(newly_added),
+        "patterns_added_list":      newly_added,
+        "patterns_already_present": patterns_already_present,
+        "written":                  True,
+        "warnings":                 warnings,
+    })
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge SKF exclusion patterns into .cocoindex_code/settings.yml.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--project-root", type=Path, required=True,
+        help="Absolute path to the project root. Script writes/reads "
+             "{project-root}/.cocoindex_code/settings.yml.",
+    )
+    parser.add_argument(
+        "--skills-output-folder", default="",
+        help="Raw value of skills_output_folder from {project-root}/_bmad/skf/config.yaml. "
+             "Validated before being interpolated into `**/{value}`. Empty/absolute/glob-meta "
+             "values are rejected with a warning.",
+    )
+    parser.add_argument(
+        "--forge-data-folder", default="",
+        help="Raw value of forge_data_folder from {project-root}/_bmad/skf/config.yaml. "
+             "Same validation as --skills-output-folder.",
+    )
+    args = parser.parse_args()
+
+    cmd_merge(args.project_root, args.skills_output_folder, args.forge_data_folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/scripts/skf-qmd-classify-collections.py
+++ b/src/shared/scripts/skf-qmd-classify-collections.py
@@ -1,0 +1,202 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""SKF QMD Classify Collections — Set arithmetic over QMD collection names.
+
+Replaces the prose-driven classification logic in `src/skf-setup/steps-c/
+step-03-auto-index.md` §3 with one Python invocation. Compares the live
+QMD collections (from `qmd collection list`) against the forge registry
+(`qmd_collections` array in forge-tier.yaml) and classifies each name as
+Healthy / Orphaned / Stale, applying the forge-namespace suffix filter
+added in PR #244 to silently exclude collections owned by unrelated
+tools sharing the QMD daemon.
+
+Classification rules (per step-03 §3):
+
+  Healthy   — name in {forge-suffix-matched live} AND in registry.
+              No action needed.
+  Orphaned  — name in {forge-suffix-matched live} but NOT in registry.
+              Flagged for user-prompted removal in step-03 §4.
+  Stale     — name in registry but NOT in {all live}. Registry entry
+              should be removed.
+  Foreign   — name in live but does NOT match a forge suffix. Silently
+              excluded from every classification — never displayed,
+              never proposed for removal. Reported as a count for
+              telemetry only.
+
+Forge suffixes (the only suffixes a forge-managed collection can have,
+set by producers `skf-brief-skill` and `skf-create-skill` per
+src/knowledge/qmd-registry.md § Collection Types):
+
+  -brief, -temporal, -docs, -extraction
+
+Inputs:
+
+  --live-names    Comma-separated list of collection names currently
+                  in QMD (caller obtains this from `qmd collection list`
+                  before invoking the script). Empty string → no live
+                  collections, which is a valid first-run state.
+
+  --registry-from-yaml <path>
+                  Path to forge-tier.yaml. The script reads the file's
+                  `qmd_collections` array and extracts the `name` field
+                  from each entry. Missing file or missing array → empty
+                  registry, which is a valid first-run state.
+
+Output (single JSON document on stdout):
+
+  {
+    "status": "ok",
+    "version": "v1",
+    "healthy":          ["foo-brief", "foo-extraction"],
+    "orphaned":         ["bar-extraction"],
+    "stale":            ["baz-docs"],
+    "foreign_filtered_count": 4,
+    "foreign_filtered_sample": ["memory-root-1", "sessions-2"]
+  }
+
+`foreign_filtered_sample` is capped at 5 names (telemetry; the full list
+is never useful — if it were forge-relevant it would have a forge suffix).
+
+Exit codes:
+  0 success
+  1 user error (bad args, malformed registry file)
+  2 internal error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+FORGE_SUFFIXES = ("-brief", "-temporal", "-docs", "-extraction")
+FOREIGN_SAMPLE_CAP = 5
+
+
+def _die(code: int, message: str) -> None:
+    print(json.dumps({"status": "error", "message": message}), file=sys.stderr)
+    sys.exit(code)
+
+
+def _ok(payload: dict) -> None:
+    payload.setdefault("status", "ok")
+    payload.setdefault("version", "v1")
+    print(json.dumps(payload))
+
+
+def is_forge_owned(name: str) -> bool:
+    """True if `name` ends with one of the forge suffixes."""
+    return any(name.endswith(suffix) for suffix in FORGE_SUFFIXES)
+
+
+def parse_live_names(raw: str) -> list[str]:
+    """Comma-separated → de-duplicated list, preserving first-occurrence order.
+
+    Collection names from `qmd collection list` are user-facing strings;
+    we trust them as-is rather than imposing additional validation.
+    """
+    seen = set()
+    out: list[str] = []
+    for token in raw.split(","):
+        name = token.strip()
+        if not name:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def load_registry_names(path: Path) -> list[str]:
+    """Read forge-tier.yaml and extract `name` from each qmd_collections entry.
+
+    Missing file → empty list (valid first-run state). Malformed file
+    (parse error, wrong top-level type) → exit 1 with an actionable
+    message. Entries without a `name` field are skipped silently — the
+    forge-tier-rw.py contract guarantees `name` is always present, but
+    a hand-edited file might violate it; classify what we can.
+    """
+    if not path.exists():
+        return []
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        _die(1, f"failed to parse {path}: {e}")
+    if data is None:
+        return []
+    if not isinstance(data, dict):
+        _die(1, f"expected mapping at top of {path}, got {type(data).__name__}")
+    entries = data.get("qmd_collections", []) or []
+    if not isinstance(entries, list):
+        _die(1, f"qmd_collections in {path} is not a list (got {type(entries).__name__})")
+    names: list[str] = []
+    for entry in entries:
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+            names.append(entry["name"])
+    return names
+
+
+def classify(live: list[str], registry: list[str]) -> dict:
+    """Pure function: classify live vs registry into healthy/orphaned/stale/foreign.
+
+    Returns the classification payload (without status/version envelope).
+    """
+    forge_live = [n for n in live if is_forge_owned(n)]
+    foreign_live = [n for n in live if not is_forge_owned(n)]
+
+    forge_live_set = set(forge_live)
+    registry_set = set(registry)
+    all_live_set = set(live)
+
+    healthy = sorted(forge_live_set & registry_set)
+    orphaned = sorted(forge_live_set - registry_set)
+    # Stale uses the full live set, NOT just the forge-filtered set, so a
+    # registry entry whose name happens to match a non-forge live collection
+    # would still count as stale. Registry entries always have forge suffixes
+    # by convention, so this distinction matters only on hand-edited files.
+    stale = sorted(registry_set - all_live_set)
+
+    return {
+        "healthy": healthy,
+        "orphaned": orphaned,
+        "stale": stale,
+        "foreign_filtered_count": len(foreign_live),
+        "foreign_filtered_sample": foreign_live[:FOREIGN_SAMPLE_CAP],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Classify QMD collections vs forge registry.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--live-names",
+        default="",
+        help="Comma-separated list of collection names currently in QMD "
+             "(from `qmd collection list`). Empty string → no live collections.",
+    )
+    parser.add_argument(
+        "--registry-from-yaml",
+        type=Path,
+        required=True,
+        help="Path to forge-tier.yaml. Script reads qmd_collections array. "
+             "Missing file → empty registry (first-run state).",
+    )
+    args = parser.parse_args()
+
+    live = parse_live_names(args.live_names)
+    registry = load_registry_names(args.registry_from_yaml)
+    _ok(classify(live, registry))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test-skf-emit-result-envelope.py
+++ b/test/test-skf-emit-result-envelope.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Tests for skf-emit-result-envelope.py.
+
+The envelope is a public contract that pipelines depend on. Two test
+priorities:
+
+1. Output validates against the JSON Schema at
+   src/shared/scripts/schemas/skf-setup-result-envelope.v1.json — for
+   every input shape the script accepts.
+2. Derived fields (tools_added/removed, tier_changed, warnings) match
+   the documented step-04 §4 rules exactly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parent.parent
+SCRIPT_PATH = ROOT / "src" / "shared" / "scripts" / "skf-emit-result-envelope.py"
+SCHEMA_PATH = ROOT / "src" / "shared" / "scripts" / "schemas" / "skf-setup-result-envelope.v1.json"
+
+spec = importlib.util.spec_from_file_location("skf_emit_result_envelope", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _baseline_payload() -> dict:
+    """Minimal valid payload covering every required envelope field."""
+    return {
+        "tier": "Deep",
+        "previous_tier": None,
+        "tools": {"ast_grep": True, "gh_cli": True, "qmd": True, "ccc": True},
+        "previous_tools": None,
+        "config_path": "/abs/path/_bmad/_memory/forger-sidecar/forge-tier.yaml",
+        "ccc_index": {"status": "fresh", "indexed_path": "/abs/path", "file_count": 1234},
+        "files_written": ["forge-tier.yaml"],
+        "tier_override_active": False,
+        "tier_override_invalid": False,
+        "require_tier_satisfied": None,
+        "error": None,
+    }
+
+
+# ─── Schema sanity ───────────────────────────────────────────────────────────
+
+
+def test_schema_file_exists_and_parses():
+    assert SCHEMA_PATH.exists(), f"schema missing: {SCHEMA_PATH}"
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert schema["$schema"].startswith("https://json-schema.org/")
+    assert schema["title"].startswith("SKF_SETUP_RESULT_JSON envelope")
+
+
+# ─── assemble_envelope: derivation rules ────────────────────────────────────
+
+
+def test_baseline_envelope_assembles_and_validates():
+    env = mod.assemble_envelope(_baseline_payload())
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = mod._validate_against_schema(env, schema)
+    assert errors == [], f"baseline envelope failed schema: {errors}"
+
+
+def test_tier_changed_false_on_first_run():
+    env = mod.assemble_envelope(_baseline_payload())
+    assert env["skf_setup"]["tier_changed"] is False
+    assert env["skf_setup"]["previous_tier"] is None
+
+
+def test_tier_changed_true_on_upgrade():
+    p = _baseline_payload()
+    p["previous_tier"] = "Forge"  # was Forge, now Deep
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["tier_changed"] is True
+
+
+def test_tier_changed_false_on_same_tier_rerun():
+    p = _baseline_payload()
+    p["previous_tier"] = "Deep"  # unchanged
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["tier_changed"] is False
+
+
+def test_first_run_tools_added_lists_all_available_tools():
+    """Per step-04 §4 rule: on first runs, tools_added equals currently-detected tools."""
+    p = _baseline_payload()
+    p["previous_tools"] = None
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["tools_added"] == sorted(["ast_grep", "gh_cli", "qmd", "ccc"])
+    assert env["skf_setup"]["tools_removed"] == []
+
+
+def test_tools_added_surfaces_newly_installed():
+    """User installed ccc on a Deep host — same tier, but tools_added shows ccc."""
+    p = _baseline_payload()
+    p["previous_tools"] = {"ast_grep": True, "gh_cli": True, "qmd": True, "ccc": False}
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["tools_added"] == ["ccc"]
+    assert env["skf_setup"]["tools_removed"] == []
+
+
+def test_tools_removed_surfaces_uninstalled():
+    p = _baseline_payload()
+    p["tools"] = {"ast_grep": True, "gh_cli": True, "qmd": False, "ccc": False}
+    p["previous_tools"] = {"ast_grep": True, "gh_cli": True, "qmd": True, "ccc": True}
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["tools_added"] == []
+    assert env["skf_setup"]["tools_removed"] == ["ccc", "qmd"]  # sorted
+
+
+def test_normalize_tools_accepts_detect_tools_output_shape():
+    """skf-detect-tools.py emits {key: {available: bool, version: ...}} — must work too."""
+    p = _baseline_payload()
+    p["tools"] = {
+        "ast_grep": {"available": True, "version": "0.39.5"},
+        "gh_cli":   {"available": False, "version": None},
+        "qmd":      {"available": True, "status": "healthy"},
+        "ccc":      {"available": True, "daemon": "healthy"},
+    }
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["tools"] == {
+        "ast_grep": True, "gh_cli": False, "qmd": True, "ccc": True,
+    }
+
+
+# ─── Warnings assembly (per step-04 §4 documented rules) ────────────────────
+
+
+def test_warnings_empty_on_clean_run():
+    env = mod.assemble_envelope(_baseline_payload())
+    assert env["skf_setup"]["warnings"] == []
+
+
+def test_warnings_includes_tier_override_invalid():
+    p = _baseline_payload()
+    p["tier_override_invalid"] = True
+    p["tier_override_invalid_value"] = "forge+"
+    env = mod.assemble_envelope(p)
+    assert any("tier_override_invalid: forge+" in w for w in env["skf_setup"]["warnings"])
+
+
+def test_warnings_includes_tier_override_unsafe():
+    p = _baseline_payload()
+    p["tier_override_unsafe"] = True
+    p["tier_override_unsafe_missing"] = ["gh", "qmd"]
+    env = mod.assemble_envelope(p)
+    assert any("tier_override_unsafe: missing gh, qmd" in w for w in env["skf_setup"]["warnings"])
+
+
+def test_warnings_includes_ccc_exclusion_warnings():
+    p = _baseline_payload()
+    p["ccc_exclusion_warnings"] = [
+        "skills_output_folder is empty; refused for ccc exclusion",
+        "forge_data_folder contains glob meta; refused",
+    ]
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["warnings"] == [
+        "skills_output_folder is empty; refused for ccc exclusion",
+        "forge_data_folder contains glob meta; refused",
+    ]
+
+
+def test_warnings_includes_ccc_registry_stale_removed():
+    p = _baseline_payload()
+    p["ccc_registry_stale_removed"] = ["/repo/old", "/repo/gone"]
+    env = mod.assemble_envelope(p)
+    assert "ccc_registry_stale_removed: /repo/old" in env["skf_setup"]["warnings"]
+    assert "ccc_registry_stale_removed: /repo/gone" in env["skf_setup"]["warnings"]
+
+
+def test_warnings_includes_qmd_daemon_stopped():
+    p = _baseline_payload()
+    p["qmd_status"] = "daemon_stopped"
+    env = mod.assemble_envelope(p)
+    assert "qmd_daemon_stopped" in env["skf_setup"]["warnings"]
+
+
+def test_warnings_includes_ccc_indexing_failed_reason():
+    p = _baseline_payload()
+    p["ccc_indexing_failed_reason"] = "out of disk space"
+    env = mod.assemble_envelope(p)
+    assert "ccc_indexing_failed: out of disk space" in env["skf_setup"]["warnings"]
+
+
+def test_warnings_includes_require_tier_failure():
+    p = _baseline_payload()
+    p["require_tier_satisfied"] = False
+    p["require_tier_failure_missing"] = ["ccc"]
+    env = mod.assemble_envelope(p)
+    assert any("require_tier_failed: missing ccc" in w for w in env["skf_setup"]["warnings"])
+
+
+# ─── files_written normalization ────────────────────────────────────────────
+
+
+def test_files_written_dict_form_filtered_to_canonical_order():
+    p = _baseline_payload()
+    p["files_written"] = {
+        "ccc_index": True,
+        "preferences.yaml": False,  # falsy → excluded
+        "forge-tier.yaml": True,
+        "settings.yml": True,
+        "unknown_key": True,        # not in VALID_FILES → excluded
+    }
+    env = mod.assemble_envelope(p)
+    # Canonical order: forge-tier.yaml, preferences.yaml, settings.yml, ccc_index
+    assert env["skf_setup"]["files_written"] == ["forge-tier.yaml", "settings.yml", "ccc_index"]
+
+
+def test_files_written_list_form_normalized():
+    p = _baseline_payload()
+    p["files_written"] = ["ccc_index", "forge-tier.yaml"]
+    env = mod.assemble_envelope(p)
+    # Reordered to canonical order regardless of input order
+    assert env["skf_setup"]["files_written"] == ["forge-tier.yaml", "ccc_index"]
+
+
+def test_files_written_unknown_names_dropped():
+    p = _baseline_payload()
+    p["files_written"] = ["forge-tier.yaml", "unknown.yaml"]
+    env = mod.assemble_envelope(p)
+    assert env["skf_setup"]["files_written"] == ["forge-tier.yaml"]
+
+
+# ─── error normalization ────────────────────────────────────────────────────
+
+
+def test_error_null_serializes_as_null():
+    env = mod.assemble_envelope(_baseline_payload())
+    assert env["skf_setup"]["error"] is None
+
+
+def test_error_object_includes_required_fields():
+    p = _baseline_payload()
+    p["error"] = {"phase": "step-02:write-config", "path": "/x/forge-tier.yaml", "reason": "permission denied"}
+    env = mod.assemble_envelope(p)
+    err = env["skf_setup"]["error"]
+    assert err == {
+        "phase": "step-02:write-config",
+        "path": "/x/forge-tier.yaml",
+        "reason": "permission denied",
+    }
+
+
+def test_error_object_missing_field_is_user_error():
+    p = _baseline_payload()
+    p["error"] = {"phase": "step-02", "path": "/x"}  # missing 'reason'
+    with pytest.raises(SystemExit) as exc:
+        mod.assemble_envelope(p)
+    assert exc.value.code == 1
+
+
+# ─── Validation rejects bad inputs ──────────────────────────────────────────
+
+
+def test_invalid_tier_value_rejected():
+    p = _baseline_payload()
+    p["tier"] = "Sparkle"
+    with pytest.raises(SystemExit):
+        mod.assemble_envelope(p)
+
+
+def test_invalid_previous_tier_value_rejected():
+    p = _baseline_payload()
+    p["previous_tier"] = "Sparkle"
+    with pytest.raises(SystemExit):
+        mod.assemble_envelope(p)
+
+
+def test_invalid_ccc_index_status_rejected():
+    p = _baseline_payload()
+    p["ccc_index"]["status"] = "exploded"
+    with pytest.raises(SystemExit):
+        mod.assemble_envelope(p)
+
+
+def test_empty_config_path_rejected():
+    p = _baseline_payload()
+    p["config_path"] = ""
+    with pytest.raises(SystemExit):
+        mod.assemble_envelope(p)
+
+
+# ─── emit_envelope_line: output shape and determinism ───────────────────────
+
+
+def test_envelope_line_starts_with_documented_prefix():
+    env = mod.assemble_envelope(_baseline_payload())
+    line = mod.emit_envelope_line(env)
+    assert line.startswith("SKF_SETUP_RESULT_JSON: ")
+
+
+def test_envelope_line_has_no_embedded_newline():
+    env = mod.assemble_envelope(_baseline_payload())
+    line = mod.emit_envelope_line(env)
+    assert "\n" not in line
+    # Body parses as JSON
+    body = line[len("SKF_SETUP_RESULT_JSON: "):]
+    parsed = json.loads(body)
+    assert parsed == env
+
+
+def test_envelope_line_is_deterministic_byte_for_byte():
+    """Same input → byte-identical output (sort_keys=True ensures stability)."""
+    p = _baseline_payload()
+    line_a = mod.emit_envelope_line(mod.assemble_envelope(p))
+    line_b = mod.emit_envelope_line(mod.assemble_envelope(p))
+    assert line_a == line_b
+
+
+# ─── Built-in stdlib JSON Schema validator ──────────────────────────────────
+
+
+def _schema():
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_validator_accepts_valid_envelope():
+    env = mod.assemble_envelope(_baseline_payload())
+    assert mod._validate_against_schema(env, _schema()) == []
+
+
+def test_validator_rejects_missing_required_property():
+    env = mod.assemble_envelope(_baseline_payload())
+    del env["skf_setup"]["tier"]
+    errors = mod._validate_against_schema(env, _schema())
+    assert any("missing required property 'tier'" in e for e in errors)
+
+
+def test_validator_rejects_unexpected_property():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["surprise"] = "yes"
+    errors = mod._validate_against_schema(env, _schema())
+    assert any("unexpected property 'surprise'" in e for e in errors)
+
+
+def test_validator_rejects_wrong_enum_value():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["tier"] = "Sparkle"
+    errors = mod._validate_against_schema(env, _schema())
+    assert any("not in enum" in e for e in errors)
+
+
+def test_validator_rejects_wrong_type():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["tier_changed"] = "true"  # string, not bool
+    errors = mod._validate_against_schema(env, _schema())
+    assert any("expected type boolean" in e for e in errors)
+
+
+def test_validator_rejects_duplicate_array_items():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["tools_added"] = ["ccc", "ccc"]
+    errors = mod._validate_against_schema(env, _schema())
+    assert any("not unique" in e for e in errors)
+
+
+def test_validator_accepts_error_object_branch_of_oneOf():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["error"] = {"phase": "x", "path": "y", "reason": "z"}
+    assert mod._validate_against_schema(env, _schema()) == []
+
+
+def test_validator_rejects_error_object_missing_field():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["error"] = {"phase": "x"}
+    errors = mod._validate_against_schema(env, _schema())
+    # Should NOT match either oneOf branch (null-branch fails type, object-branch fails required)
+    assert any("oneOf" in e for e in errors)
+
+
+# ─── End-to-end CLI subprocess tests ────────────────────────────────────────
+
+
+def _run_emit(payload: dict) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "emit"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _run_validate(envelope: dict) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "validate"],
+        input=json.dumps(envelope),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_cli_emit_produces_prefixed_one_line_output():
+    rc, stdout, stderr = _run_emit(_baseline_payload())
+    assert rc == 0, f"stderr: {stderr}"
+    lines = stdout.strip().split("\n")
+    assert len(lines) == 1
+    assert lines[0].startswith(mod.ENVELOPE_PREFIX)
+    body = json.loads(lines[0][len(mod.ENVELOPE_PREFIX):])
+    assert body["skf_setup"]["tier"] == "Deep"
+
+
+def test_cli_emit_default_subcommand_is_emit():
+    """`skf-emit-result-envelope.py` with no subcommand should default to emit."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],  # no subcommand
+        input=json.dumps(_baseline_payload()),
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith(mod.ENVELOPE_PREFIX)
+
+
+def test_cli_emit_rejects_invalid_payload():
+    bad = _baseline_payload()
+    bad["tier"] = "Sparkle"
+    rc, _, stderr = _run_emit(bad)
+    assert rc == 1
+    err = json.loads(stderr)
+    assert "tier" in err["message"]
+
+
+def test_cli_validate_accepts_well_formed_envelope():
+    env = mod.assemble_envelope(_baseline_payload())
+    rc, stdout, stderr = _run_validate(env)
+    assert rc == 0, f"stderr: {stderr}"
+    assert stdout == ""
+
+
+def test_cli_validate_rejects_malformed_envelope():
+    env = mod.assemble_envelope(_baseline_payload())
+    env["skf_setup"]["tier"] = "Sparkle"
+    rc, _, stderr = _run_validate(env)
+    assert rc == 1
+    err = json.loads(stderr)
+    assert "tier" in err["message"]

--- a/test/test-skf-merge-ccc-exclusions.py
+++ b/test/test-skf-merge-ccc-exclusions.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Tests for skf-merge-ccc-exclusions.py.
+
+Highest-value tests:
+- Validation rules from PR #248 reject the exact failure modes the prior
+  prose-driven version couldn't detect (empty, absolute, glob-meta).
+- Set-union merge is idempotent — re-running against a settings.yml that
+  already has the SKF patterns is a no-op (mtime unchanged).
+- User-customized exclude_patterns entries are preserved (not overwritten).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-merge-ccc-exclusions.py"
+)
+
+spec = importlib.util.spec_from_file_location("skf_merge_ccc_exclusions", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+@pytest.fixture
+def tmp_project():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+def _settings_path(project: Path) -> Path:
+    return project / ".cocoindex_code" / "settings.yml"
+
+
+def _read_settings(project: Path) -> dict:
+    path = _settings_path(project)
+    return yaml.safe_load(path.read_text(encoding="utf-8")) if path.exists() else {}
+
+
+# ─── validate_config_value: PR #248 rules ───────────────────────────────────
+
+
+@pytest.mark.parametrize("value,is_valid", [
+    # Valid — relative paths with no glob meta
+    ("skills",                       True),
+    ("_bmad-output/forge-data",      True),
+    ("nested/path/value",            True),
+    ("path-with.dots_and-dashes",    True),
+    # Invalid — empty / whitespace
+    ("",                             False),
+    ("   ",                          False),
+    ("\t",                           False),
+    # Invalid — absolute / anchored
+    ("/abs/path",                    False),
+    ("~/home",                       False),
+    ("./rel",                        False),
+    # Invalid — glob meta
+    ("path/*",                       False),
+    ("?ile",                         False),
+    ("dir[abc]",                     False),
+    ("**/wildcard",                  False),
+])
+def test_validate_config_value(value, is_valid):
+    cleaned, warning = mod.validate_config_value("skills_output_folder", value)
+    if is_valid:
+        assert cleaned is not None
+        assert warning is None
+    else:
+        assert cleaned is None
+        assert warning is not None
+        assert "skills_output_folder" in warning  # Warning names the offending key
+
+
+def test_validate_warning_messages_are_actionable():
+    """Each rejection reason should name (a) the key, (b) the failure mode, (c) where to fix it."""
+    _, w = mod.validate_config_value("skills_output_folder", "")
+    assert "skills_output_folder" in w
+    assert "empty" in w.lower() or "whitespace" in w.lower()
+    assert "_bmad/skf/config.yaml" in w  # config file location
+
+    _, w = mod.validate_config_value("forge_data_folder", "/abs")
+    assert "forge_data_folder" in w
+    assert "absolute" in w.lower() or "anchored" in w.lower()
+
+    _, w = mod.validate_config_value("forge_data_folder", "x*")
+    assert "glob meta" in w.lower()
+
+
+def test_validate_strips_surrounding_whitespace():
+    """A value like '  skills  ' should be treated as 'skills', not rejected."""
+    cleaned, warning = mod.validate_config_value("skills_output_folder", "  skills  ")
+    assert cleaned == "skills"
+    assert warning is None
+
+
+# ─── assemble_patterns ─────────────────────────────────────────────────────
+
+
+def test_assemble_patterns_always_includes_four_hardcoded():
+    patterns, warnings = mod.assemble_patterns("skills", "_bmad-output/forge-data")
+    assert "**/_bmad" in patterns
+    assert "**/_bmad-output" in patterns
+    assert "**/.claude" in patterns
+    assert "**/_skf-learn" in patterns
+    assert "**/skills" in patterns
+    assert "**/_bmad-output/forge-data" in patterns
+    assert warnings == []
+
+
+def test_assemble_patterns_skips_rejected_config_values():
+    """Config-value rejection MUST NOT disable the 4 always-include patterns."""
+    patterns, warnings = mod.assemble_patterns("", "/abs/path")
+    # Always-include patterns survive
+    for p in mod.ALWAYS_INCLUDE:
+        assert p in patterns
+    # Bad values DON'T appear as malformed globs
+    assert "**/" not in patterns
+    assert "**//abs/path" not in patterns
+    # Both produce warnings
+    assert len(warnings) == 2
+
+
+def test_assemble_patterns_empty_skills_keeps_forge_data():
+    """One bad value doesn't poison the other."""
+    patterns, warnings = mod.assemble_patterns("", "_bmad-output/forge-data")
+    assert "**/_bmad-output/forge-data" in patterns
+    assert "**/" not in patterns
+    assert len(warnings) == 1
+    assert "skills_output_folder" in warnings[0]
+
+
+# ─── merge_patterns ────────────────────────────────────────────────────────
+
+
+def test_merge_patterns_appends_new():
+    merged, added = mod.merge_patterns(["**/node_modules"], ["**/_bmad", "**/_bmad-output"])
+    assert merged == ["**/node_modules", "**/_bmad", "**/_bmad-output"]
+    assert added == ["**/_bmad", "**/_bmad-output"]
+
+
+def test_merge_patterns_skips_already_present():
+    merged, added = mod.merge_patterns(
+        ["**/node_modules", "**/_bmad"],
+        ["**/_bmad", "**/_bmad-output"],
+    )
+    assert merged == ["**/node_modules", "**/_bmad", "**/_bmad-output"]
+    assert added == ["**/_bmad-output"]
+
+
+def test_merge_patterns_preserves_existing_order():
+    merged, _ = mod.merge_patterns(
+        ["**/dist", "**/build", "**/node_modules"],
+        ["**/_bmad"],
+    )
+    # Existing order preserved, new entry appended
+    assert merged == ["**/dist", "**/build", "**/node_modules", "**/_bmad"]
+
+
+def test_merge_patterns_idempotent_on_full_overlap():
+    """Re-running with all-already-present yields no changes."""
+    existing = list(mod.ALWAYS_INCLUDE) + ["**/skills"]
+    to_add   = list(mod.ALWAYS_INCLUDE) + ["**/skills"]
+    merged, added = mod.merge_patterns(existing, to_add)
+    assert merged == existing
+    assert added == []
+
+
+# ─── End-to-end CLI: first run (no settings.yml) ────────────────────────────
+
+
+def _run(project: Path, skills="skills", forge_data="_bmad-output/forge-data") -> tuple[int, dict, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH),
+         "--project-root", str(project),
+         "--skills-output-folder", skills,
+         "--forge-data-folder", forge_data],
+        capture_output=True, text=True, timeout=10,
+    )
+    payload = json.loads(result.stdout) if result.stdout else None
+    return result.returncode, payload, result.stderr
+
+
+def test_cli_first_run_creates_settings_yml(tmp_project):
+    rc, payload, stderr = _run(tmp_project)
+    assert rc == 0, f"stderr: {stderr}"
+    assert payload["status"] == "ok"
+    assert payload["settings_yml_existed"] is False
+    assert payload["written"] is True
+    assert payload["patterns_added"] == 6  # 4 always + 2 config
+    assert payload["warnings"] == []
+    # File created with all 6 patterns
+    settings = _read_settings(tmp_project)
+    excludes = settings["exclude_patterns"]
+    for p in mod.ALWAYS_INCLUDE:
+        assert p in excludes
+    assert "**/skills" in excludes
+    assert "**/_bmad-output/forge-data" in excludes
+
+
+def test_cli_re_run_is_no_op_after_first_write(tmp_project):
+    # First run creates the file
+    _run(tmp_project)
+    settings_path = _settings_path(tmp_project)
+    mtime_before = settings_path.stat().st_mtime_ns
+
+    # Second run with identical inputs should be a no-op (no write, no mtime change)
+    rc, payload, _ = _run(tmp_project)
+    assert rc == 0
+    assert payload["written"] is False
+    assert payload["patterns_added"] == 0
+    assert payload["patterns_already_present"] == 6
+    assert settings_path.stat().st_mtime_ns == mtime_before
+
+
+def test_cli_existing_settings_with_user_customizations_preserved(tmp_project):
+    """A pre-existing settings.yml with user excludes must keep them."""
+    settings_path = _settings_path(tmp_project)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        "exclude_patterns:\n"
+        "  - '**/node_modules'\n"
+        "  - '**/dist'\n"
+        "other_user_setting: keep_me\n",
+        encoding="utf-8",
+    )
+
+    rc, payload, _ = _run(tmp_project)
+    assert rc == 0
+    assert payload["settings_yml_existed"] is True
+    assert payload["written"] is True
+    assert payload["patterns_added"] == 6  # All 6 SKF patterns are new
+
+    settings = _read_settings(tmp_project)
+    # User customizations preserved
+    assert "**/node_modules" in settings["exclude_patterns"]
+    assert "**/dist" in settings["exclude_patterns"]
+    assert settings["other_user_setting"] == "keep_me"
+    # Plus all SKF patterns appended
+    for p in mod.ALWAYS_INCLUDE:
+        assert p in settings["exclude_patterns"]
+
+
+def test_cli_partial_overlap_only_adds_missing(tmp_project):
+    """Some SKF patterns already present — only the missing ones are added."""
+    settings_path = _settings_path(tmp_project)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    # User has manually added two of the four always-include patterns.
+    settings_path.write_text(
+        "exclude_patterns:\n"
+        "  - '**/_bmad'\n"
+        "  - '**/.claude'\n",
+        encoding="utf-8",
+    )
+
+    rc, payload, _ = _run(tmp_project)
+    assert rc == 0
+    assert payload["written"] is True
+    # 6 SKF patterns total, 2 already present, 4 newly added
+    assert payload["patterns_added"] == 4
+    assert payload["patterns_already_present"] == 2
+    assert "**/_bmad" not in payload["patterns_added_list"]
+    assert "**/.claude" not in payload["patterns_added_list"]
+
+
+# ─── PR #248 incident reproductions ─────────────────────────────────────────
+
+
+def test_cli_pr248_empty_skills_folder(tmp_project):
+    """User has skills_output_folder='' in config — refuse, warn, but still write hardcoded patterns."""
+    rc, payload, _ = _run(tmp_project, skills="", forge_data="_bmad-output/forge-data")
+    assert rc == 0
+    settings = _read_settings(tmp_project)
+    assert "**/" not in settings["exclude_patterns"]  # The would-be-malformed glob is NOT present
+    # Always-include patterns still applied
+    for p in mod.ALWAYS_INCLUDE:
+        assert p in settings["exclude_patterns"]
+    # forge_data_folder still applied (one bad value doesn't poison the other)
+    assert "**/_bmad-output/forge-data" in settings["exclude_patterns"]
+    # Warning is surfaced
+    assert any("skills_output_folder" in w for w in payload["warnings"])
+
+
+def test_cli_pr248_absolute_skills_folder(tmp_project):
+    rc, payload, _ = _run(tmp_project, skills="/home/u/skills", forge_data="_bmad-output/forge-data")
+    assert rc == 0
+    settings = _read_settings(tmp_project)
+    # Malformed `**//home/u/skills` glob NOT present
+    assert "**//home/u/skills" not in settings["exclude_patterns"]
+    assert any("skills_output_folder" in w and ("absolute" in w.lower() or "anchored" in w.lower())
+               for w in payload["warnings"])
+
+
+def test_cli_pr248_glob_meta_in_forge_data_folder(tmp_project):
+    rc, payload, _ = _run(tmp_project, skills="skills", forge_data="forge-*")
+    assert rc == 0
+    settings = _read_settings(tmp_project)
+    assert "**/forge-*" not in settings["exclude_patterns"]
+    assert any("forge_data_folder" in w and "glob meta" in w.lower() for w in payload["warnings"])
+
+
+# ─── Error paths ────────────────────────────────────────────────────────────
+
+
+def test_cli_missing_required_arg():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--skills-output-folder", "skills"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode != 0
+
+
+def test_cli_malformed_existing_settings(tmp_project):
+    settings_path = _settings_path(tmp_project)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text("exclude_patterns: [unclosed\n", encoding="utf-8")
+    rc, _, stderr = _run(tmp_project)
+    assert rc == 1
+    err = json.loads(stderr)
+    assert "failed to parse" in err["message"]
+
+
+def test_cli_non_list_exclude_patterns_dies(tmp_project):
+    settings_path = _settings_path(tmp_project)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text("exclude_patterns: 42\n", encoding="utf-8")
+    rc, _, stderr = _run(tmp_project)
+    assert rc == 1
+
+
+def test_cli_non_mapping_top_level_dies(tmp_project):
+    settings_path = _settings_path(tmp_project)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    rc, _, stderr = _run(tmp_project)
+    assert rc == 1

--- a/test/test-skf-qmd-classify-collections.py
+++ b/test/test-skf-qmd-classify-collections.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Tests for skf-qmd-classify-collections.py.
+
+Classification rules under test (per step-03 §3 and PR #244):
+
+  Healthy   = forge-suffix-matched live ∩ registry
+  Orphaned  = forge-suffix-matched live − registry
+  Stale     = registry − ALL live (includes foreign-suffix names)
+  Foreign   = live − forge-suffix-matched (silently excluded from
+              every classification, reported as count + capped sample)
+
+The PR #244 incident — a fresh-setup user with 48 unrelated Hindsight
+memory-bank collections in their QMD daemon — is reproduced as
+test_pr244_incident_reproduction below.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-qmd-classify-collections.py"
+)
+
+spec = importlib.util.spec_from_file_location("skf_qmd_classify", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ─── Forge-namespace recognition ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("foo-brief",          True),
+    ("foo-temporal",       True),
+    ("foo-docs",           True),
+    ("foo-extraction",     True),
+    ("multi-word-skill-name-extraction", True),
+    ("memory-root-1",      False),
+    ("sessions-2",         False),
+    ("foo",                False),
+    ("foo-other",          False),
+    ("brief",              False),  # exact match without prefix dash → not forge
+    ("foo-brief-extra",    False),  # suffix must be terminal
+    ("",                   False),
+])
+def test_is_forge_owned(name, expected):
+    assert mod.is_forge_owned(name) is expected
+
+
+# ─── parse_live_names ───────────────────────────────────────────────────────
+
+
+def test_parse_live_names_handles_empty():
+    assert mod.parse_live_names("") == []
+    assert mod.parse_live_names("   ") == []
+
+
+def test_parse_live_names_strips_whitespace():
+    assert mod.parse_live_names(" foo , bar ,  baz ") == ["foo", "bar", "baz"]
+
+
+def test_parse_live_names_dedups_preserving_order():
+    assert mod.parse_live_names("a,b,a,c,b,a") == ["a", "b", "c"]
+
+
+def test_parse_live_names_skips_empty_segments():
+    assert mod.parse_live_names("a,,b,,,c,") == ["a", "b", "c"]
+
+
+# ─── load_registry_names ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_yaml():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td) / "forge-tier.yaml"
+
+
+def test_load_registry_missing_file_returns_empty(tmp_yaml):
+    assert mod.load_registry_names(tmp_yaml) == []
+
+
+def test_load_registry_extracts_names_from_qmd_collections(tmp_yaml):
+    tmp_yaml.write_text(
+        "qmd_collections:\n"
+        "  - name: foo-brief\n"
+        "    type: brief\n"
+        "  - name: foo-extraction\n"
+        "    type: extraction\n",
+        encoding="utf-8",
+    )
+    assert mod.load_registry_names(tmp_yaml) == ["foo-brief", "foo-extraction"]
+
+
+def test_load_registry_skips_entries_without_name(tmp_yaml):
+    tmp_yaml.write_text(
+        "qmd_collections:\n"
+        "  - name: foo-brief\n"
+        "  - type: extraction\n"  # no name
+        "  - name: bar-docs\n",
+        encoding="utf-8",
+    )
+    assert mod.load_registry_names(tmp_yaml) == ["foo-brief", "bar-docs"]
+
+
+def test_load_registry_empty_array(tmp_yaml):
+    tmp_yaml.write_text("qmd_collections: []\n", encoding="utf-8")
+    assert mod.load_registry_names(tmp_yaml) == []
+
+
+def test_load_registry_missing_array_key(tmp_yaml):
+    tmp_yaml.write_text("tier: Deep\n", encoding="utf-8")
+    assert mod.load_registry_names(tmp_yaml) == []
+
+
+def test_load_registry_malformed_yaml_dies(tmp_yaml):
+    tmp_yaml.write_text("qmd_collections: [unclosed\n", encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        mod.load_registry_names(tmp_yaml)
+    assert exc.value.code == 1
+
+
+def test_load_registry_non_list_dies(tmp_yaml):
+    tmp_yaml.write_text("qmd_collections: 42\n", encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        mod.load_registry_names(tmp_yaml)
+    assert exc.value.code == 1
+
+
+# ─── classify() — the core set arithmetic ────────────────────────────────────
+
+
+def test_classify_first_run_no_collections():
+    """Empty live, empty registry — everything is empty."""
+    out = mod.classify([], [])
+    assert out == {
+        "healthy": [],
+        "orphaned": [],
+        "stale": [],
+        "foreign_filtered_count": 0,
+        "foreign_filtered_sample": [],
+    }
+
+
+def test_classify_all_healthy():
+    live = ["foo-brief", "foo-extraction"]
+    registry = ["foo-brief", "foo-extraction"]
+    out = mod.classify(live, registry)
+    assert out["healthy"] == ["foo-brief", "foo-extraction"]
+    assert out["orphaned"] == []
+    assert out["stale"] == []
+
+
+def test_classify_orphan_in_qmd_only():
+    """Live collection with forge suffix but not in registry → orphaned."""
+    live = ["foo-brief", "lost-extraction"]
+    registry = ["foo-brief"]
+    out = mod.classify(live, registry)
+    assert out["healthy"] == ["foo-brief"]
+    assert out["orphaned"] == ["lost-extraction"]
+    assert out["stale"] == []
+
+
+def test_classify_stale_in_registry_only():
+    """Registry entry not in QMD → stale."""
+    live = ["foo-brief"]
+    registry = ["foo-brief", "deleted-temporal"]
+    out = mod.classify(live, registry)
+    assert out["healthy"] == ["foo-brief"]
+    assert out["orphaned"] == []
+    assert out["stale"] == ["deleted-temporal"]
+
+
+def test_classify_foreign_silently_excluded():
+    """Live collections without forge suffix are foreign — never displayed."""
+    live = ["foo-brief", "memory-root-1", "sessions-2", "bar-extraction"]
+    registry = ["foo-brief", "bar-extraction"]
+    out = mod.classify(live, registry)
+    assert out["healthy"] == ["bar-extraction", "foo-brief"]
+    assert out["orphaned"] == []
+    assert out["stale"] == []
+    assert out["foreign_filtered_count"] == 2
+    assert out["foreign_filtered_sample"] == ["memory-root-1", "sessions-2"]
+
+
+def test_classify_pr244_incident_reproduction():
+    """The exact data-loss footgun PR #244 closed, in test form.
+
+    User runs setup for the first time on a host that has 48 Hindsight
+    memory-bank collections in QMD. Registry is empty. Without the
+    forge-namespace filter, all 48 Hindsight collections would have
+    been classified as orphaned and offered for removal. With the
+    filter, they are silently excluded and never enter the orphan
+    classification.
+    """
+    hindsight = [f"{prefix}-{i}" for prefix in
+                 ("memory-root", "memory-alt", "memory-dir", "sessions") for i in range(12)]
+    assert len(hindsight) == 48
+
+    out = mod.classify(hindsight, [])
+    assert out["orphaned"] == [], "PR #244 regression — Hindsight banks would be deleted"
+    assert out["stale"] == []
+    assert out["foreign_filtered_count"] == 48
+    assert len(out["foreign_filtered_sample"]) == mod.FOREIGN_SAMPLE_CAP  # capped
+
+
+def test_classify_mixed_realistic_scenario():
+    """A real-world Deep host with some forge skills + some foreign collections + drift."""
+    live = [
+        # Forge-managed, in registry — healthy
+        "lib1-brief", "lib1-extraction", "lib2-brief",
+        # Forge-managed, NOT in registry — orphaned (manual ccc test maybe)
+        "experimental-extraction",
+        # Foreign collections from other tools — silently excluded
+        "memory-root-1", "memory-alt-2",
+    ]
+    registry = [
+        "lib1-brief", "lib1-extraction", "lib2-brief",
+        "deleted-skill-extraction",  # was deleted from QMD — stale
+    ]
+    out = mod.classify(live, registry)
+    assert out["healthy"] == ["lib1-brief", "lib1-extraction", "lib2-brief"]
+    assert out["orphaned"] == ["experimental-extraction"]
+    assert out["stale"] == ["deleted-skill-extraction"]
+    assert out["foreign_filtered_count"] == 2
+
+
+def test_classify_results_are_sorted_for_determinism():
+    """Same input — byte-identical output. Set ops are unordered; sorted() makes them stable."""
+    live = ["zoo-brief", "alpha-brief", "mid-extraction"]
+    registry = ["zoo-brief", "alpha-brief", "mid-extraction"]
+    out = mod.classify(live, registry)
+    assert out["healthy"] == ["alpha-brief", "mid-extraction", "zoo-brief"]
+
+
+def test_classify_foreign_sample_capped_but_count_accurate():
+    live = [f"foreign-{i}" for i in range(20)]  # all foreign (no forge suffix)
+    out = mod.classify(live, [])
+    assert out["foreign_filtered_count"] == 20
+    assert len(out["foreign_filtered_sample"]) == mod.FOREIGN_SAMPLE_CAP
+
+
+def test_classify_registry_entries_with_non_forge_names_still_classified():
+    """Hand-edited registry could contain a non-forge name — still tracked correctly."""
+    live = ["foo-brief"]  # no foreign-name in live
+    registry = ["foo-brief", "weird-no-suffix"]  # registry has a non-forge name
+    out = mod.classify(live, registry)
+    # weird-no-suffix is not in live, so it's stale (registry−live).
+    assert "weird-no-suffix" in out["stale"]
+
+
+# ─── End-to-end CLI subprocess tests ────────────────────────────────────────
+
+
+def _run(*args) -> tuple[int, dict, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True, text=True, timeout=10,
+    )
+    payload = json.loads(result.stdout) if result.stdout else None
+    return result.returncode, payload, result.stderr
+
+
+def test_cli_first_run_state(tmp_yaml):
+    """No live collections, no registry file → emit empty everything."""
+    rc, payload, stderr = _run("--live-names", "", "--registry-from-yaml", str(tmp_yaml))
+    assert rc == 0, f"stderr: {stderr}"
+    assert payload["status"] == "ok"
+    assert payload["version"] == "v1"
+    assert payload["healthy"] == []
+    assert payload["orphaned"] == []
+    assert payload["stale"] == []
+
+
+def test_cli_realistic_deep_host(tmp_yaml):
+    tmp_yaml.write_text(
+        "qmd_collections:\n"
+        "  - name: lib1-brief\n"
+        "    type: brief\n"
+        "  - name: lib1-extraction\n"
+        "    type: extraction\n",
+        encoding="utf-8",
+    )
+    rc, payload, _ = _run(
+        "--live-names", "lib1-brief,lib1-extraction,memory-root-1",
+        "--registry-from-yaml", str(tmp_yaml),
+    )
+    assert rc == 0
+    assert payload["healthy"] == ["lib1-brief", "lib1-extraction"]
+    assert payload["orphaned"] == []
+    assert payload["stale"] == []
+    assert payload["foreign_filtered_count"] == 1
+
+
+def test_cli_pr244_incident(tmp_yaml):
+    """End-to-end repro of the PR #244 incident."""
+    # Empty registry, 4 Hindsight foreign collections in live
+    rc, payload, _ = _run(
+        "--live-names", "memory-root-1,memory-alt-2,memory-dir-3,sessions-4",
+        "--registry-from-yaml", str(tmp_yaml),  # missing file → empty registry
+    )
+    assert rc == 0
+    assert payload["orphaned"] == []
+    assert payload["foreign_filtered_count"] == 4
+
+
+def test_cli_missing_required_arg():
+    """--registry-from-yaml is required."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--live-names", "foo-brief"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode != 0
+
+
+def test_cli_malformed_registry_emits_error(tmp_yaml):
+    tmp_yaml.write_text("qmd_collections: [unclosed\n", encoding="utf-8")
+    rc, _, stderr = _run("--live-names", "", "--registry-from-yaml", str(tmp_yaml))
+    assert rc == 1
+    err = json.loads(stderr)
+    assert "failed to parse" in err["message"]


### PR DESCRIPTION
## Summary

Second of three PRs implementing Theme #1 (Intelligence Placement). This PR adds the three "hygiene" scripts: the envelope schema-lock for the public \`SKF_SETUP_RESULT_JSON\` contract, the QMD collection classifier with the PR #244 forge-namespace filter, and the CCC exclusion merger with the PR #248 config-value validation. Like PR A (#249), this is **Phase 1** — scripts wired into \`npm run test:python\` but **no live workflow path invokes them yet**. PR C does that.

Branch: \`feat/skf-setup-shared-scripts-hygiene\` (3 commits, 115 passing tests, +2,185 lines).

## Commits

- **\`feat(shared/scripts): lock SKF_SETUP_RESULT_JSON envelope behind a script + JSON Schema\`** — Three artifacts. (1) JSON Schema at \`src/shared/scripts/schemas/skf-setup-result-envelope.v1.json\` documenting every required field with Draft 2020-12. (2) \`skf-emit-result-envelope.py\` with two subcommands: \`emit\` (default) reads context payload as JSON on stdin, derives \`tools_added\`/\`tools_removed\` via set-diff, derives \`tier_changed\` via comparison, folds in every documented warning source, validates against the schema (assertion of internal correctness), emits the single prefixed line \`SKF_SETUP_RESULT_JSON: {one-line JSON}\`. \`validate\` checks an envelope without the prefix against the schema. (3) Stdlib-only minimal JSON Schema validator covering the subset we actually use (avoids a \`jsonschema\` runtime dep). 43 passing tests including derivation rules, warnings fold-in for every source, files_written normalization, error oneOf handling, deterministic byte-for-byte output, validator coverage, and end-to-end CLI tests.

- **\`feat(shared/scripts): add skf-qmd-classify-collections.py for forge-namespace classification\`** — Set arithmetic over QMD collection names. Reads forge-tier.yaml's \`qmd_collections\` array and a comma-separated live-names list from \`qmd collection list\`. Applies the PR #244 forge-namespace suffix filter (\`-brief\`, \`-temporal\`, \`-docs\`, \`-extraction\`) so collections owned by unrelated tools sharing the QMD daemon are silently excluded from every classification. Output: healthy / orphaned / stale / foreign_filtered_count / capped 5-entry foreign_filtered_sample. 38 passing tests including a parametrized 12-case forge-suffix recognition table, registry loading edge cases, the explicit PR #244 incident reproduction (48 simulated Hindsight foreign collections produce 0 orphaned), a hand-edited registry edge case, and end-to-end CLI tests.

- **\`feat(shared/scripts): add skf-merge-ccc-exclusions.py for SKF exclusion merge\`** — Validates config-driven values per PR #248 (rejects empty/absolute/glob-meta), assembles the SKF exclusion list (4 always-include + 2 conditional from validated config), and performs an idempotent set-union merge into \`.cocoindex_code/settings.yml\`. User customizations preserved. Idempotent re-runs do NOT rewrite the file (mtime unchanged) when nothing new needs adding. 34 passing tests including a 14-case parametrized validation table covering all PR #248 rejection rules, three explicit PR #248 incident reproductions (empty value, absolute path, glob-meta), and assertions that the would-be-malformed glob never appears in the resulting settings.yml AND the warning is surfaced.

## Architectural decisions (consistent with PR A)

- **All three scripts under \`src/shared/scripts/\`** with the \`skf-\` prefix, matching the precedent.
- **Two distinct contracts**: the per-script JSON outputs (consumed by future PR C step prompts) are separate from the public \`SKF_SETUP_RESULT_JSON\` envelope (assembled by \`skf-emit-result-envelope.py\` from those per-script outputs). Decoupled so internal extension doesn't drift the public contract.
- **Idempotent re-runs**: every script that mutates files (just \`merge-ccc-exclusions\` in this PR) skips the write entirely when nothing changed, preserving mtime — important for CI flock budget and re-run cleanliness.
- **No new runtime dependencies**: PyYAML (already declared) is the only dep added; the JSON Schema validator is hand-rolled stdlib to avoid pulling in \`jsonschema\`.
- **Pure functions throughout**: \`assemble_envelope\`, \`classify\`, \`assemble_patterns\`, \`merge_patterns\`, \`validate_config_value\` are all importable and side-effect-free, which is what makes the test coverage so dense.

## Tests

115 passing across three new test files:

\`\`\`
test/test-skf-emit-result-envelope.py        43 passed
test/test-skf-qmd-classify-collections.py    38 passed
test/test-skf-merge-ccc-exclusions.py        34 passed
\`\`\`

Highlights:

- **PR #244 incident reproduction** (\`test_classify_pr244_incident_reproduction\`) — 48 simulated Hindsight foreign collections must produce 0 orphaned entries on a fresh-setup empty-registry run. Locks the data-loss footgun that PR #244 closed.
- **PR #248 incident reproductions** (3 tests) — empty / absolute / glob-meta config values must NOT result in a malformed glob appearing in the resulting \`settings.yml\`. Each rejection produces an actionable warning naming the offending key, the failure mode, and the fix location.
- **Envelope derivation rules** match the documented step-04 §4 behaviour exactly: \`tier_changed\` is false on first runs and same-tier reruns; \`tools_added\` surfaces newly-installed tools on same-tier reruns; sorted-deterministic output everywhere.
- **Schema-validator coverage** covers oneOf branch resolution, missing/extra/wrong-type properties, enum violations, and uniqueItems — every Schema feature the envelope schema actually uses.
- **Merge idempotence** — running ccc-exclusions twice with identical input does NOT rewrite settings.yml (mtime asserted unchanged).

Full local \`npm run quality\` passed on every commit via husky pre-commit.

## Combined Theme #1 status (after this PR)

| PR | Status | Scripts | Tests |
|---|---|---|---|
| PR A (#249) | Merged | \`skf-detect-tools.py\`, \`skf-forge-tier-rw.py\` | 124 |
| **PR B (this)** | **Open** | \`skf-emit-result-envelope.py\` + JSON Schema, \`skf-qmd-classify-collections.py\`, \`skf-merge-ccc-exclusions.py\` | **115** |
| PR C (next) | Not started | (no new scripts — rewrites step prompts to invoke all 5) | TBD |

After this PR, all 5 of the planned scripts are in place. PR C is the live-workflow change.

## Test plan

- [x] CI green on \`quality.yaml\` (Linux + Windows matrix). Note: test:python now runs 115 additional tests; total runtime impact ~2s.
- [x] On a fresh checkout, \`echo '{...minimal-context...}' | python3 src/shared/scripts/skf-emit-result-envelope.py\` produces a single-line \`SKF_SETUP_RESULT_JSON: {...}\` whose body parses as JSON and validates against the schema.
- [x] On a host with \`qmd collection list\` showing some forge collections + some foreign ones, \`skf-qmd-classify-collections.py --live-names "..." --registry-from-yaml /path/to/forge-tier.yaml\` produces the expected healthy/orphaned/stale split with foreign collections in \`foreign_filtered_sample\` only.
- [x] On a project with no \`.cocoindex_code/settings.yml\`, \`skf-merge-ccc-exclusions.py --project-root . --skills-output-folder skills --forge-data-folder _bmad-output/forge-data\` creates the file with all 6 patterns and an empty \`warnings\` array.
- [x] Same command run a second time produces \`written: false, patterns_added: 0\` and does NOT change the file's mtime.
- [x] Same command with \`--skills-output-folder ""\` (empty) produces a warning naming \`skills_output_folder\` and fix location \`{project-root}/_bmad/skf/config.yaml\`, AND the resulting settings.yml does NOT contain a \`**/\` entry.