### PR TITLE
docs: surface v1.2.0 user-visible additions in workflows + troubleshooting + skill-model

### DIFF
--- a/docs/skill-model.md
+++ b/docs/skill-model.md
@@ -25,51 +25,45 @@ Setup detects your installed tools and sets your tier automatically:
 ```
 
 ```
-┌─────────────────────────────┐
-│ FORGE STATUS                │
-└─────────────────────────────┘
+═══════════════════════════════════════
+  FORGE STATUS
+═══════════════════════════════════════
 
   Tier:  Deep
-
-  Deep tier active. Full capability unlocked — AST-backed code
-  analysis, GitHub repository exploration, and QMD knowledge search
-  with cross-repository synthesis. Maximum provenance and intelligence.
+  Deep tier active. Full capability unlocked — AST-backed code analysis,
+  GitHub repository exploration, and QMD knowledge search with
+  cross-repository synthesis. Maximum provenance and intelligence.
 
   Tools Detected:
-    ast-grep  — 0.42.0
-    gh        — 2.89.0
-    qmd       — operational (104 docs indexed globally)
-    ccc       — 0.2.10 (daemon healthy)
+  - ast-grep 0.42.0
+  - gh 2.91.0 (2026-04-22)
+  - qmd 2.0.1
+  - ccc (daemon healthy)
 
   QMD Registry:
-    0 collection(s) healthy
-    39 orphaned collection(s) removed
-    (empty — collections are created automatically when you run [CS] Create Skill)
+  0 collection(s) healthy
+  23 orphaned collection(s) kept
 
   CCC Index:
-    indexed this run — semantic discovery ready (2 files, 14 chunks)
-    SKF infrastructure excluded: _bmad, _bmad-output, .claude,
-    _skf-learn, skills, forge-data
+  indexed this run — semantic discovery ready (1 file)
 
-┌────────────────────────────────┐
-│ Forge ready. Deep tier active. │
-└────────────────────────────────┘
+  Files written this run:
+  - forge-tier.yaml — {project-root}/_bmad/_memory/forger-sidecar/forge-tier.yaml
+  - .cocoindex_code/settings.yml — {project-root}/.cocoindex_code/settings.yml (6 SKF exclusion patterns merged)
+  - .cocoindex_code/ ccc index — 1 file indexed
+
+═══════════════════════════════════════
+  Forge ready. Deep tier active.
+═══════════════════════════════════════
+
+  Next: try [BS] Brief Skill to scope your first compilation target,
+  or [QS] Quick Skill for a fast template-driven path.
+  Already have a skill? [AS] Audit Skill drift-checks an existing skill
+  against current sources.
 
 Health Check: Clean run. No workflow issues to report.
 
 Workflow complete.
-
----
-Forge is live at Deep tier, armel. All four core tools are available, the CCC semantic index is built, and the QMD registry is clean.
-
-What would you like to forge next? Common starting points:
-
-- QS — fast skill from a GitHub URL or package name
-- BS → CS — brief, then compile a skill from source
-- AN — analyze a large repo to discover what's worth skilling
-- WS — show current lifecycle status
-
-Or chain them: forge (BS CS TS EX), forge-quick (QS TS EX), onboard (AN CS TS EX).
 ```
 
 Don't have ast-grep, cocoindex-code, or QMD yet? No problem — Quick mode works with no additional tools. Optional GitHub CLI improves source access. Install tools later; your tier upgrades automatically.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,18 @@ If something isn't working, start here. For general setup help see [Getting Star
 
 ## Common errors
 
+### "Setup cannot proceed: `uv` is not installed"
+
+Surfaced by `/skf-setup` On Activation when `uv --version` is missing on `$PATH`. SKF helpers depend on `uv` to auto-resolve their Python dependencies via PEP 723 inline metadata; bare `python3` ignores that metadata and would fail later with `ModuleNotFoundError: No module named 'yaml'`. The probe halts the workflow up-front with one cohesive diagnostic instead of letting five steps each fail individually.
+
+**Fix:** install `uv` from <https://docs.astral.sh/uv/getting-started/installation/> and re-run `/skf-setup`. `uv` is documented as a runtime prerequisite in [Getting Started → Prerequisites](../getting-started/#prerequisites-full-reference).
+
+### "Setup cannot proceed: `_bmad/skf/config.yaml` was not found"
+
+Surfaced by `/skf-setup` On Activation when the SKF install config is missing — typically because you invoked `/skf-setup` from a directory that is not an SKF-initialised project. The check runs before any file mutation so nothing is written.
+
+**Fix:** from the project root, run `npx bmad-module-skill-forge install` (or `npx bmad-method install` and add SKF as a custom module — see [Getting Started → Install](../getting-started/#install)), then re-run `/skf-setup`. If you ARE in the right project but the file was deleted, restore it from version control or re-run the SKF installer. A separate "config.yaml is not valid YAML" diagnostic surfaces the parser error inline if the file exists but is malformed — open the file at the named path and repair the YAML.
+
 ### Forge reports ast-grep is unavailable
 
 If setup reports that ast-grep was not detected, install it to unlock the Forge tier: <https://ast-grep.github.io>. Re-run `@Ferris SF` afterward — your tier upgrades automatically.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -348,7 +348,7 @@ You can also set `headless_mode: true` in your forge preferences (`_bmad/_memory
 SKF_SETUP_RESULT_JSON: {"skf_setup":{"tier":"Deep","previous_tier":"Forge","tier_changed":true,"tools":{...},"tools_added":[...],"tools_removed":[],"config_path":"...","ccc_index":{...},"files_written":[...],"tier_override_active":false,"tier_override_invalid":false,"require_tier_satisfied":null,"warnings":[],"error":null}}
 ```
 
-Parent skills and CI pipelines `grep` one line out of the workflow log to learn the outcome — no ASCII-art parsing, no race against the `forge-tier.yaml` writer. The envelope schema is versioned at `src/shared/scripts/schemas/skf-setup-result-envelope.v1.json` and asserted against on every emit.
+Parent skills and CI pipelines `grep` one line out of the workflow log to learn the outcome — no ASCII-art parsing, no race against the [`forge-tier.yaml`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-setup/steps-c/step-02-write-config.md) writer. The envelope schema is versioned at [`src/shared/scripts/schemas/skf-setup-result-envelope.v1.json`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/shared/scripts/schemas/skf-setup-result-envelope.v1.json) and asserted against on every emit.
 
 ---
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -21,6 +21,11 @@ Trigger workflows by typing commands to [Ferris](../agents/). See [Concepts](../
 
 **Key Steps:** Detect tools + Determine tier → CCC index check (Forge+) → Write forge-tier.yaml → QMD + CCC registry hygiene (Deep/Forge+) → Status report
 
+**Flags (v1.2.0+):**
+
+- `--require-tier=<Quick|Forge|Forge+|Deep>` — fail-fast for CI: if the calculated tier does not satisfy the requested tier (tool-prerequisite check, not a name comparison — Deep does NOT subsume Forge+ because Deep does not require ccc), the workflow halts with a "REQUIRED TIER NOT MET" block and exits without chaining to the health check. Pipelines branch on the JSON envelope's `require_tier_satisfied` field.
+- `--headless` / `-H` — see [Headless Mode](#headless-mode) below. For `/skf-setup` specifically, headless mode emits a single-line `SKF_SETUP_RESULT_JSON: {…}` envelope to stdout (schema-locked, includes `tier`, `previous_tier`, `tier_changed`, `tools`, `tools_added`/`removed`, `files_written`, `warnings`, `error`) and SUPPRESSES the human-readable banner — the entire payload pipelines need is on one parseable line.
+
 **Agent:** Ferris (Architect mode)
 
 ---
@@ -336,6 +341,14 @@ Add `--headless` or `-H` to any workflow command to skip all confirmation gates.
 ```
 
 You can also set `headless_mode: true` in your forge preferences (`_bmad/_memory/forger-sidecar/preferences.yaml`) to make headless the default for all workflows.
+
+**Exception — `/skf-setup` headless emits a single-line JSON envelope (v1.2.0+).** Unlike other workflows, headless `/skf-setup` SUPPRESSES the human-readable status banner entirely and emits exactly one prefixed line on stdout:
+
+```
+SKF_SETUP_RESULT_JSON: {"skf_setup":{"tier":"Deep","previous_tier":"Forge","tier_changed":true,"tools":{...},"tools_added":[...],"tools_removed":[],"config_path":"...","ccc_index":{...},"files_written":[...],"tier_override_active":false,"tier_override_invalid":false,"require_tier_satisfied":null,"warnings":[],"error":null}}
+```
+
+Parent skills and CI pipelines `grep` one line out of the workflow log to learn the outcome — no ASCII-art parsing, no race against the `forge-tier.yaml` writer. The envelope schema is versioned at `src/shared/scripts/schemas/skf-setup-result-envelope.v1.json` and asserted against on every emit.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the user-visible additions that shipped in v1.2.0 (\`/skf-setup\` headless contract, \`--require-tier\` flag, two new On Activation diagnostics) and refreshes the Forge Status example block in skill-model.md so it matches what users actually see post-v1.2.0. No code changes; pure docs.

Branch: \`docs/workflows-troubleshooting-v1.2.0-additions\` (4 commits, ~75 line additions across 3 files).

## Commits

- **\`docs(workflows): document /skf-setup --require-tier flag + headless envelope contract\`** — Adds a "Flags (v1.2.0+)" subsection under Setup Forge (SF) naming the two new user-visible additions: \`--require-tier=<tier>\` (with the explicit "Deep does NOT subsume Forge+" note matching the script's tool-prerequisite check) and \`--headless\` linking to the existing Headless Mode section. The Headless Mode section gains an "Exception" callout: prior text said *"Progress output is still shown — headless skips interaction, not reporting"* which is no longer true for \`/skf-setup\` post-PR #253. Headless \`/skf-setup\` now suppresses the human banner entirely and emits a single \`SKF_SETUP_RESULT_JSON: {…}\` line. Includes a representative envelope shape inline + a pointer to the versioned JSON Schema.

- **\`docs(troubleshooting): list new uv-missing + missing-config diagnostics from v1.2.0\`** — Adds two new entries to "Common errors" so users searching for the literal error strings find the resolution path. Both fire during On Activation (PRs #253 and #254) so they're placed at the TOP of the section — a user hitting them never gets to the later ast-grep / brief / ecosystem-check entries below.

- **\`docs(workflows): make schema + step-prompt file references clickable\`** — Convention from \`README.md\` and \`docs/_internal/RELEASING.md\` is that file path references in docs link to the file on GitHub via the \`[\\\`label\\\`](https://github.com/.../path)\` shape, not bare backticked text. The schema reference (\`src/shared/scripts/schemas/skf-setup-result-envelope.v1.json\`) is the single most useful place for an envelope consumer to land — making it clickable cuts a manual repo-tree navigation step. Same treatment for the neighbouring \`forge-tier.yaml\` writer reference.

- **\`docs(skill-model): refresh Forge Status example to v1.2.0 actual output\`** — Caught after running \`@Ferris SF\` on a fresh install and noticing the example block in the Progressive Capability Model section was captured pre-v1.2.0. Concrete drift fixed: box-drawing chars (\`┌─┐│└─┘\` → \`═══\`); tools now bullet-formatted; CCC Index inline "SKF infrastructure excluded" line removed (the info now surfaces in the new Files Written section); **NEW Files written this run section** (PR #248) listing every file mutated with absolute path; **NEW "Next: try [BS] / [QS] / [AS]" breadcrumb** (PR #253) replacing the prior conversational Ferris greeting prose. Sanitized \`{project-root}\` placeholder rather than leaking a specific local path. Drops the post-workflow Ferris chatter from the example since that varies per session and isn't workflow output proper.

## What does NOT need updating

For posterity (verified during the audit before opening this PR):

- **\`README.md\`** — high-level, doesn't go into per-workflow flag detail. Quick Start still accurate.
- **\`docs/getting-started.md\`** — already documents \`uv\` as the runtime prereq + \`@Ferris SF\` for setup.
- **\`docs/_data/pinned.yaml\`** — auto-bumped by release.yaml (already at 1.2.0).
- **\`docs/concepts.md\`, \`docs/architecture.md\`** — describe the SKF model, not per-workflow behavior.
- **\`docs/_internal/STABILITY.md\`** — covered surface didn't expand. The new envelope schema lives in \`src/shared/scripts/schemas/\` but is intentionally not promoted to a covered surface in this release. Optional future minor: promote it explicitly.
- **\`docs/_internal/RELEASING.md\`** — process unchanged.

## Test plan

- [x] CI green on \`quality.yaml\` (Linux + Windows matrix; markdownlint runs)
- [x] Render the docs site preview — confirm the new "Flags (v1.2.0+)" block formats cleanly under Setup Forge (SF)
- [x] Confirm the two clickable file references in the Headless Mode "Exception" callout resolve to the linked GitHub paths (not 404)
- [x] Search the troubleshooting page in browser for the literal error strings ("Setup cannot proceed: \`uv\`" and "config.yaml was not found") — both should land on the relevant entries
- [x] Render the Skill Model page preview — confirm the refreshed Forge Status block matches what \`@Ferris SF\` produces on a fresh install (run it on a clean directory to verify)