### PR TITLE
feat(skf-quick-skill): edge-case sniffs at the seams (repo shape, language ambiguity, version existence, zero exports)

### DIFF
--- a/src/skf-quick-skill/steps-c/step-01-resolve-target.md
+++ b/src/skf-quick-skill/steps-c/step-01-resolve-target.md
@@ -91,8 +91,8 @@ In interactive mode, wait for corrected input and loop back to step 2. In headle
 
 Determine primary language from:
 
-1. **User-provided language hint** (overrides detection)
-2. **Manifest file presence** (check via GitHub API or web browsing):
+1. **User-provided language hint** (overrides detection — skip the ambiguity gate below).
+2. **Manifest-presence scan** — check the repo root for ALL of these (priority order = first hit wins on auto-pick):
    - `package.json` → JavaScript/TypeScript
    - `pyproject.toml` or `setup.py` → Python
    - `Cargo.toml` → Rust
@@ -100,7 +100,21 @@ Determine primary language from:
    - `pom.xml` → Java (or Kotlin if `src/main/kotlin/` is present)
    - `build.gradle.kts` or `build.gradle` → Kotlin (or Java if only `src/main/java/` is present)
 
-Set `language` to detected language.
+   Collect every match into `detected_languages`.
+
+3. **Single-language case** (`len(detected_languages) <= 1`) — set `language` to the detected value (or HALT in step-01 §3 if zero matches).
+
+4. **Multi-language case** (`len(detected_languages) > 1`) — surface the choice rather than silently picking the first match. Multi-language repos (Python + JS bindings, or monorepos with mixed manifests) otherwise produce a skill for whichever manifest probe hits first, with no signal that the user might have wanted the other one.
+
+   "**`{repo_name}` has manifests for multiple languages:** {detected_languages}.
+
+   Primary guess: **{first_match}** (manifest-priority order). If you wanted a different language, abort and re-run with `--language-hint <lang>` or with the optional language hint at step-01 §1.
+
+   Select: [C] Continue with `{first_match}` · [A] Abort"
+
+   - **IF C** — log "user accepted multi-manifest pick: `{first_match}`" and set `language` to the first match.
+   - **IF A** — HARD HALT with **exit code 3 (resolution-failure)**: "Aborted to disambiguate language. Re-run with a `language_hint`." Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "resolve-target"`, `error.code: "resolution-failure"`, `error.details: {detected_languages: [...], auto_pick: "{first_match}"}`, `skill_package: null`).
+   - **GATE [default: C]** — Headless mode auto-proceeds with the manifest-priority pick; record `detected_languages` and `language_resolution: "auto-picked-first"` in the extraction context so the result contract surfaces the ambiguity downstream.
 
 ### 5. Confirm Resolution
 

--- a/src/skf-quick-skill/steps-c/step-01-resolve-target.md
+++ b/src/skf-quick-skill/steps-c/step-01-resolve-target.md
@@ -50,7 +50,7 @@ If no `@version` suffix is present, proceed as today — version will be auto-de
 - Extract org/repo from URL
 - Set `resolved_url` to the GitHub URL
 - Set `repo_name` to the repo name (last path segment)
-- Skip to step 4 (Detect Language)
+- Skip to step 3a (Verify Target Version Tag), then step 4 (Detect Language)
 
 **If input is a package-name-like token** (no whitespace, matches `[@a-zA-Z0-9._/-]+(@<semver>)?`, e.g. `lodash`, `@scope/name`, `requests==2.31`, `cognee@0.5.0`):
 - Proceed to step 3 (Registry Resolution)
@@ -86,6 +86,34 @@ Check:
 **Provide the GitHub URL directly to continue.**"
 
 In interactive mode, wait for corrected input and loop back to step 2. In headless mode, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "resolve-target"`, `error.code: "resolution-failure"`, `skill_package: null`) and exit 3.
+
+### 3a. Verify Target Version Tag (when applicable)
+
+Skip this section if `target_version` is null (auto-detect path — version comes from manifest read in step-03).
+
+When the user explicitly supplied `@version` in §1b, verify the tag exists in the resolved repo before extraction. Otherwise step-03 silently reads from the default branch while metadata records the requested version — a quiet provenance bug where the SKILL.md claims version 0.5.0 but the exports actually came from main.
+
+Probe both with-and-without v-prefix (the v-prefix is conventional but not universal across ecosystems):
+
+```bash
+gh api repos/{owner}/{repo}/git/ref/tags/{target_version} --silent \
+  || gh api repos/{owner}/{repo}/git/ref/tags/v{target_version} --silent
+```
+
+**If a matching tag is found** — set `source_ref` to the matching ref (with v-prefix when that variant matched). Step-03's ref-aware source reading uses this value to fetch from the tagged commit. Proceed to §4.
+
+**If no tag matches** — HARD HALT with **exit code 3 (resolution-failure)**:
+
+"**Tag `{target_version}` not found in `{owner}/{repo}`.**
+
+The version was parsed from your `@version` suffix but does not exist as a tag in the resolved repository. Quick-skill cannot extract from a version with no commit pointer — the result would be sourced from the default branch but labelled `{target_version}` in metadata.
+
+Recent tags in this repo:
+{list top 5 from `gh api repos/{owner}/{repo}/tags --paginate=false`, or "(none — repo has no tags; omit @version to auto-detect from default branch)"}
+
+Re-run with one of these tags, or omit the `@version` suffix to auto-detect from the default branch."
+
+Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "resolve-target"`, `error.code: "resolution-failure"`, `error.details: {requested_version: "{target_version}", available_tags: [...top 5]}`, `skill_package: null`). In headless mode, exit immediately; do not loop.
 
 ### 4. Detect Language
 

--- a/src/skf-quick-skill/steps-c/step-03-quick-extract.md
+++ b/src/skf-quick-skill/steps-c/step-03-quick-extract.md
@@ -34,6 +34,30 @@ Extract:
 
 If README is unavailable, note and continue.
 
+### 1.5. Repo-Shape Sniff
+
+After the README has loaded, classify the repo shape from the available signals before committing further effort to extraction. Quick-skill is designed to wrap a library; non-library repos sail through silently today and produce low-quality skills the user only notices via the description field after compilation.
+
+**Classify as one of:**
+
+- **library** (default) — README has installation / usage / API content; manifest at root with publishable metadata. Proceed normally.
+- **awesome-list** — README H1 contains "awesome" (case-insensitive) or `awesome-` is in the repo name; README body is dominated by curated bullet links of the form `- [name](url) — desc`; no manifest at root.
+- **docs-site / website** — README is short (under ~50 non-empty lines) and primarily points elsewhere ("See https://… for docs"); root has no manifest, or only a docs-framework manifest (e.g. `docusaurus.config.js`, `astro.config.mjs`, `mkdocs.yml`).
+- **examples-only / tutorial** — README explicitly labels the repo as examples or a tutorial ("Code examples for…", "Tutorial: …", "Learn X by building Y"); typically no published package; many small standalone files instead of a single API surface.
+
+**If a non-library shape is detected** — soft-warn and gate before continuing:
+
+"**Heads up — `{repo_name}` looks like a `{shape}` repo, not a library.**
+
+Quick-skill is designed to wrap a library's public API. The compiled SKILL.md will likely have a thin Description and an empty Key Exports list. You can continue anyway, or abort and pick a target library.
+
+Select: [C] Continue anyway · [A] Abort"
+
+- **IF C** — log "user accepted `{shape}` shape" and proceed to §2. Set `extraction_inventory.repo_shape` to the detected shape so the result contract carries the signal for automators.
+- **IF A** — HARD HALT with **exit code 3 (resolution-failure)** per the SKILL.md exit-code map: "Aborted. `{shape}` repos are best wrapped manually with `/skf-create-skill` from a brief, not auto-extracted." Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "quick-extract"`, `error.code: "resolution-failure"`, `error.details: {repo_shape: "{shape}"}`, `skill_package: null`).
+
+**GATE [default: C]** — In headless mode, log "headless: detected `{shape}` repo, continuing anyway" and proceed; the result contract's `summary.repo_shape` carries the signal so automators can flag low-quality outputs without re-parsing logs.
+
 ### 2. Read Manifest File
 
 Based on detected language, read the primary manifest file:

--- a/src/skf-quick-skill/steps-c/step-03-quick-extract.md
+++ b/src/skf-quick-skill/steps-c/step-03-quick-extract.md
@@ -133,6 +133,29 @@ extraction_inventory:
 - Use README description and features as fallback content
 - Note: "No exports detected — SKILL.md will be based on README content only"
 
+### 4.5. Zero-Exports Soft Gate (rescue mode)
+
+Run this gate **only when** `extraction_inventory.exports.length == 0` AND `extraction_inventory.description` is empty (no usable README content either). When either is non-empty, the README-fallback in §4 produces a usable skill and this section is skipped.
+
+When both are empty, the compiled SKILL.md would be effectively empty — no API surface to document and no description to fall back on. Offer the user a chance to retry with hints before producing a degenerate output:
+
+"**Extraction yielded zero exports and no README description.**
+
+The compiled SKILL.md would be effectively empty — no API surface to document and no description to fall back on.
+
+Common causes:
+- Wrong scope (extraction read the repo root, but the public API lives in a subdir)
+- Wrong language (manifest probe picked the test/build language, not the lib language)
+- Repo lays out exports unconventionally (e.g., not in `src/index.*` or `lib.rs`)
+
+Select: [R] Retry with new hints · [P] Proceed anyway (low-confidence skill) · [A] Abort"
+
+- **IF R** — prompt for new `scope_hint` ("New scope hint (e.g. `src/server/`):") and optional new `language_hint` ("New language hint (or empty to keep `{language}`):"). Update the extraction context with the new hints, then **re-execute step-03 from §1** with the new values. Discards the prior empty inventory.
+- **IF P** — log "user accepted zero-exports outcome" and proceed to §5. The compiled skill will be README-content-only with confidence `low`. Record `zero_exports_rescue: "user-accepted"` in the inventory so the result contract summary surfaces it.
+- **IF A** — HARD HALT with **exit code 3 (resolution-failure)**: "Aborted. Run `/skf-create-skill` from a brief if you want a guided extraction with provenance tracking." Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "quick-extract"`, `error.code: "resolution-failure"`, `error.details: {exports_found: 0, description_empty: true, language: "{language}", scope: "{scope_hint or 'entire repo'}"}`, `skill_package: null`).
+
+**GATE [default: P]** — In headless mode, log "headless: zero exports + empty description, proceeding with low-confidence skill" and proceed; record `zero_exports_rescue: "auto-proceeded"` in the result contract summary so batch automators can re-queue these targets with stricter hints downstream. [P] preserves the pre-rescue behaviour for unattended pipelines.
+
 ### 5. Report Extraction Summary
 
 "**Extraction complete:**


### PR DESCRIPTION
## Summary

Resolves theme 4 ("Workflow silently produces wrong-shape skills on edge-case inputs") from the 2026-05-01 quality analysis. quick-skill trusted that any GitHub repo passed in was a library, that any package@version was published as a tag, that the first manifest probe to hit was the right language, and that zero exports + empty README was still worth compiling. Each of those silent passthroughs is now a soft gate at the relevant seam.

## Commits

- **`feat(skf-quick-skill)`** — repo-shape sniff at step-03 §1.5 (after README read, before manifest parse). Classifies the repo as library / awesome-list / docs-site / examples-only and soft-warns + gates if a non-library shape is detected. [C] continue / [A] abort. Headless auto-proceeds and records the shape in the result contract summary.
- **`feat(skf-quick-skill)`** — ambiguous-language gate at step-01 §4. Scans for ALL manifests at root (not just first hit), and when multiple are detected (Python+JS bindings, monorepos with mixed manifests), surfaces the choice. [C] continue with manifest-priority pick / [A] abort and re-run with `--language-hint`. Headless auto-proceeds and records `detected_languages` + `language_resolution: "auto-picked-first"`.
- **`feat(skf-quick-skill)`** — version-existence check at step-01 §3a (between registry resolution and language detection). Probes `gh api .../git/ref/tags/{target_version}` (with and without v-prefix). On miss, HARD HALTs with exit code 3 and a list of recent tags. Closes a quiet provenance bug where `cognee@0.5.0` parsed fine but extraction silently read from main.
- **`feat(skf-quick-skill)`** — zero-exports rescue gate at step-03 §4.5. Fires only when both `exports.length == 0` AND `description` is empty (cases with either non-empty already produce a usable README-fallback skill). [R] retry with new scope/language hints / [P] proceed with low-confidence / [A] abort. Headless default [P] preserves pre-rescue behaviour for unattended pipelines.

## Why

Each of these was a silent failure mode the user only noticed by reading the compiled output after the fact — too late to course-correct without re-running the whole pipeline. Catching them at the seams gives the user a real choice while the workflow can still abort cheaply.

The defaults are calibrated for non-disruption:
- Interactive: every gate offers an [A]bort, but [C]/[P] keeps the workflow flowing.
- Headless: every gate auto-proceeds and records the disambiguating signal in the result contract summary so batch automators can filter / re-queue downstream without log-grepping.

## Test plan

- [x] `npm run quality` — runs as the husky pre-commit hook on every commit; all four commits passed locally
- [x] CI green on `ubuntu-latest` + `windows-latest`
- [x] Manual: `/skf-quick-skill sindresorhus/awesome` — confirm step-03 §1.5 fires with `awesome-list` shape and offers [C]/[A]
- [x] Manual: `/skf-quick-skill cognee@99.99.99 --headless` — confirm step-01 §3a HARD HALTs with exit 3 and lists recent tags
- [x] Manual: a repo with both Python and JS manifests — confirm step-01 §4 ambiguous-language gate fires; pass `--language-hint python` to skip it
- [x] Manual: `/skf-quick-skill <repo with no exports and no README>` — confirm step-03 §4.5 rescue gate fires

## Notes for reviewers

- All four gates respect the headless contract added in PR #263: each HARD HALT path emits the exit-code-mapped error result contract per SKILL.md "Result Contract on HARD HALT".
- This is PR 5 of 6 in the phased plan generated from the quality analysis at `skills/reports/skf-quick-skill/quality-analysis/20260501-083628/`. PRs 1–4 (#260, #261, #262, #263) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)