### PR TITLE
polish(skf-setup): close remaining themes — Language headers + low-severity edges (zero open opportunities)

### DIFF
--- a/src/shared/scripts/skf-detect-tools.py
+++ b/src/shared/scripts/skf-detect-tools.py
@@ -71,6 +71,7 @@ DETECT_OUTPUT_SCHEMA (v1):
       "override_value":          str|null,
       "override_invalid":        bool,
       "override_invalid_value":  str|null,
+      "override_invalid_suggestion": str|null,
       "override_unsafe":         bool,
       "override_unsafe_missing": [str]
     },
@@ -206,6 +207,33 @@ def calculate_tier(tools: dict) -> str:
     return "Quick"
 
 
+def suggest_valid_tier(bad_value: str) -> str | None:
+    """For an invalid --tier-override value, return the closest valid tier name.
+
+    Two-stage match:
+    1. Case-insensitive exact match — handles `deep` / `DEEP` / `forge+` /
+       `FORGE+` (the most common typo class: right tier, wrong case).
+    2. difflib fuzzy match against `VALID_TIERS` with a 0.6 cutoff — handles
+       `frorge`, `quik`, `forge plus`, etc.
+
+    Returns None if no candidate clears the cutoff. Used only for diagnostic
+    messages — the override itself is never silently auto-corrected.
+    """
+    import difflib
+
+    if not bad_value or not isinstance(bad_value, str):
+        return None
+    cleaned = bad_value.strip()
+    if not cleaned:
+        return None
+    cleaned_lower = cleaned.lower()
+    for valid in VALID_TIERS:
+        if valid.lower() == cleaned_lower:
+            return valid
+    matches = difflib.get_close_matches(cleaned, VALID_TIERS, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
 def tier_prerequisites_met(tier: str, tools: dict) -> tuple[bool, list[str]]:
     """Return (satisfied, missing_tools) for tier-prerequisite checks.
 
@@ -243,6 +271,7 @@ def detect(args: argparse.Namespace) -> dict:
     override_value: str | None = None
     override_invalid = False
     override_invalid_value: str | None = None
+    override_invalid_suggestion: str | None = None
     override_unsafe = False
     override_unsafe_missing: list[str] = []
 
@@ -258,6 +287,7 @@ def detect(args: argparse.Namespace) -> dict:
         else:
             override_invalid = True
             override_invalid_value = args.tier_override
+            override_invalid_suggestion = suggest_valid_tier(args.tier_override)
             calculated = detected
     else:
         calculated = detected
@@ -281,6 +311,7 @@ def detect(args: argparse.Namespace) -> dict:
             "override_value": override_value,
             "override_invalid": override_invalid,
             "override_invalid_value": override_invalid_value,
+            "override_invalid_suggestion": override_invalid_suggestion,
             "override_unsafe": override_unsafe,
             "override_unsafe_missing": override_unsafe_missing,
         },

--- a/src/shared/scripts/skf-emit-result-envelope.py
+++ b/src/shared/scripts/skf-emit-result-envelope.py
@@ -45,6 +45,7 @@ Context payload shape (consumed by `emit`):
     "tier_override_active":          bool,
     "tier_override_invalid":         bool,
     "tier_override_invalid_value":   "string|null",
+    "tier_override_invalid_suggestion": "string|null",
     "tier_override_unsafe":          bool,
     "tier_override_unsafe_missing":  ["gh", "qmd", ...],
     "require_tier_satisfied":        bool|null,
@@ -152,7 +153,12 @@ def _assemble_warnings(payload: dict) -> list[str]:
     warnings: list[str] = []
     if payload.get("tier_override_invalid"):
         bad = payload.get("tier_override_invalid_value")
-        warnings.append(f"tier_override_invalid: {bad if bad is not None else '<unknown>'}")
+        suggestion = payload.get("tier_override_invalid_suggestion")
+        bad_text = bad if bad is not None else "<unknown>"
+        if suggestion:
+            warnings.append(f"tier_override_invalid: {bad_text} (did you mean {suggestion}?)")
+        else:
+            warnings.append(f"tier_override_invalid: {bad_text}")
     if payload.get("tier_override_unsafe"):
         missing = payload.get("tier_override_unsafe_missing", []) or []
         warnings.append(f"tier_override_unsafe: missing {', '.join(missing) if missing else '<none>'}")

--- a/src/skf-setup/SKILL.md
+++ b/src/skf-setup/SKILL.md
@@ -57,6 +57,12 @@ These rules apply to every step in this workflow:
    - `project_name` (from installer-generated config.yaml, not module.yaml), `output_folder`, `user_name`, `communication_language`, `document_output_language`
    - `skills_output_folder`, `forge_data_folder`, `sidecar_path`
 
+   **If the file does not exist**, halt with a single cohesive "wrong directory" diagnostic rather than failing later with a generic file-read error from a downstream step:
+
+   "**Setup cannot proceed: `{project-root}/_bmad/skf/config.yaml` was not found.** This directory does not appear to be an SKF-initialised project. From the project root, run `npx bmad-module-skill-forge install` (or `npx bmad-method install` and add SKF as a custom module — see `docs/getting-started.md`), then re-run `/skf-setup`. If you ARE in the right project but the file was deleted, restore it from version control or re-run the SKF installer."
+
+   **If the file exists but is malformed YAML**, halt and surface the parser error along with the file path so the user can fix it directly: "**Setup cannot proceed: `{project-root}/_bmad/skf/config.yaml` is not valid YAML.** Parser error: {error_message}. Open the file and repair the YAML, or restore from version control."
+
 3. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
 4. **Resolve `{require_tier}`**: parse `--require-tier=<value>` from the invocation arguments. Accept exactly `Quick`, `Forge`, `Forge+`, or `Deep` (case-sensitive). If absent or unparseable, leave as null (no tier requirement).

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -9,6 +9,8 @@ detectToolsProbeOrder:
   - '{project-root}/src/shared/scripts/skf-detect-tools.py'
 ---
 
+<!-- Config: communicate in {communication_language}. The first-run preamble below is user-visible — render it in the user's language. -->
+
 # Step 1: Detect Tools and Determine Tier
 
 ## STEP GOAL:

--- a/src/skf-setup/steps-c/step-01-detect-and-tier.md
+++ b/src/skf-setup/steps-c/step-01-detect-and-tier.md
@@ -82,6 +82,7 @@ From `tier`:
 - `{tier_override_active}` ← `tier.override_applied`
 - `{tier_override_invalid}` ← `tier.override_invalid`
 - `{tier_override_invalid_value}` ← `tier.override_invalid_value`
+- `{tier_override_invalid_suggestion}` ← `tier.override_invalid_suggestion` (closest valid tier name from a fuzzy match — `null` when no candidate cleared the cutoff or when override is valid; consumed by step-04's invalid-override note as a "did you mean ...?" hint)
 - `{tier_override_unsafe}` ← `tier.override_unsafe`
 - `{tier_override_unsafe_missing}` ← `tier.override_unsafe_missing` (a list — step-04 joins with `", "` for display)
 

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -10,6 +10,8 @@ mergeCccExclusionsProbeOrder:
   - '{project-root}/src/shared/scripts/skf-merge-ccc-exclusions.py'
 ---
 
+<!-- Config: communicate in {communication_language}. User-visible status messages (CCC exclusion summary, indexing progress message) render in the user's language. -->
+
 # Step 1b: CCC Index Verification
 
 ## STEP GOAL:

--- a/src/skf-setup/steps-c/step-02-write-config.md
+++ b/src/skf-setup/steps-c/step-02-write-config.md
@@ -12,6 +12,8 @@ forgeTierRwProbeOrder:
   - '{project-root}/src/shared/scripts/skf-forge-tier-rw.py'
 ---
 
+<!-- Config: communicate in {communication_language}. Halt-on-write-failure messages render in the user's language. -->
+
 # Step 2: Write Configuration
 
 ## STEP GOAL:

--- a/src/skf-setup/steps-c/step-03-auto-index.md
+++ b/src/skf-setup/steps-c/step-03-auto-index.md
@@ -13,6 +13,8 @@ forgeTierRwProbeOrder:
   - '{project-root}/src/shared/scripts/skf-forge-tier-rw.py'
 ---
 
+<!-- Config: communicate in {communication_language}. The orphan-removal prompt and the headless-resolution log message render in the user's language. -->
+
 # Step 3: QMD + CCC Registry Hygiene
 
 ## STEP GOAL:

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -64,6 +64,7 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
   {if tools.ast_grep and not tools.gh_cli: - Install GitHub CLI (https://cli.github.com) — required for Deep tier (cross-repository synthesis)}
   {if tools.ast_grep and not tools.qmd and qmd_status is "absent": - Install qmd (https://github.com/tobi/qmd) — required for Deep tier (knowledge search)}
   {if tools.ast_grep and not tools.qmd and qmd_status is "daemon_stopped": - Start the qmd daemon (already installed) — run `qmd start` (or your distribution's qmd service command) to unlock Deep tier (knowledge search)}
+  {if tools.ccc and ccc_daemon is "error": - The ccc daemon is reporting errors — run `ccc doctor` to diagnose. CCC index will fail until resolved (mirrors the qmd daemon-stopped pattern above for parity)}
   {end if}
 
   {if hygiene_result is "completed":}
@@ -109,6 +110,7 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 
 {if tier_override_invalid is true:}
   Note: tier_override value "{tier_override_invalid_value}" in preferences.yaml is not valid.
+        {if tier_override_invalid_suggestion is non-null: Did you mean "{tier_override_invalid_suggestion}"?}
         Valid values are case-sensitive: Quick, Forge, Forge+, Deep. Using detected tier {calculated_tier}.
 
 {if tier_override_unsafe is true:}

--- a/src/skf-setup/steps-c/step-04-report.md
+++ b/src/skf-setup/steps-c/step-04-report.md
@@ -12,6 +12,8 @@ emitEnvelopeProbeOrder:
   - '{project-root}/src/shared/scripts/skf-emit-result-envelope.py'
 ---
 
+<!-- Config: communicate in {communication_language}; emit user-visible report text (FORGE STATUS banner, climb hint, REQUIRED TIER NOT MET block, breadcrumb) in {document_output_language}. The JSON envelope from section 4 is a machine contract — its keys and enum values stay English regardless. -->
+
 # Step 4: Forge Status Report
 
 ## STEP GOAL:

--- a/src/skf-setup/steps-c/step-05-health-check.md
+++ b/src/skf-setup/steps-c/step-05-health-check.md
@@ -5,6 +5,8 @@
 nextStepFile: 'shared/health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. This is a delegation-only step (no user-visible output of its own); shared/health-check.md inherits the language directive on load. -->
+
 # Step 5: Workflow Health Check
 
 ## STEP GOAL:

--- a/test/test-skf-detect-tools.py
+++ b/test/test-skf-detect-tools.py
@@ -314,6 +314,75 @@ def test_detect_invalid_override_falls_back_to_detected():
     assert out["tier"]["override_applied"] is False
     assert out["tier"]["override_invalid"] is True
     assert out["tier"]["override_invalid_value"] == "forge+"
+    # Case-insensitive match should suggest the canonical form
+    assert out["tier"]["override_invalid_suggestion"] == "Forge+"
+
+
+# ─── suggest_valid_tier (fuzzy match for invalid --tier-override) ────────────
+
+
+@pytest.mark.parametrize("bad,expected", [
+    # Case-insensitive exact matches — most common typo class
+    ("deep",     "Deep"),
+    ("DEEP",     "Deep"),
+    ("Deep",     None),    # Already valid — never called for valid values, but defensive
+    ("forge+",   "Forge+"),
+    ("FORGE+",   "Forge+"),
+    ("quick",    "Quick"),
+    ("forge",    "Forge"),
+    # Whitespace tolerance — same suggestion logic applies after .strip()
+    (" deep ",   "Deep"),
+    ("\tquick\n", "Quick"),
+    # difflib fuzzy match — handles single-character typos
+    ("Deeep",    "Deep"),
+    ("Quik",     "Quick"),
+    ("Frge",     "Forge"),  # missing letter
+    # Below cutoff — no suggestion is better than a wrong suggestion
+    ("xyz",      None),
+    ("",         None),
+    ("   ",      None),
+])
+def test_suggest_valid_tier(bad, expected):
+    """`Deep` is intentionally `None` because it's already valid; the function
+    is only called from the invalid-override branch in production, but the
+    parametrized case documents the expected return for an exact valid match."""
+    if expected is None and bad in mod.VALID_TIERS:
+        # Exact valid match: function does return the valid value via the
+        # case-insensitive branch. Adjust expectation for those rows.
+        assert mod.suggest_valid_tier(bad) == bad
+    else:
+        assert mod.suggest_valid_tier(bad) == expected
+
+
+def test_suggest_valid_tier_for_non_string_returns_none():
+    assert mod.suggest_valid_tier(None) is None
+    assert mod.suggest_valid_tier(42) is None
+    assert mod.suggest_valid_tier(["Deep"]) is None
+
+
+def test_detect_invalid_override_with_no_close_match_has_null_suggestion():
+    with _patch_all_probes(ag=True, gh=False, qm=False, cc=False):
+        out = mod.detect(_detect_args(tier_override="xyzzy"))
+    assert out["tier"]["override_invalid"] is True
+    assert out["tier"]["override_invalid_value"] == "xyzzy"
+    assert out["tier"]["override_invalid_suggestion"] is None
+
+
+def test_detect_no_override_has_null_suggestion():
+    """When no override is set, suggestion is null (suggestion is meaningful only with invalid override)."""
+    with _patch_all_probes(ag=True, gh=True, qm=True, cc=True):
+        out = mod.detect(_detect_args())
+    assert out["tier"]["override_invalid"] is False
+    assert out["tier"]["override_invalid_suggestion"] is None
+
+
+def test_detect_valid_override_has_null_suggestion():
+    """Valid override → no suggestion needed."""
+    with _patch_all_probes(ag=True, gh=True, qm=True, cc=True):
+        out = mod.detect(_detect_args(tier_override="Deep"))
+    assert out["tier"]["override_applied"] is True
+    assert out["tier"]["override_invalid"] is False
+    assert out["tier"]["override_invalid_suggestion"] is None
 
 
 def test_detect_require_tier_satisfied():

--- a/test/test-skf-emit-result-envelope.py
+++ b/test/test-skf-emit-result-envelope.py
@@ -149,6 +149,29 @@ def test_warnings_includes_tier_override_invalid():
     assert any("tier_override_invalid: forge+" in w for w in env["skf_setup"]["warnings"])
 
 
+def test_warnings_includes_tier_override_invalid_suggestion_when_present():
+    p = _baseline_payload()
+    p["tier_override_invalid"] = True
+    p["tier_override_invalid_value"] = "forge+"
+    p["tier_override_invalid_suggestion"] = "Forge+"
+    env = mod.assemble_envelope(p)
+    assert any("tier_override_invalid: forge+ (did you mean Forge+?)" in w
+               for w in env["skf_setup"]["warnings"])
+
+
+def test_warnings_omits_did_you_mean_when_suggestion_null():
+    """No suggestion → fall back to the bare warning shape (no parenthetical)."""
+    p = _baseline_payload()
+    p["tier_override_invalid"] = True
+    p["tier_override_invalid_value"] = "xyzzy"
+    p["tier_override_invalid_suggestion"] = None
+    env = mod.assemble_envelope(p)
+    invalid_warnings = [w for w in env["skf_setup"]["warnings"] if "tier_override_invalid" in w]
+    assert len(invalid_warnings) == 1
+    assert "did you mean" not in invalid_warnings[0]
+    assert "tier_override_invalid: xyzzy" in invalid_warnings[0]
+
+
 def test_warnings_includes_tier_override_unsafe():
     p = _baseline_payload()
     p["tier_override_unsafe"] = True


### PR DESCRIPTION
## Summary

Closes the final two themes from the \`2026-04-27T121255\` quality re-scan. After this lands, **skf-setup's quality-analysis backlog is empty** — every theme from the original baseline scan is closed.

Branch: \`polish/skf-setup-close-remaining-themes\` (2 commits, +151 / -1 across 11 files, 20 new test cases).

## Commits

### Commit 1 — \`docs(skf-setup): add per-stage Language config headers\`

The workflow-integrity prepass scanner flagged this as Theme 1 of the re-scan: SKILL.md \`## Workflow Rules\` declares \`communicate in {communication_language}\` workflow-wide, but per-stage headers harden against context loss when a step file is loaded in isolation. Adds an HTML-comment \`Language:\` directive immediately after the frontmatter close in each of the 6 step files. step-04 also gets \`Output Language: {document_output_language}\` since it emits human-facing prose.

Each comment names the user-visible touchpoints that step actually emits, so the reason the header is on the file is self-documenting. Verified via the prepass: config-header findings went 6 → 0.

### Commit 2 — \`feat(skf-setup): close low-severity edges (missing-config + fuzzy match + ccc-doctor)\`

Three independent low-severity refinements bundled into one commit (Theme 3 of the re-scan):

**Fix 1 — Missing-config diagnostic** (SKILL.md On Activation step 2). A user invoking \`/skf-setup\` from the wrong directory previously hit a generic file-read error from a downstream step. Now catches missing \`{project-root}/_bmad/skf/config.yaml\` explicitly with a "this directory does not appear to be an SKF-initialised project" diagnostic naming the install command. Also adds a malformed-YAML branch surfacing the parser error inline.

**Fix 2 — Tier-override fuzzy match** (\`skf-detect-tools.py\` + tests + workflow wiring). Common typos like \`deep\`, \`DEEP\`, \`forge+\`, \`FORGE+\` previously just reported "tier_override is not valid" with no help. New \`suggest_valid_tier()\` does case-insensitive exact match (most common typo class) plus \`difflib.get_close_matches\` with a 0.6 cutoff (single-character typos like \`Deeep\`, \`Quik\`, \`Frge\`). Adds \`tier.override_invalid_suggestion\` to the DETECT_OUTPUT_SCHEMA. Wired through step-01 (context flag), step-04 ("Did you mean ...?" line in the invalid-override note), and \`skf-emit-result-envelope.py\` (extends the envelope warnings text). 18 new test cases — full parametrized table covering case-insensitive matches, fuzzy matches, below-cutoff cases, and invalid-input edge cases.

**Fix 3 — ccc-doctor climb hint** (step-04). Mirrors the qmd daemon-stopped climb-hint pattern from PR #248 for the parallel \`ccc_daemon: error\` case. When ccc is present but daemon reports errors, the climb-hint section now suggests \`ccc doctor\` for diagnosis.

Tests: 18 new in test-skf-detect-tools.py, 2 new in test-skf-emit-result-envelope.py — 163 total Python tests passing, full \`npm run quality\` green via husky pre-commit.

## After this lands

| Theme | Status |
|---|---|
| Theme 1 — per-stage Language config headers | ✅ Closed (commit 1) |
| Theme 2 — Human-experience polish (uv probe / tier defuser / headless banner) | ✅ Closed by PR #253 |
| Theme 3 — Edge-case + ergonomic refinements (missing config / fuzzy match / ccc-doctor) | ✅ Closed (commit 2) |

skf-setup is at **zero open quality-analysis opportunities**. A re-scan will probably surface a handful of tiny fresh observations (the scanners are sensitive), but the headline backlog from the original baseline is fully retired.

## Test plan

- [x] CI green on \`quality.yaml\` (Linux + Windows matrix)
- [x] Quality re-scan on skf-setup retires Theme 1 (config-header findings) — already verified locally via prepass: 6 → 0
- [x] On a host where \`{project-root}/_bmad/skf/config.yaml\` is missing (test by running \`/skf-setup\` from \`/tmp\` or any non-SKF directory), the workflow halts at On Activation step 2 with the "wrong directory" diagnostic naming the install command — no downstream generic file-read error
- [x] Setting \`tier_override: forge+\` (lowercase) in preferences.yaml produces "Did you mean \"Forge+\"?" in the step-04 invalid-override note
- [x] \`/skf-setup --headless\` with the same invalid override produces an envelope warning matching the pattern \`tier_override_invalid: forge+ (did you mean Forge+?)\`
- [x] Setting \`tier_override: xyzzy\` produces the bare \`tier_override_invalid: xyzzy\` warning with no \`(did you mean ...?)\` parenthetical (below the 0.6 cutoff, no suggestion offered)
- [x] On a Forge+ host with ccc installed but daemon reporting errors, step-04 climb-hint section displays "The ccc daemon is reporting errors — run \`ccc doctor\` to diagnose"