### PR TITLE
refactor(skf-quick-skill): pick canonical surfaces, drop duplications

### DIFF
--- a/src/skf-quick-skill/references/registry-resolution.md
+++ b/src/skf-quick-skill/references/registry-resolution.md
@@ -13,6 +13,8 @@ When the user provides a package name instead of a GitHub URL, use this fallback
 
 Try each registry in order. Stop at first success.
 
+**Per-call timeout:** apply a 10s timeout to each registry HTTP call (15s for the web-search fallback) so a single hung registry cannot stall the workflow under hostile network conditions. Treat a timeout as a soft failure and fall through to the next entry in the chain.
+
 #### 1. npm Registry (JavaScript/TypeScript)
 
 ```

--- a/src/skf-quick-skill/steps-c/step-01-resolve-target.md
+++ b/src/skf-quick-skill/steps-c/step-01-resolve-target.md
@@ -72,14 +72,7 @@ Otherwise, paste the package name or GitHub URL of the library you want to wrap,
 
 ### 3. Registry Resolution
 
-Load {registryResolutionData} for resolution patterns.
-
-**Execute the fallback chain in order — stop at first success. Apply a 10s per-call timeout** so a single hung registry cannot stall the workflow under hostile network conditions; treat timeout as a soft failure and fall through to the next registry:
-
-1. **npm registry:** Fetch `https://registry.npmjs.org/{package_name}` — extract `repository.url`
-2. **PyPI registry:** Fetch `https://pypi.org/pypi/{package_name}/json` — extract `info.project_urls.Source` or `info.home_page`
-3. **crates.io registry:** Fetch `https://crates.io/api/v1/crates/{package_name}` — extract `crate.repository`
-4. **Web search fallback:** Search `"{package_name} github repository"` — look for GitHub URL (15s timeout)
+Load {registryResolutionData} and execute its fallback chain in order — stop at first success. The reference is canonical for the chain order (npm → PyPI → crates.io → web search), the per-registry URL templates and response-field paths, the per-call timeouts (10s per registry, 15s for web search), and the timeout-as-soft-failure semantics.
 
 **If all methods fail — HARD HALT:**
 

--- a/src/skf-quick-skill/steps-c/step-04-compile.md
+++ b/src/skf-quick-skill/steps-c/step-04-compile.md
@@ -84,17 +84,26 @@ Create context-snippet.md in Vercel-aligned indexed format (~80-120 tokens):
 
 Generate metadata.json following the **canonical schema in `{skillTemplateData}` § "metadata.json Format"** (loaded in §1). Use the template's exact field set, ordering, and types — do not duplicate the schema here. Apply these quick-skill-specific population rules on top of the template:
 
-- `confidence_tier`: `"Quick"` (constant)
-- `generated_by`: `"quick-skill"` (constant)
-- `source_authority`: `"community"` (constant)
-- `confidence_distribution.t1_low`: number of exports found — **integer, not string**. Other distribution buckets stay at `0`.
-- `tool_versions.skf`: resolved from `{project-root}/_bmad/skf/package.json` → npm require → `{project-root}/_bmad/skf/VERSION` → `"unknown"` (first hit wins)
-- `tool_versions.ast_grep` / `tool_versions.qmd`: `null` (Quick is tier-unaware)
-- `stats.exports_documented` / `exports_public_api` / `exports_total`: equal to the count of exports detected in step-03 (integers); `exports_internal: 0`; `public_api_coverage: 1.0`; `total_coverage: 1.0`; `scripts_count` / `assets_count`: `0` for Quick
-- `provenance.language_hint` / `provenance.scope_hint`: echo the user-supplied hints from step-01 (or `null` when omitted)
+**Constants (always these literal values for Quick):**
+
+| Field                                                                       | Value                          |
+| --------------------------------------------------------------------------- | ------------------------------ |
+| `confidence_tier`                                                           | `"Quick"`                      |
+| `generated_by`                                                              | `"quick-skill"`                |
+| `source_authority`                                                          | `"community"`                  |
+| `tool_versions.ast_grep`, `tool_versions.qmd`                               | `null` (Quick is tier-unaware) |
+| `stats.exports_internal`, `stats.scripts_count`, `stats.assets_count`       | `0`                            |
+| `stats.public_api_coverage`, `stats.total_coverage`                         | `1.0`                          |
+| Other `confidence_distribution.*` buckets (besides `t1_low`)                | `0`                            |
+
+**Input-derived rules:**
+
 - `version`: `extraction_inventory.version` or `"1.0.0"`
 - `generation_date`: current ISO 8601 UTC datetime
-- `exports[]`: list of detected export names from `extraction_inventory.exports`
+- `exports[]`: detected export names from `extraction_inventory.exports`
+- `confidence_distribution.t1_low` and `stats.exports_documented` / `exports_public_api` / `exports_total`: count of exports detected in step-03 (integers, not strings)
+- `provenance.language_hint` / `provenance.scope_hint`: echo the user-supplied hints from step-01 (or `null` when omitted)
+- `tool_versions.skf`: resolved from `{project-root}/_bmad/skf/package.json` → npm require → `{project-root}/_bmad/skf/VERSION` → `"unknown"` (first hit wins)
 
 If a field is added to the template's metadata.json schema in the future, it lands here automatically — these rules describe **how Quick populates** the template, not what fields exist.
 

--- a/src/skf-quick-skill/steps-c/step-05-validate.md
+++ b/src/skf-quick-skill/steps-c/step-05-validate.md
@@ -91,7 +91,7 @@ This validates frontmatter, description, body limits, links, and formatting; run
 
 Record quality score, remaining diagnostics, and security findings as validation issues.
 
-**If skill-check is NOT available**, run the shared frontmatter validator instead of an LLM-walked checklist. Resolve `{frontmatterValidator}` by probing `{frontmatterValidatorProbeOrder}` (installed `{project-root}/_bmad/skf/shared/scripts/skf-validate-frontmatter.py` first, dev `{project-root}/src/shared/scripts/skf-validate-frontmatter.py` fallback); first existing path wins. If neither candidate exists, log a high-severity issue ("frontmatter validator unavailable — both `npx skill-check` and `skf-validate-frontmatter.py` missing") and skip frontmatter validation.
+**If skill-check is NOT available**, run the shared frontmatter validator instead of an LLM-walked checklist. Resolve `{frontmatterValidator}` from `{frontmatterValidatorProbeOrder}`; first existing path wins. If no candidate exists, log a high-severity issue ("frontmatter validator unavailable — both `npx skill-check` and `skf-validate-frontmatter.py` missing") and skip frontmatter validation.
 
 ```bash
 python3 {frontmatterValidator} {skill_package}/SKILL.md --skill-dir-name {repo_name}

--- a/src/skf-quick-skill/steps-c/step-06-write.md
+++ b/src/skf-quick-skill/steps-c/step-06-write.md
@@ -27,7 +27,7 @@ To finalize the skill by creating the active-version pointer, displaying the com
 
 Create or update the `active` pointer at `{skill_group}/active` pointing to `{version}` using the shared atomic-flip helper. The helper acquires an `flock` on `{skill_group}/active.skf-lock`, refuses to replace a non-link at `{skill_group}/active` (protecting against accidental `rm -rf` of a real directory), and uses a rename-over-symlink pattern so the update is atomic from a concurrent reader's perspective. On Windows the helper automatically falls back to a directory junction (`mklink /J`) when `os.symlink` fails with `PRIVILEGE_NOT_HELD` / `ACCESS_DENIED` — junctions require no admin elevation and resolve identically for `skf-skill-inventory`'s consumers:
 
-**Resolve `{atomicWriteHelper}`:** probe `{atomicWriteProbeOrder}` (installed `{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py` first, dev `{project-root}/src/shared/scripts/skf-atomic-write.py` fallback); first existing path wins. HALT if neither candidate exists — the active-pointer flip MUST go through the atomic helper.
+**Resolve `{atomicWriteHelper}`** from `{atomicWriteProbeOrder}`; first existing path wins. HALT if no candidate exists — the active-pointer flip MUST go through the atomic helper.
 
 ```bash
 python3 {atomicWriteHelper} flip-link \


### PR DESCRIPTION
## Summary

Resolves theme 2 ("Canonical-source drift between prompts and references") from the 2026-05-01 quality analysis. Three pieces of canonical knowledge were duplicated across prompts and reference files; each is now single-sourced.

## Commits

- **`docs(skf-quick-skill)`** — promote the 10s per-call registry timeout (and the 15s web-search variant) from skf-quick-skill step-01 §3 to `references/registry-resolution.md`. Pre-req for the next commit so no operational nuance is lost.
- **`refactor(skf-quick-skill)`** — reduce step-01 §3 to a one-line load+apply that defers to the reference. The four-bullet chain enumeration was strictly less detailed than the reference (which already had npm `git+`/`.git` stripping and PyPI Source/Repository/Homepage priority — both omitted in the inline list).
- **`refactor(skf-quick-skill)`** — drop the prose probe-path enumeration in step-05 §4 (frontmatter validator) and step-06 §1 (atomic-write helper). Both steps already declared the probe order in YAML frontmatter; the prose duplicated it.
- **`refactor(skf-quick-skill)`** — split step-04 §4's flat 11-bullet metadata population block into a 7-row constants table + 6 input-derived rules. Reduces drift surface — when the template's schema changes, only the input-derived rules need touching.

## Why

Each duplication was a future-maintenance footgun: schema changes had to land in two places, and (as the analysis noted) the surfaces had already drifted — the inline registry list was missing nuances the reference already had, and vice-versa for the timeout directive.

## Test plan

- [x] `npm run quality` — runs as the husky pre-commit hook on every commit; all four commits passed locally
- [x] CI green on `ubuntu-latest` + `windows-latest`
- [x] Manual: `/skf-quick-skill lodash` — confirm step-01 §3 still resolves via the reference and the HARD HALT message renders identically; step-05 §4 still resolves the frontmatter validator; step-06 §1 still resolves the atomic-write helper; step-04 §4 still emits a metadata.json with the same shape

## Notes for reviewers

- No drive-by reformats; only lines tied to each finding are touched.
- This is PR 2 of 6 in the phased plan generated from the quality analysis at `skills/reports/skf-quick-skill/quality-analysis/20260501-083628/`. PR 1 (#260) merged in `c3e1019`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)