### PR TITLE
refactor(skf-quick-skill): wire skf-validate-output.py into step-05

### DIFF
--- a/src/shared/scripts/skf-validate-output.py
+++ b/src/shared/scripts/skf-validate-output.py
@@ -9,6 +9,7 @@ schema against agentskills.io specification. Outputs JSON validation results.
 
 CLI: python3 skf-validate-output.py <skill-package-dir>
      python3 skf-validate-output.py <skill-package-dir> --generated-by quick-skill
+     python3 skf-validate-output.py <skill-package-dir> --skip-frontmatter
 """
 
 from __future__ import annotations
@@ -73,7 +74,7 @@ def validate_body_structure(content):
     issues = []
     body = content.split("---", 2)[-1] if content.startswith("---") else content
 
-    required_sections = ["Overview", "Key Exports", "Usage"]
+    required_sections = ["Overview", "Description", "Key Exports", "Usage"]
     for section in required_sections:
         pattern = rf"^##\s+.*{re.escape(section)}"
         if not re.search(pattern, body, re.MULTILINE | re.IGNORECASE):
@@ -155,8 +156,13 @@ def validate_metadata_json(data, generated_by=None):
     return issues
 
 
-def validate_skill_package(skill_dir, generated_by=None):
-    """Validate a complete skill package directory."""
+def validate_skill_package(skill_dir, generated_by=None, skip_frontmatter=False):
+    """Validate a complete skill package directory.
+
+    When `skip_frontmatter` is True, the SKILL.md frontmatter pass is omitted —
+    intended for callers that already validated frontmatter via skill-check or
+    skf-validate-frontmatter.py and only want body / snippet / metadata checks.
+    """
     skill_dir = Path(skill_dir)
     skill_name = skill_dir.name
 
@@ -183,9 +189,14 @@ def validate_skill_package(skill_dir, generated_by=None):
     skill_md_path = files["SKILL.md"]
     if skill_md_path.exists():
         content = skill_md_path.read_text(encoding="utf-8")
-        fm_issues = validate_frontmatter(content, skill_name)
+        if skip_frontmatter:
+            fm_section = {"skipped": "frontmatter validation skipped (--skip-frontmatter)"}
+            fm_issues = []
+        else:
+            fm_issues = validate_frontmatter(content, skill_name)
+            fm_section = fm_issues
         body_issues = validate_body_structure(content)
-        result["validation"]["skill_md"] = {"frontmatter": fm_issues, "body": body_issues}
+        result["validation"]["skill_md"] = {"frontmatter": fm_section, "body": body_issues}
         for issue in fm_issues + body_issues:
             result["summary"]["total_issues"] += 1
             result["summary"]["by_severity"][issue["severity"]] += 1
@@ -232,7 +243,11 @@ def validate_skill_package(skill_dir, generated_by=None):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python3 skf-validate-output.py <skill-package-dir> [--generated-by <generator>]", file=sys.stderr)
+        print(
+            "Usage: python3 skf-validate-output.py <skill-package-dir> "
+            "[--generated-by <generator>] [--skip-frontmatter]",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     pkg_dir = sys.argv[1]
@@ -242,6 +257,8 @@ if __name__ == "__main__":
         if idx + 1 < len(sys.argv):
             gen_by = sys.argv[idx + 1]
 
-    result = validate_skill_package(pkg_dir, generated_by=gen_by)
+    skip_fm = "--skip-frontmatter" in sys.argv
+
+    result = validate_skill_package(pkg_dir, generated_by=gen_by, skip_frontmatter=skip_fm)
     print(json.dumps(result, indent=2))
     sys.exit(0 if result["result"] == "PASS" else 1)

--- a/src/skf-quick-skill/steps-c/step-05-validate.md
+++ b/src/skf-quick-skill/steps-c/step-05-validate.md
@@ -3,6 +3,9 @@ nextStepFile: './step-06-write.md'
 frontmatterValidatorProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-validate-frontmatter.py'
   - '{project-root}/src/shared/scripts/skf-validate-frontmatter.py'
+outputValidatorProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-validate-output.py'
+  - '{project-root}/src/shared/scripts/skf-validate-output.py'
 ---
 
 # Step 5: Write & Validate
@@ -42,7 +45,7 @@ If `{skill_package}` already exists, confirm with user before overwriting:
 
 ### 2. Write Deliverables
 
-Write the three compiled artifacts to the skill package so that validation in sections 3–9 has files on disk to read:
+Write the three compiled artifacts to the skill package so that validation in sections 3–7 has files on disk to read:
 
 **File 1:** `{skill_package}/SKILL.md` — the compiled skill document
 **File 2:** `{skill_package}/context-snippet.md` — the compressed context snippet
@@ -72,7 +75,7 @@ Run: `npx skill-check -h`
 
 ### 4. Validate SKILL.md via skill-check (if available)
 
-**If `npx skill-check` is available**, run automated validation + security scan in one invocation against the skill package written in section 2 (security scan is enabled by default when `--no-security-scan` is omitted, so the same call covers §8 and avoids paying the npx startup cost twice):
+**If `npx skill-check` is available**, run automated validation + security scan in one invocation against the skill package written in section 2 (security scan is enabled by default when `--no-security-scan` is omitted, so the same call covers §6 and avoids paying the npx startup cost twice):
 
 ```bash
 npx skill-check check {skill_package} --fix --format json
@@ -96,53 +99,29 @@ python3 {frontmatterValidator} {skill_package}/SKILL.md --skill-dir-name {repo_n
 
 The validator emits JSON with `status` (`pass`/`fail`), `issues[]` (each with `severity`, `code`, `message`), and `frontmatter` (the parsed name/description). It checks frontmatter delimiters, name format (Unicode letters + digits + hyphens, no consecutive/trailing hyphens), name-directory match, description presence and length, and unknown fields against the agentskills.io spec — the same shape this step would otherwise hand-walk. Record each `issues[]` entry as a validation issue with its reported severity. Missing frontmatter or missing required fields are high-severity — skills without valid frontmatter will fail `npx skills add` and `npx skill-check check`.
 
-### 5. Validate SKILL.md Body Structure
+### 5. Validate Body, Snippet, and Metadata via skf-validate-output.py
 
-Check that SKILL.md has these required sections populated:
+Run the shared output validator against the on-disk skill package — it performs the body-structure, snippet-format, and metadata-shape checks that this step previously walked by hand. Pass `--skip-frontmatter` since §4 has already covered frontmatter.
 
-- [ ] **Overview section** present with package name, repo, language, authority
-- [ ] **Description section** present with non-empty content
-- [ ] **Key Exports section** present (may be empty if confidence is low)
-- [ ] **Usage Patterns section** present (may have README fallback)
+**Resolve `{outputValidator}`:** probe `{outputValidatorProbeOrder}` (installed first, dev fallback); first existing path wins. If neither candidate exists, log a high-severity issue ("output validator unavailable — `skf-validate-output.py` missing") and skip body/snippet/metadata validation.
 
-**For each missing or empty required section, log an issue.**
+```bash
+python3 {outputValidator} {skill_package} --generated-by quick-skill --skip-frontmatter
+```
 
-### 6. Validate Context Snippet Format
+The validator emits JSON with `result` (PASS/FAIL), `validation.skill_md.body[]`, `validation.context_snippet.issues[]`, `validation.metadata.issues[]`, and a severity-bucketed `summary`. Record each issue as a validation issue at its reported severity.
 
-Check context-snippet.md format compliance:
+Coverage replaces these former hand-walked checklists:
 
-- [ ] **Vercel-aligned indexed format** — pipe-delimited with version, retrieval instruction, section anchors
-- [ ] **First line** matches pattern: `[{name} v{version}]|root: {prefix}{name}/` where prefix is `skills/` (draft form) or any IDE skill root (`.{dir}/skills/`)
-- [ ] **Second line** starts with: `|IMPORTANT:`
-- [ ] **Approximate token count** is ~80-120 tokens
+- **Body structure** — Overview, Description, Key Exports, Usage sections present (medium when missing)
+- **Context snippet** — `[{name} v{version}]|root: ...` first line, `|IMPORTANT:` second line, ~80–120-token length
+- **Metadata** — required string fields (`name`, `version`, `source_authority`, `language`, `generation_date`), `source_repo`, `generated_by`, `confidence_tier`, and `stats` numerics (`exports_documented`, `exports_public_api`, `exports_total`, `public_api_coverage`, `total_coverage`)
 
-**If format is wrong, log an issue.**
-
-### 7. Validate Metadata JSON
-
-Check metadata.json has required fields:
-
-- [ ] `name` — present, non-empty
-- [ ] `version` — present (auto-detected or "1.0.0")
-- [ ] `source_authority` — must be "community"
-- [ ] `source_repo` — present, valid GitHub URL
-- [ ] `language` — present, non-empty
-- [ ] `generated_by` — must be "quick-skill"
-- [ ] `generation_date` — present
-- [ ] `stats.exports_documented` — present, number
-- [ ] `stats.exports_public_api` — present, number
-- [ ] `stats.exports_total` — present, number
-- [ ] `stats.public_api_coverage` — present, number
-- [ ] `stats.total_coverage` — present, number
-- [ ] `confidence_tier` — present
-
-**For each missing or invalid field, log an issue.**
-
-### 8. Security Scan (covered by §4)
+### 6. Security Scan (covered by §4)
 
 Security findings are already collected from the §4 invocation (no separate `npx` round trip needed — `skill-check check ... --fix --format json` runs the security scan by default). If skill-check was unavailable in §3, log "security scan skipped — skill-check unavailable" in validation results.
 
-### 9. Report Validation Results
+### 7. Report Validation Results
 
 "**Validation complete:**
 
@@ -168,7 +147,7 @@ These issues are advisory for community-tier skills. You can proceed to finalize
 
 Set `validation_result` with pass/fail status, quality score, and issues list.
 
-### 10. Auto-Proceed to Finalize
+### 8. Auto-Proceed to Finalize
 
 #### Menu Handling Logic:
 

--- a/test/test-skf-validate-output.py
+++ b/test/test-skf-validate-output.py
@@ -148,3 +148,36 @@ class TestSkfValidateOutput:
         # Should parse successfully — no high-severity issues
         high_issues = [i for i in issues if i["severity"] == "high"]
         assert len(high_issues) == 0
+
+    def test_missing_description_section_flagged(self):
+        """SKILL.md without a Description section should log a medium body issue."""
+        content_no_desc = (
+            "---\nname: no-desc\ndescription: a skill missing its Description section\n---\n\n"
+            "## Overview\n\nTest\n\n## Key Exports\n\nNone\n\n## Usage\n\nNone\n"
+        )
+        body_issues = mod.validate_body_structure(content_no_desc)
+        desc_issues = [i for i in body_issues if "Description" in i.get("field", "")]
+        assert len(desc_issues) == 1
+        assert desc_issues[0]["severity"] == "medium"
+
+    def test_skip_frontmatter_omits_frontmatter_pass(self):
+        """--skip-frontmatter / skip_frontmatter=True must skip the frontmatter validator entirely."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = Path(tmp) / "skip-fm"
+            pkg.mkdir()
+            # Deliberately broken frontmatter — would normally produce a high-severity issue
+            (pkg / "SKILL.md").write_text(
+                "# No frontmatter at all\n\n## Overview\n\nT\n\n## Description\n\nT\n\n## Key Exports\n\nNone\n\n## Usage\n\nT\n",
+                encoding="utf-8",
+            )
+            (pkg / "context-snippet.md").write_text(VALID_SNIPPET.replace("test-skill", "skip-fm"), encoding="utf-8")
+            meta = dict(VALID_METADATA)
+            meta["name"] = "skip-fm"
+            (pkg / "metadata.json").write_text(json.dumps(meta), encoding="utf-8")
+
+            r = validate_skill_package(str(pkg), skip_frontmatter=True)
+            fm = r["validation"]["skill_md"]["frontmatter"]
+            assert isinstance(fm, dict) and "skipped" in fm, f"Expected skipped marker, got: {fm}"
+            # No high-severity issues should be raised when frontmatter is skipped on otherwise-valid body/snippet/metadata
+            assert r["summary"]["by_severity"]["high"] == 0
+            assert r["result"] == "PASS"


### PR DESCRIPTION
## Summary

Resolves the highest-leverage finding from the 2026-05-01 quality analysis (theme 1 / "Body/snippet/metadata validation checklists walked by hand") in skf-quick-skill: ~25 LLM-walked checkboxes in `step-05-validate.md` §5–§7 are replaced by one shared-helper invocation.

The shared helper (`src/shared/scripts/skf-validate-output.py`) already existed and already covered the surface — the work is wire-up plus two backward-compatible extensions, not a new script. This corrects the report's recommendation #1, which framed it as a build.

## Changes

- **`feat(shared)`** — extend `skf-validate-output.py` with `--skip-frontmatter` flag and a Description-section check in `validate_body_structure`. Existing tests still pass; behaviour for callers that don't pass the flag is unchanged.
- **`refactor(skf-quick-skill)`** — replace step-05 §5–§7 hand-walked checklists with one invocation of `python3 {outputValidator} {skill_package} --generated-by quick-skill --skip-frontmatter`. Helper resolved via a new `outputValidatorProbeOrder` (installed → dev fallback) mirroring the existing `frontmatterValidatorProbeOrder` pattern. Section numbers shift: former §8 (Security note) → §6, §9 (Report) → §7, §10 (Auto-Proceed) → §8; inline back-references updated to match.
- **`test(shared)`** — two new test cases cover Description-section enforcement and `--skip-frontmatter` skip semantics.

## Why

The hand-walked checklists in step-05 §5–§7 (~25 checkboxes total) cost ~700 tokens per run and reproduce checks the shared helper already performs. Wiring them up:

- Removes the workflow's only remaining hand-walked validation pass (§4 already delegates frontmatter)
- Avoids double-validating frontmatter (§4 covers it; `--skip-frontmatter` keeps §5 from repeating the work)
- Gives skf-create-skill a unit-tested helper to share (see PR 6 in the analysis plan)

## Test plan

- [x] `uv run pytest test/test-skf-validate-output.py` — 10/10 pass (8 existing + 2 new)
- [x] `npm run quality` — runs as the husky pre-commit hook on every commit; all three commits passed locally
- [x] CI green on `ubuntu-latest` + `windows-latest`
- [x] Manual: `/skf-quick-skill lodash --headless` against a clean output folder, confirm step-05 §5 shells out to the helper and §7 renders body/snippet/metadata sections of the validation report from the helper's JSON

## Notes for reviewers

- No drive-by reformats; only lines tied to the wire-up are touched.
- step-05 §4's Python invocation pattern (`python3 {validator}`) is preserved for `skf-validate-output.py`, which has no PEP 723 deps. (Aside: `skf-validate-frontmatter.py` does need `uv run` per its docstring; that pre-existing inconsistency in §4 is out of scope here.)
- This is PR 1 of 6 in the phased plan generated from the quality analysis at `skills/reports/skf-quick-skill/quality-analysis/20260501-083628/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)