### PR TITLE
polish(skf-setup): close human-experience polish themes (uv probe + tier defuser + headless banner suppression)

### DIFF
--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -49,12 +49,16 @@ These rules apply to every step in this workflow:
 
 ## On Activation
 
-1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
+1. **Probe `uv` runtime.** Run `uv --version`. Every step in this workflow invokes shared Python helpers via `uv run` (PEP 723 inline metadata is what auto-resolves `pyyaml` for the helpers that need it — see `docs/getting-started.md`). If `uv` is missing, halt now with a single cohesive diagnostic rather than letting five separate steps each fail with `uv: command not found`:
+
+   "**Setup cannot proceed: `uv` is not installed.** SKF helpers depend on `uv` to auto-resolve their Python dependencies. Install it from <https://docs.astral.sh/uv/getting-started/installation/> and re-run `/skf-setup`. (See the Prerequisites section in <https://docs.astral.sh/uv/getting-started/installation/> or the SKF docs at `docs/getting-started.md` for details.)"
+
+2. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
    - `project_name` (from installer-generated config.yaml, not module.yaml), `output_folder`, `user_name`, `communication_language`, `document_output_language`
    - `skills_output_folder`, `forge_data_folder`, `sidecar_path`
 
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+3. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
-3. **Resolve `{require_tier}`**: parse `--require-tier=<value>` from the invocation arguments. Accept exactly `Quick`, `Forge`, `Forge+`, or `Deep` (case-sensitive). If absent or unparseable, leave as null (no tier requirement).
+4. **Resolve `{require_tier}`**: parse `--require-tier=<value>` from the invocation arguments. Accept exactly `Quick`, `Forge`, `Forge+`, or `Deep` (case-sensitive). If absent or unparseable, leave as null (no tier requirement).
 
-4. Load, read the full file, and then execute `./steps-c/step-01-detect-and-tier.md` to begin the workflow.
+5. Load, read the full file, and then execute `./steps-c/step-01-detect-and-tier.md` to begin the workflow.

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -45,6 +45,8 @@ Verify availability of the four forge tools (ast-grep, gh, qmd, ccc), read any e
 - Create `{forge_data_folder}/` if missing
 - When ccc is available: augment `{project-root}/.cocoindex_code/settings.yml` with SKF exclusion patterns, then create or refresh the project ccc index
 
+**About tiers:** SKF picks one of four tiers (Quick / Forge / Forge+ / Deep) based on which tools are installed. **All four are fully usable** — higher tiers add power, they don't fix gaps. If you're new and only have a base Python install, Quick tier is the right starting point and the report at the end will show you exactly which tools to install if you want to climb later.
+
 Press Esc or Ctrl+C now if this isn't the right project — no files have been written yet."
 
 ### 2. Run Detection Helper

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -27,13 +27,19 @@ Display the forge status report with positive capability framing, surface tier c
 - Never inline-render the envelope JSON — the script owns the schema; drift breaks pipelines
 - Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing status report is NOT the terminal step
 
+## Headless Mode Display Rule
+
+When `{headless_mode}` is `true`, sections 2 (the human-readable banner) and 3 (the REQUIRED TIER NOT MET human prose block) are **skipped entirely**. The single line of stdout in headless mode is the `SKF_SETUP_RESULT_JSON: {…}` envelope from section 4 — every signal the human banner would have surfaced is already in the envelope (`tier`, `previous_tier`, `tier_changed`, `tools`, `tools_added`, `tools_removed`, `files_written`, `tier_override_*`, `require_tier_satisfied`, `warnings`, `error`). Parent skills and CI pipelines consume one parseable line; they should not be forced to scroll past 30 lines of ASCII-art they cannot use.
+
+When `{headless_mode}` is `false`, sections 2 and 3 display normally and section 4 is skipped (interactive runs read the human banner; envelope emission would just be log noise).
+
 ## MANDATORY SEQUENCE
 
 ### 1. Load Capability Descriptions
 
-Load and read {tierRulesData} for the tier capability descriptions and re-run messages.
+Load and read {tierRulesData} for the tier capability descriptions and re-run messages. Needed by section 2; safe to load unconditionally — the data load itself is silent.
 
-### 2. Display Forge Status Report
+### 2. Display Forge Status Report (skip when `{headless_mode}` is true)
 
 **Format the report as follows:**
 
@@ -136,9 +142,11 @@ The same-tier-with-tool-deltas branch reads `{tools_added}` and `{tools_removed}
 - Do NOT list unavailable tools
 - Do NOT show a "missing" column or section
 
-### 3. Display Required-Tier Failure Block (when applicable)
+### 3. Display Required-Tier Failure Block (when applicable; skip when `{headless_mode}` is true)
 
-If `{require_tier_satisfied}` is `false`, display this block immediately after the status report and BEFORE the JSON envelope:
+If `{require_tier_satisfied}` is `false` AND `{headless_mode}` is `false`, display this block immediately after the status report. In headless mode the failure surfaces via the envelope's `require_tier_satisfied: false` and the synthesized `warnings` entry — the human prose block would be log noise that pipelines have to scroll past.
+
+When the block does fire (interactive run with require-tier failure):
 
 ```
 ═══════════════════════════════════════


### PR DESCRIPTION
## Summary

Theme #2 from the post-Theme-#1 quality re-scan (\`2026-04-27T121255\`). Three small refinements that touch distinct user journeys with outsized leverage.

Branch: \`polish/skf-setup-human-experience-theme2\` (1 commit, +22 / -8 lines across 3 files).

## Three fixes

**1. Upfront \`uv\` probe** (SKILL.md, On Activation step 1) — every step in this workflow invokes Python helpers via \`uv run\` post-PR-#251/#252. When \`uv\` is missing, prior behaviour was 5 separate \`uv: command not found\` errors as each step tried and failed individually. Now a single \`uv --version\` probe runs once before any helper invocation and halts with a cohesive diagnostic naming the install URL. Subsequent activation steps renumbered (2-5).

**2. Tier vocabulary defuser** (step-01 first-run preamble) — the status report leans on "tier" everywhere (capability descriptions, climb-hints, re-run delta messages). A first-time user at Quick reads "Climb to next tier" and concludes they did something wrong; in fact Quick is fully usable and "tier" just means "set of installed tools". Added a one-paragraph "About tiers" defuser to the first-run preamble (which already only fires when \`{previous_tier}\` is null AND \`{headless_mode}\` is false, so it doesn't pollute re-runs or pipelines).

**3. Headless mode suppresses the human banner** (step-04) — the SKF_SETUP_RESULT_JSON envelope contract is best-in-class but prior behaviour was to emit the full ~30-line ASCII-art banner PLUS the envelope on every headless run. Parent skills and CI pipelines had to scroll past or filter around banner output they could not consume. New "Headless Mode Display Rule" section establishes the contract explicitly: when \`{headless_mode}\` is true, sections 2 (banner) and 3 (REQUIRED TIER NOT MET prose block) are skipped entirely, and the single line of stdout is the envelope from section 4. Every signal the banner would have surfaced is already in the envelope (tier, previous_tier, tier_changed, tools, tools_added, tools_removed, files_written, tier_override_*, require_tier_satisfied, warnings, error).

## Why now

The \`2026-04-27T121255\` re-scan placed all three findings in Theme #2 (medium severity, "outsized leverage"). After this lands, skf-setup's remaining quality-analysis backlog is just **Theme #1 of the rescan** (per-stage \`Language\` config headers — mechanical config-header compliance, single small commit) and **Theme #3** (low-severity edge-case refinements). The workflow is now in clear "polish-only" status.

## Test plan

- [x] CI green on \`quality.yaml\` (Linux + Windows matrix)
- [x] On a host without \`uv\` installed, invoking \`/skf-setup\` halts at On Activation step 1 with the cohesive install-instructions diagnostic — no downstream \`uv: command not found\` errors
- [x] First-time interactive run displays the "About tiers" defuser as part of the preamble; user understands Quick is a fully-usable tier rather than a failure mode
- [x] \`/skf-setup --headless\` produces a SINGLE line of stdout (the \`SKF_SETUP_RESULT_JSON: {…}\` envelope) — no ASCII banner, no climb hints, no FORGE STATUS box
- [x] \`/skf-setup --headless --require-tier=Deep\` on a Forge-tier host produces a single envelope line with \`require_tier_satisfied: false\` and a synthesized \`warnings\` entry — the REQUIRED TIER NOT MET human prose block is suppressed in favor of the envelope signal
- [x] Re-run on a Deep host (interactive, not first-run) does NOT show the "About tiers" defuser (already a returning user; first-run preamble correctly gated on \`{previous_tier}\` being null)