### PR TITLE
refactor(skf-quick-skill): extract skf-resolve-package.py + wire into step-01 §3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py test/test-skf-merge-ccc-exclusions.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py test/test-skf-merge-ccc-exclusions.py test/test-skf-resolve-package.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/src/shared/scripts/skf-resolve-package.py
+++ b/src/shared/scripts/skf-resolve-package.py
@@ -1,0 +1,264 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SKF Resolve Package — resolve a package name to a GitHub repository URL.
+
+Walks the canonical fallback chain documented in
+`src/skf-quick-skill/references/registry-resolution.md`:
+
+  1. npm registry        (JavaScript/TypeScript)
+  2. PyPI registry       (Python)
+  3. crates.io registry  (Rust)
+
+Per-call timeout (default 10s); a timeout is treated as a soft failure
+and the resolver falls through to the next entry. Web-search fallback
+is intentionally NOT in this helper — registries are deterministic;
+web search is judgment, and stays in the LLM step.
+
+CLI:
+
+  python3 skf-resolve-package.py <package_name> [--timeout 10]
+
+Output JSON (stdout):
+
+  status:           "ok" | "fallthrough"
+  package_name:     "<input>"
+  resolved_url:     "https://github.com/<owner>/<repo>"  (when status == "ok")
+  repo_owner:       "<owner>"                            (when status == "ok")
+  repo_name:        "<repo>"                             (when status == "ok")
+  registry_used:    "npm" | "pypi" | "crates"            (when status == "ok")
+  registries_tried: ["npm", ...]
+  registry_outcomes: {"npm": "ok|404|timeout|error|no-github-link", ...}
+
+Exit codes:
+
+  0  status == "ok"
+  1  status == "fallthrough" — every registry replied without a GitHub
+     URL; the LLM step should fall back to web search.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import socket
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+REGISTRY_TIMEOUT_SECONDS = 10.0
+USER_AGENT = "skf-resolve-package/1.0 (+https://github.com/armelhbobdad/bmad-module-skill-forge)"
+
+_GITHUB_URL_RE = re.compile(
+    r"https?://(?:www\.)?github\.com/([^/\s]+)/([^/\s.]+?)(?:\.git)?/?$",
+    re.IGNORECASE,
+)
+
+
+def parse_github_url(url: str) -> Optional[tuple[str, str, str]]:
+    """Parse a GitHub URL/string into (canonical_url, owner, repo).
+
+    Handles the variants registries actually emit:
+      - https://github.com/owner/repo
+      - http://github.com/owner/repo
+      - github.com/owner/repo
+      - git+https://github.com/owner/repo.git
+      - git@github.com:owner/repo.git
+      - github:owner/repo (npm shortcut)
+    """
+    if not url or not isinstance(url, str):
+        return None
+
+    s = url.strip()
+
+    if s.startswith("github:"):
+        rest = s[len("github:") :]
+        if "/" in rest:
+            owner, _, repo = rest.partition("/")
+            repo = repo.removesuffix(".git").rstrip("/")
+            if owner and repo:
+                return f"https://github.com/{owner}/{repo}", owner, repo
+        return None
+
+    if s.startswith("git+"):
+        s = s[len("git+") :]
+
+    if s.startswith("git@github.com:"):
+        rest = s[len("git@github.com:") :]
+        rest = rest.removesuffix(".git").rstrip("/")
+        if "/" in rest:
+            owner, _, repo = rest.partition("/")
+            if owner and repo:
+                return f"https://github.com/{owner}/{repo}", owner, repo
+        return None
+
+    if s.startswith("github.com/"):
+        s = "https://" + s
+
+    m = _GITHUB_URL_RE.match(s)
+    if m:
+        owner, repo = m.group(1), m.group(2)
+        return f"https://github.com/{owner}/{repo}", owner, repo
+
+    return None
+
+
+def _http_get_json(url: str, timeout: float) -> tuple[Optional[dict], str]:
+    """Fetch JSON. Returns (payload_or_None, outcome).
+
+    Outcome values:
+      "ok"       — valid JSON object returned
+      "404"      — HTTP 404 (package does not exist on this registry)
+      "timeout"  — socket / urlopen timed out
+      "error"    — any other transport / parse error
+    """
+    req = urllib.request.Request(url, headers={"Accept": "application/json", "User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+            if isinstance(payload, dict):
+                return payload, "ok"
+            return None, "error"
+    except urllib.error.HTTPError as e:
+        return None, "404" if e.code == 404 else "error"
+    except urllib.error.URLError as e:
+        if isinstance(getattr(e, "reason", None), (socket.timeout, TimeoutError)):
+            return None, "timeout"
+        return None, "error"
+    except (TimeoutError, socket.timeout):
+        return None, "timeout"
+    except (ValueError, json.JSONDecodeError):
+        return None, "error"
+
+
+def try_npm(package_name: str, timeout: float) -> tuple[Optional[tuple[str, str, str]], str]:
+    """Try the npm registry. Returns (parsed_or_None, outcome)."""
+    encoded = urllib.parse.quote(package_name, safe="@")
+    url = f"https://registry.npmjs.org/{encoded}"
+    payload, outcome = _http_get_json(url, timeout)
+    if payload is None:
+        return None, outcome
+    candidates: list[str] = []
+    repo = payload.get("repository")
+    if isinstance(repo, dict) and isinstance(repo.get("url"), str):
+        candidates.append(repo["url"])
+    elif isinstance(repo, str):
+        candidates.append(repo)
+    homepage = payload.get("homepage")
+    if isinstance(homepage, str):
+        candidates.append(homepage)
+    for c in candidates:
+        parsed = parse_github_url(c)
+        if parsed:
+            return parsed, "ok"
+    return None, "no-github-link"
+
+
+def try_pypi(package_name: str, timeout: float) -> tuple[Optional[tuple[str, str, str]], str]:
+    """Try the PyPI registry. Returns (parsed_or_None, outcome)."""
+    encoded = urllib.parse.quote(package_name, safe="")
+    url = f"https://pypi.org/pypi/{encoded}/json"
+    payload, outcome = _http_get_json(url, timeout)
+    if payload is None:
+        return None, outcome
+    info = payload.get("info") or {}
+    candidates: list[str] = []
+    project_urls = info.get("project_urls") or {}
+    if isinstance(project_urls, dict):
+        for key in ("Source", "Source Code", "Repository", "Homepage"):
+            v = project_urls.get(key)
+            if isinstance(v, str):
+                candidates.append(v)
+    home_page = info.get("home_page")
+    if isinstance(home_page, str):
+        candidates.append(home_page)
+    for c in candidates:
+        parsed = parse_github_url(c)
+        if parsed:
+            return parsed, "ok"
+    return None, "no-github-link"
+
+
+def try_crates(package_name: str, timeout: float) -> tuple[Optional[tuple[str, str, str]], str]:
+    """Try the crates.io registry. Returns (parsed_or_None, outcome)."""
+    encoded = urllib.parse.quote(package_name, safe="")
+    url = f"https://crates.io/api/v1/crates/{encoded}"
+    payload, outcome = _http_get_json(url, timeout)
+    if payload is None:
+        return None, outcome
+    crate = payload.get("crate") or {}
+    for key in ("repository", "homepage"):
+        v = crate.get(key)
+        if isinstance(v, str):
+            parsed = parse_github_url(v)
+            if parsed:
+                return parsed, "ok"
+    return None, "no-github-link"
+
+
+_RESOLVER_NAMES: tuple[tuple[str, str], ...] = (
+    ("npm", "try_npm"),
+    ("pypi", "try_pypi"),
+    ("crates", "try_crates"),
+)
+
+
+def resolve_package(package_name: str, timeout: float = REGISTRY_TIMEOUT_SECONDS) -> dict:
+    registries_tried: list[str] = []
+    outcomes: dict[str, str] = {}
+
+    # Dynamic lookup so test code can monkeypatch try_npm / try_pypi / try_crates
+    # without re-binding entries in a module-level tuple of function refs.
+    for name, fn_name in _RESOLVER_NAMES:
+        registries_tried.append(name)
+        fn = globals()[fn_name]
+        result, outcome = fn(package_name, timeout)
+        outcomes[name] = outcome
+        if result is not None:
+            url, owner, repo = result
+            return {
+                "status": "ok",
+                "package_name": package_name,
+                "resolved_url": url,
+                "repo_owner": owner,
+                "repo_name": repo,
+                "registry_used": name,
+                "registries_tried": registries_tried,
+                "registry_outcomes": outcomes,
+            }
+
+    return {
+        "status": "fallthrough",
+        "package_name": package_name,
+        "registries_tried": registries_tried,
+        "registry_outcomes": outcomes,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve a package name to a GitHub repository URL via npm/PyPI/crates.io.",
+    )
+    parser.add_argument(
+        "package_name",
+        help="Package name to resolve (e.g., lodash, @tanstack/query, requests, serde).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=REGISTRY_TIMEOUT_SECONDS,
+        help=f"Per-registry timeout in seconds (default: {REGISTRY_TIMEOUT_SECONDS}).",
+    )
+    args = parser.parse_args(argv)
+
+    result = resolve_package(args.package_name, timeout=args.timeout)
+    print(json.dumps(result, indent=2))
+    return 0 if result["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/skf-quick-skill/steps-c/step-01-resolve-target.md
+++ b/src/skf-quick-skill/steps-c/step-01-resolve-target.md
@@ -1,6 +1,9 @@
 ---
 nextStepFile: './step-02-ecosystem-check.md'
 registryResolutionData: 'references/registry-resolution.md'
+packageResolverProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-resolve-package.py'
+  - '{project-root}/src/shared/scripts/skf-resolve-package.py'
 ---
 
 # Step 1: Resolve Target
@@ -72,7 +75,18 @@ Otherwise, paste the package name or GitHub URL of the library you want to wrap,
 
 ### 3. Registry Resolution
 
-Load {registryResolutionData} and execute its fallback chain in order — stop at first success. The reference is canonical for the chain order (npm → PyPI → crates.io → web search), the per-registry URL templates and response-field paths, the per-call timeouts (10s per registry, 15s for web search), and the timeout-as-soft-failure semantics.
+Run the shared resolver against the deterministic registries (npm → PyPI → crates.io). The resolver does the HTTP+JSON+GitHub-URL-extraction work; the LLM only handles the web-search fallback below when needed.
+
+**Resolve `{packageResolver}`** from `{packageResolverProbeOrder}`; first existing path wins. If no candidate exists, fall back to the LLM walk of {registryResolutionData} for the full chain.
+
+```bash
+python3 {packageResolver} {package_name} --timeout 10
+```
+
+The resolver emits JSON with `status` (`"ok"` or `"fallthrough"`), `resolved_url`, `repo_owner`, `repo_name`, `registry_used`, `registries_tried`, and a per-registry `registry_outcomes` map. Exit 0 means ok; exit 1 means fallthrough.
+
+- **On `status: "ok"`** — capture `resolved_url`, `repo_name`, and `registry_used` from the JSON. Proceed to §3a.
+- **On `status: "fallthrough"`** — the deterministic chain returned no GitHub URL (every registry replied with 404 / no-github-link / timeout). Fall back to the web-search step from {registryResolutionData} §4: search `"{package_name} github repository"` with a 15s timeout and look for a GitHub URL in the top results. If found, set `resolved_url` and proceed. If web search also returns nothing, HARD HALT below.
 
 **If all methods fail — HARD HALT (exit code 3, resolution-failure):**
 

--- a/test/test-skf-resolve-package.py
+++ b/test/test-skf-resolve-package.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Tests for skf-resolve-package.py.
+
+Network is mocked at the _http_get_json layer so the tests stay offline
+and deterministic. The script's own _http_get_json error-classification
+is not exercised here (it is thin glue around urllib + json); tests
+focus on the GitHub-URL parser, registry-payload parsers, and the
+overall resolve-package fallback behaviour.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "skf_resolve_package",
+    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-resolve-package.py",
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class TestParseGithubUrl:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("https://github.com/lodash/lodash", ("https://github.com/lodash/lodash", "lodash", "lodash")),
+            ("http://github.com/lodash/lodash", ("https://github.com/lodash/lodash", "lodash", "lodash")),
+            ("github.com/lodash/lodash", ("https://github.com/lodash/lodash", "lodash", "lodash")),
+            (
+                "git+https://github.com/lodash/lodash.git",
+                ("https://github.com/lodash/lodash", "lodash", "lodash"),
+            ),
+            (
+                "git@github.com:lodash/lodash.git",
+                ("https://github.com/lodash/lodash", "lodash", "lodash"),
+            ),
+            ("github:lodash/lodash", ("https://github.com/lodash/lodash", "lodash", "lodash")),
+            ("https://github.com/scope-name/pkg.git", ("https://github.com/scope-name/pkg", "scope-name", "pkg")),
+            ("https://github.com/owner/repo/", ("https://github.com/owner/repo", "owner", "repo")),
+        ],
+    )
+    def test_recognized_variants(self, raw, expected):
+        assert mod.parse_github_url(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "not-a-url",
+            "https://example.com/foo",
+            "https://gitlab.com/owner/repo",
+            "https://bitbucket.org/owner/repo",
+            "ftp://github.com/owner/repo",  # only http/https
+        ],
+    )
+    def test_rejects_non_github(self, raw):
+        assert mod.parse_github_url(raw) is None
+
+    def test_handles_none_and_non_string(self):
+        assert mod.parse_github_url(None) is None  # type: ignore[arg-type]
+        assert mod.parse_github_url(42) is None  # type: ignore[arg-type]
+
+
+class TestRegistryPayloadParsers:
+    """Each try_* function calls _http_get_json then extracts a GitHub URL.
+    Tests monkeypatch the HTTP fetch and assert the correct candidate-field
+    priority and outcome reporting.
+    """
+
+    def _patch_http(self, monkeypatch, payload, outcome="ok"):
+        monkeypatch.setattr(mod, "_http_get_json", lambda url, timeout: (payload, outcome))
+
+    def test_npm_repository_object(self, monkeypatch):
+        self._patch_http(monkeypatch, {"repository": {"url": "git+https://github.com/lodash/lodash.git"}})
+        result, outcome = mod.try_npm("lodash", 5)
+        assert result == ("https://github.com/lodash/lodash", "lodash", "lodash")
+        assert outcome == "ok"
+
+    def test_npm_repository_string_shortcut(self, monkeypatch):
+        self._patch_http(monkeypatch, {"repository": "github:lodash/lodash"})
+        result, outcome = mod.try_npm("lodash", 5)
+        assert result == ("https://github.com/lodash/lodash", "lodash", "lodash")
+        assert outcome == "ok"
+
+    def test_npm_falls_back_to_homepage(self, monkeypatch):
+        self._patch_http(
+            monkeypatch,
+            {"repository": "https://example.com/not-github", "homepage": "https://github.com/owner/repo"},
+        )
+        result, _ = mod.try_npm("foo", 5)
+        assert result == ("https://github.com/owner/repo", "owner", "repo")
+
+    def test_npm_no_github_link(self, monkeypatch):
+        self._patch_http(monkeypatch, {"repository": "https://example.com/x", "homepage": "https://example.com/y"})
+        result, outcome = mod.try_npm("foo", 5)
+        assert result is None
+        assert outcome == "no-github-link"
+
+    def test_npm_404(self, monkeypatch):
+        self._patch_http(monkeypatch, None, outcome="404")
+        result, outcome = mod.try_npm("foo", 5)
+        assert result is None
+        assert outcome == "404"
+
+    def test_pypi_project_urls_priority(self, monkeypatch):
+        self._patch_http(
+            monkeypatch,
+            {
+                "info": {
+                    "project_urls": {
+                        "Homepage": "https://example.com/docs",
+                        "Source": "https://github.com/psf/requests",
+                        "Repository": "https://github.com/psf/requests-mirror",
+                    },
+                    "home_page": "https://example.com/old",
+                },
+            },
+        )
+        result, _ = mod.try_pypi("requests", 5)
+        assert result == ("https://github.com/psf/requests", "psf", "requests")
+
+    def test_pypi_falls_back_to_home_page(self, monkeypatch):
+        self._patch_http(
+            monkeypatch,
+            {
+                "info": {
+                    "project_urls": {"Documentation": "https://example.com/docs"},
+                    "home_page": "https://github.com/owner/repo",
+                },
+            },
+        )
+        result, _ = mod.try_pypi("foo", 5)
+        assert result == ("https://github.com/owner/repo", "owner", "repo")
+
+    def test_pypi_no_github_link(self, monkeypatch):
+        self._patch_http(
+            monkeypatch,
+            {"info": {"project_urls": {"Homepage": "https://example.com/x"}, "home_page": "https://example.com/y"}},
+        )
+        result, outcome = mod.try_pypi("foo", 5)
+        assert result is None
+        assert outcome == "no-github-link"
+
+    def test_crates_repository(self, monkeypatch):
+        self._patch_http(monkeypatch, {"crate": {"repository": "https://github.com/serde-rs/serde"}})
+        result, _ = mod.try_crates("serde", 5)
+        assert result == ("https://github.com/serde-rs/serde", "serde-rs", "serde")
+
+    def test_crates_falls_back_to_homepage(self, monkeypatch):
+        self._patch_http(monkeypatch, {"crate": {"homepage": "https://github.com/owner/repo"}})
+        result, _ = mod.try_crates("foo", 5)
+        assert result == ("https://github.com/owner/repo", "owner", "repo")
+
+
+class TestResolvePackage:
+    def test_first_registry_wins(self, monkeypatch):
+        def fake_npm(name, t):
+            return ("https://github.com/lodash/lodash", "lodash", "lodash"), "ok"
+
+        def fake_pypi(name, t):
+            raise AssertionError("pypi must not be called once npm resolved")
+
+        monkeypatch.setattr(mod, "try_npm", fake_npm)
+        monkeypatch.setattr(mod, "try_pypi", fake_pypi)
+        result = mod.resolve_package("lodash")
+        assert result["status"] == "ok"
+        assert result["registry_used"] == "npm"
+        assert result["registries_tried"] == ["npm"]
+        assert result["registry_outcomes"] == {"npm": "ok"}
+
+    def test_falls_through_to_pypi(self, monkeypatch):
+        monkeypatch.setattr(mod, "try_npm", lambda n, t: (None, "404"))
+        monkeypatch.setattr(
+            mod, "try_pypi", lambda n, t: (("https://github.com/psf/requests", "psf", "requests"), "ok")
+        )
+        result = mod.resolve_package("requests")
+        assert result["status"] == "ok"
+        assert result["registry_used"] == "pypi"
+        assert result["registries_tried"] == ["npm", "pypi"]
+        assert result["registry_outcomes"] == {"npm": "404", "pypi": "ok"}
+
+    def test_falls_through_all_registries(self, monkeypatch):
+        monkeypatch.setattr(mod, "try_npm", lambda n, t: (None, "404"))
+        monkeypatch.setattr(mod, "try_pypi", lambda n, t: (None, "404"))
+        monkeypatch.setattr(mod, "try_crates", lambda n, t: (None, "404"))
+        result = mod.resolve_package("nonexistent")
+        assert result["status"] == "fallthrough"
+        assert "resolved_url" not in result
+        assert result["registries_tried"] == ["npm", "pypi", "crates"]
+        assert result["registry_outcomes"] == {"npm": "404", "pypi": "404", "crates": "404"}
+
+    def test_records_timeouts_in_outcomes(self, monkeypatch):
+        monkeypatch.setattr(mod, "try_npm", lambda n, t: (None, "timeout"))
+        monkeypatch.setattr(mod, "try_pypi", lambda n, t: (None, "no-github-link"))
+        monkeypatch.setattr(
+            mod, "try_crates", lambda n, t: (("https://github.com/serde-rs/serde", "serde-rs", "serde"), "ok")
+        )
+        result = mod.resolve_package("serde")
+        assert result["status"] == "ok"
+        assert result["registry_used"] == "crates"
+        assert result["registry_outcomes"] == {"npm": "timeout", "pypi": "no-github-link", "crates": "ok"}
+
+
+class TestCli:
+    def test_cli_ok_exit_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            mod,
+            "resolve_package",
+            lambda name, timeout: {
+                "status": "ok",
+                "package_name": name,
+                "resolved_url": "https://github.com/o/r",
+                "repo_owner": "o",
+                "repo_name": "r",
+                "registry_used": "npm",
+                "registries_tried": ["npm"],
+                "registry_outcomes": {"npm": "ok"},
+            },
+        )
+        rc = mod.main(["lodash"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert '"status": "ok"' in out
+
+    def test_cli_fallthrough_exit_one(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            mod,
+            "resolve_package",
+            lambda name, timeout: {
+                "status": "fallthrough",
+                "package_name": name,
+                "registries_tried": ["npm", "pypi", "crates"],
+                "registry_outcomes": {"npm": "404", "pypi": "404", "crates": "404"},
+            },
+        )
+        rc = mod.main(["nonexistent"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert '"status": "fallthrough"' in out


### PR DESCRIPTION
## Summary

First of three split-out PRs from the original PR 6 plan (theme 1 from the 2026-05-01 quality analysis: "Deterministic work belongs in scripts, not prompts"). Moves the LLM-walked npm → PyPI → crates.io fallback chain out of step-01 §3 and into a new shared Python helper.

PR-by-PR plan (theme 1 remainder):
- **6a (this PR)** — `skf-resolve-package.py` + step-01 §3 wiring
- **6b** — `skf-extract-public-api.py --mode quick|full` + step-03 wiring (largest)
- **6c** — `skf-render-quick-metadata.py` + step-04 §4 wiring + skf-emit-result-envelope.py divergence note

## Commits

- **`feat(shared)`** — add `src/shared/scripts/skf-resolve-package.py`. Pure-stdlib (PEP 723 `dependencies = []`); walks npm/PyPI/crates with per-call timeouts; emits structured JSON with `status: "ok" | "fallthrough"`, `resolved_url`, `repo_owner`, `repo_name`, `registry_used`, `registries_tried`, `registry_outcomes`. Exit 0 ok, exit 1 fallthrough. Web-search fallback intentionally **not** in this helper — registries are deterministic; web search is judgment and stays in the LLM step.
- **`test(shared)`** — 31 offline test cases covering the GitHub URL parser (every variant the registries actually emit: https/http/bare/git+/git@/github: shortcut), npm/PyPI/crates payload parsers (object vs string repository, project_urls priority, homepage fallback, no-github-link / 404 / timeout outcomes), the resolve_package fallthrough behaviour, and the CLI exit codes. HTTP layer is monkeypatched at `_http_get_json` so no live registry is hit.
- **`chore`** — wire `test/test-skf-resolve-package.py` into `npm run test:python`. Local run: 439 passed across the full Python suite.
- **`refactor(skf-quick-skill)`** — invoke the helper from step-01 §3 via a new `packageResolverProbeOrder` (installed → dev fallback). When the helper is missing entirely, §3 falls back to the LLM walk of `references/registry-resolution.md` for graceful degradation. Helper exit codes drive next-step routing: ok → §3a; fallthrough → LLM web-search fallback; both fail → existing HARD HALT (exit code 3).

## Why

step-01 §3 was the largest "deterministic work in a prompt" finding from the analysis (~1500 tokens per invocation). HTTP fetches with timeouts, JSON-walking through nested fields, `git+`/`.git` stripping — none of it benefits from LLM judgment, all of it benefits from being unit-tested. The shared helper also gives skf-create-skill (and any future SKF workflow that resolves package names) a tested resolution path to reuse.

## Test plan

- [x] `uv run pytest test/test-skf-resolve-package.py` — 31/31 pass offline
- [x] `npm run quality` — runs as the husky pre-commit hook on every commit; all four commits passed locally (439 tests across the full Python suite once the new file is wired)
- [x] Live verification: `python3 src/shared/scripts/skf-resolve-package.py lodash` → `unshiftio/requests`, `serde`, `@tanstack/react-query` all resolve correctly; bogus name returns `status: "fallthrough"` with exit 1
- [x] CI green on `ubuntu-latest` + `windows-latest`
- [x] Manual: `/skf-quick-skill lodash --headless` — confirm step-01 §3 shells out to the helper and proceeds without re-doing the registry walk in-prompt

## Notes for reviewers

- Resolver-chain dispatch uses name-based lookup (`globals()[fn_name]`) so test code can monkeypatch `try_npm` / `try_pypi` / `try_crates` cleanly — a tuple of pre-bound function refs would have made the resolve_package tests untestable. The first attempt used a tuple and the failure surfaced in the test run.
- `requests` resolves to `unshiftio/requests` (npm) instead of `psf/requests` (PyPI) because the canonical chain is npm-first. Same behaviour as before this PR; the LLM step surfaces the resolved URL to the user, who can correct via direct GitHub URL if the canonical chain picked the wrong package.
- This is PR 6a of three split-out PRs from the original PR 6 plan. PRs 1–5 (#260–264) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)