### PR TITLE
refactor(skf-quick-skill): extract skf-render-quick-metadata.py + wire into step-04 §4 + result-envelope divergence note

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:cli": "node test/test-cli-integration.js",
     "test:install": "node test/test-installation-components.js",
     "test:knowledge": "node test/test-knowledge-base.js",
-    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py test/test-skf-merge-ccc-exclusions.py test/test-skf-resolve-package.py test/test-skf-extract-public-api.py -v",
+    "test:python": "uv run --with pytest --with pyyaml pytest test/test-compute-score-contract.py test/test-skf-preflight.py test/test-skf-skill-inventory.py test/test-skf-validate-output.py test/test-skf-validate-frontmatter.py test/test-skf-manifest-ops.py test/test-skf-rebuild-managed-sections.py test/test-skf-severity-classify.py test/test-skf-structural-diff.py test/test-skf-detect-tools.py test/test-skf-forge-tier-rw.py test/test-skf-emit-result-envelope.py test/test-skf-qmd-classify-collections.py test/test-skf-merge-ccc-exclusions.py test/test-skf-resolve-package.py test/test-skf-extract-public-api.py test/test-skf-render-quick-metadata.py -v",
     "test:schemas": "node test/test-agent-schema.js",
     "test:workflow": "node test/test-workflow-state.js",
     "validate:refs": "node tools/validate-file-refs.js --strict",

--- a/src/shared/references/output-contract-schema.md
+++ b/src/shared/references/output-contract-schema.md
@@ -33,3 +33,13 @@ Each run writes **two files** to `{output_dir}`:
 Write the per-run record first, then copy it to the `-latest.json` path. If the copy fails, the per-run record still exists — the run is not lost.
 
 **Consumers (forger, CI, chained workflows):** read from `{skill-name}-result-latest.json`. Do not enumerate timestamped files unless inspecting prior-run history.
+
+## Available Helpers
+
+There is no generic helper that writes the schema above; each skill assembles the JSON in its terminal step today. One specialised helper exists:
+
+- **`src/shared/scripts/skf-emit-result-envelope.py`** — `skf-setup`-specific. Writes a different envelope (`SKF_SETUP_RESULT_JSON: {…}`) following the JSON schema at `src/shared/scripts/schemas/skf-setup-result-envelope.v1.json`. Carries setup-specific fields (`tier`, `previous_tier`, `tools`, `ccc_index`, `tier_override_*`, `qmd_status`, etc.) that have no analogue in other workflows. **Do not reuse for non-skf-setup skills.**
+
+A generalised emitter (matching this document's schema) is a reasonable future helper when a second consumer materialises with the same shape. For now, skills that write this contract assemble the JSON in their terminal step — the work is small (5–8 fields) and skill-specific summary content benefits from being expressed inline alongside the rest of the step's logic.
+
+skf-quick-skill writes both the success-variant contract (`step-06-finalize.md` §3) and the error-variant contract on every HARD HALT (per `SKILL.md` § "Result Contract on HARD HALT") in this hand-assembled style.

--- a/src/shared/scripts/skf-render-quick-metadata.py
+++ b/src/shared/scripts/skf-render-quick-metadata.py
@@ -1,0 +1,192 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SKF Render Quick Metadata — render metadata.json per the canonical
+skill-template.md schema with quick-skill-specific population rules.
+
+Pure renderer — no I/O beyond stdin/stdout. Reads a JSON payload of
+extracted state on stdin and emits the corresponding metadata.json
+on stdout. Replaces the hand-assembly the LLM previously did in
+skf-quick-skill step-04 §4.
+
+Constants vs. input-derived split mirrors step-04's documentation:
+
+  Constants (always literal):
+    skill_type            "single"
+    spec_version          "1.3"
+    source_authority      "community"
+    confidence_tier       "Quick"
+    generated_by          "quick-skill"
+    confidence_distribution.t1, t2, t3                             0
+    tool_versions.ast_grep, tool_versions.qmd                      null
+    stats.exports_internal, stats.scripts_count, stats.assets_count 0
+    stats.public_api_coverage, stats.total_coverage                 1.0
+
+  Input-derived (from stdin payload):
+    name, version, description, language, source_repo,
+    source_root, source_commit, source_package,
+    exports[], dependencies[], compatibility,
+    provenance.language_hint, provenance.scope_hint,
+    tool_versions.skf
+
+  Computed:
+    generation_date                 ISO 8601 UTC ("YYYY-MM-DDTHH:MM:SSZ")
+    confidence_distribution.t1_low  count(exports)
+    stats.exports_documented / public_api / total  count(exports)
+
+Input JSON shape (stdin):
+
+  {
+    "name":           "foo",
+    "version":        "1.2.3",                      (default "1.0.0")
+    "description":    "...",                         (default "")
+    "language":       "python",
+    "source_repo":    "https://github.com/x/y",
+    "source_root":    "src/foo",                     (optional)
+    "source_commit":  "abc123",                      (optional)
+    "source_package": "foo",                         (optional)
+    "exports":        [{"name":"fn","type":"def"}]   or list of strings
+    "dependencies":   ["a", "b"],                    (default [])
+    "compatibility":  ">=3.10",                      (optional, default "")
+    "language_hint":  null,                          (echoed verbatim)
+    "scope_hint":     null,                          (echoed verbatim)
+    "skf_version":    "1.2.0"                        (default "unknown")
+  }
+
+CLI:
+
+  python3 skf-render-quick-metadata.py < input.json
+
+Exit codes:
+
+  0   success
+  1   payload-level error (missing required field)
+  2   stdin / argparse / JSON-decode error
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+
+
+REQUIRED_FIELDS = ("name", "language", "source_repo")
+
+
+def _normalize_exports(raw) -> list[str]:
+    """Accept either a list of strings or a list of {name, type, ...} dicts.
+    Returns a flat list of export names in declaration order, deduplicated.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        name: str | None = None
+        if isinstance(item, str):
+            name = item
+        elif isinstance(item, dict):
+            v = item.get("name")
+            if isinstance(v, str):
+                name = v
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def _iso_utc_now() -> str:
+    """Returns 'YYYY-MM-DDTHH:MM:SSZ' for the current UTC instant."""
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def render_metadata(payload: dict, *, now_fn=_iso_utc_now) -> dict:
+    """Render the metadata.json envelope. Pass `now_fn` to inject a
+    deterministic timestamp in tests.
+    """
+    missing = [f for f in REQUIRED_FIELDS if not payload.get(f)]
+    if missing:
+        return {"_error": f"missing required field(s): {', '.join(missing)}"}
+
+    exports = _normalize_exports(payload.get("exports"))
+    export_count = len(exports)
+
+    metadata = {
+        "name": payload["name"],
+        "version": payload.get("version") or "1.0.0",
+        "description": payload.get("description") or "",
+        "skill_type": "single",
+        "source_authority": "community",
+        "source_repo": payload["source_repo"],
+        "source_root": payload.get("source_root") or "",
+        "source_commit": payload.get("source_commit") or "",
+        "source_package": payload.get("source_package") or payload["name"],
+        "language": payload["language"],
+        "generated_by": "quick-skill",
+        "generation_date": now_fn(),
+        "confidence_tier": "Quick",
+        "spec_version": "1.3",
+        "exports": exports,
+        "confidence_distribution": {
+            "t1": 0,
+            "t1_low": export_count,
+            "t2": 0,
+            "t3": 0,
+        },
+        "tool_versions": {
+            "ast_grep": None,
+            "qmd": None,
+            "skf": payload.get("skf_version") or "unknown",
+        },
+        "stats": {
+            "exports_documented": export_count,
+            "exports_public_api": export_count,
+            "exports_internal": 0,
+            "exports_total": export_count,
+            "public_api_coverage": 1.0,
+            "total_coverage": 1.0,
+            "scripts_count": 0,
+            "assets_count": 0,
+        },
+        "dependencies": payload.get("dependencies") or [],
+        "compatibility": payload.get("compatibility") or "",
+        "provenance": {
+            "language_hint": payload.get("language_hint"),
+            "scope_hint": payload.get("scope_hint"),
+        },
+    }
+    return metadata
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render skf-quick-skill metadata.json from extracted state on stdin.",
+    )
+    parser.parse_args(argv)  # currently no flags; kept for forward compat
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        sys.stderr.write("error: no input on stdin (expected JSON payload)\n")
+        return 2
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"error: stdin JSON parse error: {e}\n")
+        return 2
+    if not isinstance(payload, dict):
+        sys.stderr.write("error: stdin payload must be a JSON object\n")
+        return 2
+
+    result = render_metadata(payload)
+    if "_error" in result:
+        sys.stderr.write(f"error: {result['_error']}\n")
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/skf-quick-skill/steps-c/step-04-compile.md
+++ b/src/skf-quick-skill/steps-c/step-04-compile.md
@@ -1,6 +1,9 @@
 ---
 nextStepFile: './step-05-write-and-validate.md'
 skillTemplateData: 'assets/skill-template.md'
+quickMetadataRendererProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-render-quick-metadata.py'
+  - '{project-root}/src/shared/scripts/skf-render-quick-metadata.py'
 ---
 
 # Step 4: Compile
@@ -84,30 +87,26 @@ Otherwise, create context-snippet.md in Vercel-aligned indexed format (~80-120 t
 
 ### 4. Generate Metadata JSON
 
-Generate metadata.json following the **canonical schema in `{skillTemplateData}` § "metadata.json Format"** (loaded in §1). Use the template's exact field set, ordering, and types — do not duplicate the schema here. Apply these quick-skill-specific population rules on top of the template:
+Run the shared renderer against the assembled state. The helper applies the constants, echoes input-derived fields, computes export counts and the ISO 8601 UTC timestamp, and emits the canonical envelope per `{skillTemplateData}` § "metadata.json Format".
 
-**Constants (always these literal values for Quick):**
+**Resolve `{quickMetadataRenderer}`** from `{quickMetadataRendererProbeOrder}`; first existing path wins. If no candidate exists, fall back to in-prompt rendering using the constants + input-derived rules previously documented in this section (the helper replaces but does not eliminate those rules — they live in the helper now).
 
-| Field                                                                       | Value                          |
-| --------------------------------------------------------------------------- | ------------------------------ |
-| `confidence_tier`                                                           | `"Quick"`                      |
-| `generated_by`                                                              | `"quick-skill"`                |
-| `source_authority`                                                          | `"community"`                  |
-| `tool_versions.ast_grep`, `tool_versions.qmd`                               | `null` (Quick is tier-unaware) |
-| `stats.exports_internal`, `stats.scripts_count`, `stats.assets_count`       | `0`                            |
-| `stats.public_api_coverage`, `stats.total_coverage`                         | `1.0`                          |
-| Other `confidence_distribution.*` buckets (besides `t1_low`)                | `0`                            |
+**Probe `tool_versions.skf` first** (the helper expects it as input — the filesystem walk stays here because the helper does no I/O):
 
-**Input-derived rules:**
+1. Read `{project-root}/_bmad/skf/package.json` → take `version`
+2. If absent, read `{project-root}/_bmad/skf/VERSION`
+3. If absent, set to `"unknown"`
 
-- `version`: `extraction_inventory.version` or `"1.0.0"`
-- `generation_date`: current ISO 8601 UTC datetime
-- `exports[]`: detected export names from `extraction_inventory.exports`
-- `confidence_distribution.t1_low` and `stats.exports_documented` / `exports_public_api` / `exports_total`: count of exports detected in step-03 (integers, not strings)
-- `provenance.language_hint` / `provenance.scope_hint`: echo the user-supplied hints from step-01 (or `null` when omitted)
-- `tool_versions.skf`: resolved from `{project-root}/_bmad/skf/package.json` → npm require → `{project-root}/_bmad/skf/VERSION` → `"unknown"` (first hit wins)
+Build the input payload from the extraction inventory + step-01 resolution + the probed `tool_versions.skf` and pipe it to the renderer:
 
-If a field is added to the template's metadata.json schema in the future, it lands here automatically — these rules describe **how Quick populates** the template, not what fields exist.
+```bash
+echo '{"name":"<name>","version":"<v>","description":"<desc>","language":"<lang>","source_repo":"<url>","source_root":"<path or empty>","source_commit":"<source_ref or empty>","source_package":"<package or name>","exports":[{"name":"...","type":"..."}],"dependencies":["..."],"compatibility":"<semver-range or empty>","language_hint":<hint or null>,"scope_hint":<hint or null>,"skf_version":"<probed>"}' \
+  | python3 {quickMetadataRenderer}
+```
+
+The renderer emits the rendered metadata.json on stdout. Capture the output as `metadata` for the §5 preview and step-05 §2's deliverable write.
+
+**Schema is canonical in the renderer.** When `{skillTemplateData}` adds a field, the renderer is updated to populate it (constants gain a row; input-derived fields gain a payload key). Do not hand-edit the rendered envelope here — the helper is the single source of truth for the population logic.
 
 ### 5. Present Compiled Output for Review
 

--- a/test/test-skf-render-quick-metadata.py
+++ b/test/test-skf-render-quick-metadata.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Tests for skf-render-quick-metadata.py.
+
+The renderer is pure (no I/O beyond stdin/stdout) so tests call
+render_metadata() directly and assert on the returned envelope.
+A frozen `now_fn` injects a deterministic timestamp.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "skf_render_quick_metadata",
+    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-render-quick-metadata.py",
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+FROZEN_TS = "2026-05-01T12:00:00Z"
+
+
+def _payload(**overrides) -> dict:
+    """Minimal valid payload; tests override one field at a time."""
+    base = {
+        "name": "foo",
+        "version": "1.2.3",
+        "description": "a python lib",
+        "language": "python",
+        "source_repo": "https://github.com/x/foo",
+        "exports": [{"name": "fn", "type": "def"}, {"name": "Cls", "type": "class"}],
+        "dependencies": ["requests"],
+        "language_hint": None,
+        "scope_hint": None,
+        "skf_version": "1.2.0",
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------
+# Constants — must always be literal regardless of input
+# --------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_top_level_constants(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["skill_type"] == "single"
+        assert m["spec_version"] == "1.3"
+        assert m["source_authority"] == "community"
+        assert m["confidence_tier"] == "Quick"
+        assert m["generated_by"] == "quick-skill"
+
+    def test_tool_versions_ast_grep_qmd_null(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["tool_versions"]["ast_grep"] is None
+        assert m["tool_versions"]["qmd"] is None
+
+    def test_zero_buckets_in_confidence_distribution(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        cd = m["confidence_distribution"]
+        assert cd["t1"] == 0
+        assert cd["t2"] == 0
+        assert cd["t3"] == 0
+
+    def test_zero_and_unit_stats(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        s = m["stats"]
+        assert s["exports_internal"] == 0
+        assert s["scripts_count"] == 0
+        assert s["assets_count"] == 0
+        assert s["public_api_coverage"] == 1.0
+        assert s["total_coverage"] == 1.0
+
+
+# --------------------------------------------------------------------------
+# Input-derived
+# --------------------------------------------------------------------------
+
+
+class TestInputDerived:
+    def test_echoes_basic_fields(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["name"] == "foo"
+        assert m["version"] == "1.2.3"
+        assert m["description"] == "a python lib"
+        assert m["language"] == "python"
+        assert m["source_repo"] == "https://github.com/x/foo"
+
+    def test_skf_version_passes_through(self):
+        m = mod.render_metadata(_payload(skf_version="2.0.0-rc.1"), now_fn=lambda: FROZEN_TS)
+        assert m["tool_versions"]["skf"] == "2.0.0-rc.1"
+
+    def test_source_package_defaults_to_name(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["source_package"] == "foo"
+
+    def test_source_package_explicit_wins(self):
+        m = mod.render_metadata(_payload(source_package="@scope/foo"), now_fn=lambda: FROZEN_TS)
+        assert m["source_package"] == "@scope/foo"
+
+    def test_optional_strings_default_to_empty(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["source_root"] == ""
+        assert m["source_commit"] == ""
+        assert m["compatibility"] == ""
+
+    def test_provenance_hints_echoed_when_provided(self):
+        m = mod.render_metadata(
+            _payload(language_hint="python", scope_hint="src/foo"),
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert m["provenance"]["language_hint"] == "python"
+        assert m["provenance"]["scope_hint"] == "src/foo"
+
+    def test_dependencies_echoed_as_list(self):
+        m = mod.render_metadata(_payload(dependencies=["a", "b", "c"]), now_fn=lambda: FROZEN_TS)
+        assert m["dependencies"] == ["a", "b", "c"]
+
+
+# --------------------------------------------------------------------------
+# Computed (export-count-driven, timestamp)
+# --------------------------------------------------------------------------
+
+
+class TestComputed:
+    def test_timestamp_uses_injected_now(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["generation_date"] == FROZEN_TS
+
+    def test_default_timestamp_format(self):
+        # Without an injected now_fn, the real one runs — assert it matches the
+        # documented "YYYY-MM-DDTHH:MM:SSZ" shape (don't pin the exact value).
+        m = mod.render_metadata(_payload())
+        ts = m["generation_date"]
+        assert len(ts) == 20
+        assert ts.endswith("Z")
+        assert ts[4] == "-" and ts[7] == "-" and ts[10] == "T" and ts[13] == ":" and ts[16] == ":"
+
+    def test_t1_low_equals_export_count(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        assert m["confidence_distribution"]["t1_low"] == 2
+
+    def test_stats_count_fields_equal_export_count(self):
+        m = mod.render_metadata(_payload(), now_fn=lambda: FROZEN_TS)
+        s = m["stats"]
+        assert s["exports_documented"] == 2
+        assert s["exports_public_api"] == 2
+        assert s["exports_total"] == 2
+
+    def test_zero_exports_envelope(self):
+        m = mod.render_metadata(_payload(exports=[]), now_fn=lambda: FROZEN_TS)
+        assert m["exports"] == []
+        assert m["confidence_distribution"]["t1_low"] == 0
+        s = m["stats"]
+        assert s["exports_documented"] == 0
+        assert s["exports_public_api"] == 0
+        assert s["exports_total"] == 0
+
+
+# --------------------------------------------------------------------------
+# Export normalisation
+# --------------------------------------------------------------------------
+
+
+class TestExportNormalisation:
+    def test_accepts_list_of_strings(self):
+        m = mod.render_metadata(_payload(exports=["a", "b", "c"]), now_fn=lambda: FROZEN_TS)
+        assert m["exports"] == ["a", "b", "c"]
+
+    def test_accepts_list_of_dicts(self):
+        m = mod.render_metadata(
+            _payload(exports=[{"name": "fn", "type": "def"}, {"name": "Cls", "type": "class"}]),
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert m["exports"] == ["fn", "Cls"]
+
+    def test_dedupes_repeated_names(self):
+        m = mod.render_metadata(
+            _payload(exports=[{"name": "fn"}, "fn", {"name": "Cls"}]),
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert m["exports"] == ["fn", "Cls"]
+        assert m["confidence_distribution"]["t1_low"] == 2
+
+    def test_skips_invalid_items(self):
+        m = mod.render_metadata(
+            _payload(exports=[None, 42, {"type": "def"}, {"name": "ok"}, ""]),
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert m["exports"] == ["ok"]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+class TestRequiredFields:
+    def test_missing_name_returns_error(self):
+        result = mod.render_metadata(
+            {"language": "python", "source_repo": "https://github.com/x/y"},
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert "_error" in result
+        assert "name" in result["_error"]
+
+    def test_missing_language_returns_error(self):
+        result = mod.render_metadata(
+            {"name": "foo", "source_repo": "https://github.com/x/y"},
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert "_error" in result
+        assert "language" in result["_error"]
+
+    def test_missing_source_repo_returns_error(self):
+        result = mod.render_metadata(
+            {"name": "foo", "language": "python"}, now_fn=lambda: FROZEN_TS
+        )
+        assert "_error" in result
+        assert "source_repo" in result["_error"]
+
+    def test_empty_string_treated_as_missing(self):
+        result = mod.render_metadata(
+            {"name": "", "language": "python", "source_repo": "https://github.com/x/y"},
+            now_fn=lambda: FROZEN_TS,
+        )
+        assert "_error" in result
+
+
+# --------------------------------------------------------------------------
+# Defaults
+# --------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_version_defaults_to_1_0_0(self):
+        p = _payload()
+        del p["version"]
+        m = mod.render_metadata(p, now_fn=lambda: FROZEN_TS)
+        assert m["version"] == "1.0.0"
+
+    def test_skf_version_defaults_to_unknown(self):
+        p = _payload()
+        del p["skf_version"]
+        m = mod.render_metadata(p, now_fn=lambda: FROZEN_TS)
+        assert m["tool_versions"]["skf"] == "unknown"
+
+    def test_dependencies_default_to_empty_list(self):
+        p = _payload()
+        del p["dependencies"]
+        m = mod.render_metadata(p, now_fn=lambda: FROZEN_TS)
+        assert m["dependencies"] == []
+
+    def test_provenance_hints_default_to_null(self):
+        p = _payload()
+        del p["language_hint"]
+        del p["scope_hint"]
+        m = mod.render_metadata(p, now_fn=lambda: FROZEN_TS)
+        assert m["provenance"]["language_hint"] is None
+        assert m["provenance"]["scope_hint"] is None
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_stdin_round_trip(self, monkeypatch, capsys):
+        payload = _payload()
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        rc = mod.main([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        envelope = json.loads(out)
+        assert envelope["name"] == "foo"
+        assert envelope["confidence_tier"] == "Quick"
+
+    def test_empty_stdin_returns_2(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        rc = mod.main([])
+        assert rc == 2
+
+    def test_invalid_json_returns_2(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("{not json"))
+        rc = mod.main([])
+        assert rc == 2
+
+    def test_array_root_returns_2(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("[1,2,3]"))
+        rc = mod.main([])
+        assert rc == 2
+
+    def test_missing_required_field_returns_1(self, monkeypatch):
+        # Missing source_repo
+        payload = {"name": "foo", "language": "python"}
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        rc = mod.main([])
+        assert rc == 1


### PR DESCRIPTION
## Summary

Final theme-1 PR from the original PR 6 plan (2026-05-01 quality analysis). Closes the metadata-hand-assembly finding and dispositions the `skf-emit-result-envelope.py` divergence note.

PR-by-PR plan (theme 1):
- **6a (#265, merged)** — `skf-resolve-package.py` + step-01 §3 wiring
- **6b (#266, merged)** — `skf-extract-public-api.py --mode quick` + step-03 §2/§3 wiring
- **6c (this PR)** — `skf-render-quick-metadata.py` + step-04 §4 wiring + envelope divergence note

## Commits

- **`feat(shared)`** — add `src/shared/scripts/skf-render-quick-metadata.py`. Pure renderer (PEP 723 `dependencies = []`, `requires-python >= 3.10`). Reads JSON payload of extracted state on stdin, emits the canonical metadata.json per `skill-template.md` § "metadata.json Format". Constants/input-derived/computed split mirrors step-04 documentation. Accepts exports as either a list of strings or a list of `{name, type, ...}` dicts (the shape `skf-extract-public-api.py` emits) and deduplicates.
- **`test(shared)`** — 33 offline test cases covering constants, input-derived field echo, computed fields (timestamp + export-count-driven), export normalisation, required-field validation, default values, and CLI round trip. Frozen `now_fn` injects deterministic timestamps in tests.
- **`chore`** — wire into `npm run test:python`. Local run: 505 passed across the full Python suite.
- **`refactor(skf-quick-skill)`** — invoke from step-04 §4 via `quickMetadataRendererProbeOrder`. The `tool_versions.skf` filesystem probe stays in the LLM step (the helper is pure I/O-free) and lands in the helper input as `skf_version`. When the helper is absent, §4 falls back to in-prompt rendering.
- **`docs(shared)`** — document the `skf-emit-result-envelope.py` divergence in `src/shared/references/output-contract-schema.md`. The 2026-05-01 analysis flagged that helper as a candidate for skf-quick-skill to reuse; that recommendation is wrong as stated — the v1 schema is skf-setup-specific (carries `tier`, `previous_tier`, `tools`, `ccc_index`, etc.). A generalised emitter is reasonable future work; for now skills assemble the contract inline. Closes the disposition.

## Why

step-04 §4's hand-assembly was the last "deterministic work in a prompt" finding from the analysis (~500 tokens per invocation). Moving the constants table + input-derived rules + ISO timestamp to a unit-tested helper:
- Saves ~500 tokens per invocation
- Centralises schema authority — when `skill-template.md` adds a field, the helper is updated, the prompt does not need to change
- Sets up skf-create-skill (and any future SKF compiler) to share the renderer

## Test plan

- [x] `uv run pytest test/test-skf-render-quick-metadata.py` — 33/33 pass offline
- [x] `npm run quality` — runs as the husky pre-commit hook on every commit; all five commits passed locally (505 tests across the full Python suite)
- [x] Live verification: `python3 src/shared/scripts/skf-render-quick-metadata.py < payload.json` — emits the exact canonical envelope shape, all constants in place, export count drives `t1_low` and `stats.exports_*`, ISO 8601 UTC timestamp
- [x] CI green on `ubuntu-latest` + `windows-latest`
- [x] Manual: `/skf-quick-skill lodash --headless` — confirm step-04 §4 shells out to the renderer and the rendered metadata.json matches the canonical schema; step-05 §5 validation passes against the rendered envelope

## Notes for reviewers

- `tool_versions.skf` probe stays in the LLM step on purpose. The helper is pure (no filesystem I/O) so the probe (`{project-root}/_bmad/skf/package.json` → `_bmad/skf/VERSION` → `"unknown"`) lives where the I/O lives — in the prompt. This matches the same separation that PR 6b (`skf-extract-public-api.py`) uses for source-file fetches.
- The divergence note in `output-contract-schema.md` resists premature abstraction — the report's "just call skf-emit-result-envelope.py" suggestion would require either renaming + generalising the helper (breaking skf-setup) or building a thin wrapper around `json.dumps`. Neither is worth the complexity until a second consumer surfaces with the same shape.
- This is the final theme-1 PR. Theme-1 net-net: `skf-resolve-package.py` (~1500 tokens/run), `skf-extract-public-api.py` (~1500 tokens/run), `skf-render-quick-metadata.py` (~500 tokens/run) ≈ ~3500 tokens saved per skf-quick-skill invocation, plus a unit-testable parsing+rendering core that future SKF compilers can share.
- This is PR 6c of three split-out PRs from the original PR 6 plan. PRs 1–5 (#260–264) and 6a/6b (#265, #266) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)