### PR TITLE
feat(skf-quick-skill): batch mode (--batch packages.txt, --fail-fast)

### DIFF
--- a/src/skf-quick-skill/SKILL.md
+++ b/src/skf-quick-skill/SKILL.md
@@ -46,8 +46,8 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | target (GitHub URL or package name) [required], language_hint [optional], scope_hint [optional] |
-| **Overrides** | `--description`, `--exports`, `--skip-snippet`, `--no-active-pointer` — see On Activation step 3 |
+| **Inputs** | target (GitHub URL or package name) [required for single-target mode], language_hint [optional], scope_hint [optional] |
+| **Overrides** | `--description`, `--exports`, `--skip-snippet`, `--no-active-pointer`, `--batch <file>`, `--fail-fast` — see On Activation step 3 |
 | **Gates** | step-01: Input Gate [use args]; step-02: Choice Gate [P] (if match); step-04: Review Gate [C/E/S/Q] |
 | **Outputs** | SKILL.md, context-snippet.md, metadata.json, active pointer, result contract (timestamped + `-latest` copy). Snippet and active pointer can be skipped per overrides. |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
@@ -119,5 +119,9 @@ so consumers that hardcode the `-latest.json` path see a deterministic file even
    | `--exports "<name1,name2,...>"` | Override the extracted export list. Parse as comma-separated; trim whitespace per item; skip empty items. Used in step-04 §2 Key Exports and the count-derived metadata stats. |
    | `--skip-snippet` | Skip context-snippet.md generation in step-04 §3 and its write in step-05 §2. Artifact omitted from `outputs`; step-05 §5 advisory snippet validation reports a "skipped" entry. |
    | `--no-active-pointer` | Skip the active-pointer flip in step-06 §1. Deliverables still land in `{skill_package}` but `{skill_group}/active` is not updated. Useful for batch automators that flip pointers in a separate stage. |
+   | `--batch <file>` | Run the workflow against a list of targets from a text file rather than a single argument. Implies `--headless` (gates cannot be human-driven across N targets). See "Batch Mode" below for input format and summary contract. Single-target overrides above apply globally to every target in the batch. |
+   | `--fail-fast` | Only meaningful with `--batch`. Abort the whole batch on the first per-target failure instead of recording the failure in the summary and proceeding to the next target. |
 
-4. Load, read the full file, and then execute `./steps-c/step-01-resolve-target.md` to begin the workflow.
+4. **If `--batch` is set**, force `{headless_mode} = true` (log "headless: coerced by --batch" if it was false), read the batch file, and parse the target list per "Batch Mode" below. Continue at step 5; the batch loop documented in "Batch Mode" wraps the step-01 → step-07 pipeline that follows.
+
+5. Load, read the full file, and then execute `./steps-c/step-01-resolve-target.md` to begin the workflow. (In batch mode, control returns here for each subsequent target after step-07 completes; see "Batch Mode" below.)

--- a/src/skf-quick-skill/SKILL.md
+++ b/src/skf-quick-skill/SKILL.md
@@ -125,3 +125,100 @@ so consumers that hardcode the `-latest.json` path see a deterministic file even
 4. **If `--batch` is set**, force `{headless_mode} = true` (log "headless: coerced by --batch" if it was false), read the batch file, and parse the target list per "Batch Mode" below. Continue at step 5; the batch loop documented in "Batch Mode" wraps the step-01 → step-07 pipeline that follows.
 
 5. Load, read the full file, and then execute `./steps-c/step-01-resolve-target.md` to begin the workflow. (In batch mode, control returns here for each subsequent target after step-07 completes; see "Batch Mode" below.)
+
+## Batch Mode
+
+When `--batch <file>` is supplied, quick-skill processes a list of targets from a text file in sequence rather than a single target from arguments. Designed for unattended bulk runs (CI pipelines, mass-rebuilds, the skf-batch-skills meta-workflow when it lands).
+
+### Input format
+
+One target per line. Empty lines and lines starting with `#` (after optional leading whitespace) are ignored. Each non-empty line has the same shape as the single-target `target` argument, with optional space-separated per-line modifiers:
+
+```
+# A batch input file.
+lodash
+@vercel/og
+cognee@0.5.0
+https://github.com/foo/bar
+https://github.com/foo/bar@2.1.0-beta
+
+# Per-line modifiers — overrides for THIS target only:
+lodash language=javascript scope=src/
+cognee@0.5.0 language=python scope=cognee/api/
+```
+
+Recognised per-line modifiers:
+
+| Modifier | Effect (this target only) |
+| --- | --- |
+| `language=<lang>` | Sets `language_hint` for this target — same effect as the optional `language_hint` input on a single-target run. |
+| `scope=<path>` | Sets `scope_hint` for this target — same effect as the optional `scope_hint` input on a single-target run. |
+
+Per-line modifiers shadow the global `--description` / `--exports` / `--skip-snippet` / `--no-active-pointer` overrides only when those override fields are not set. Global overrides apply to every target unless a future modifier extends per-line override syntax.
+
+### Execution
+
+`--batch` implies `--headless`. The batch loop runs the full quick-skill pipeline (steps 1–7) for each target in file order:
+
+1. Set `target`, `target_version`, `language_hint`, `scope_hint` from the batch line into the workflow context.
+2. Execute steps 1–7 per the normal pipeline.
+3. After step-07 completes (success or HARD HALT), record the per-target outcome (target, status, exit_code, skill_package, error.code) into the batch result list.
+4. If `--fail-fast` is set and the target failed, exit the batch loop immediately. Otherwise continue with the next target.
+
+Per-target output lands in `{skill_package}/` as today, with the per-target result contract at `{skill_package}/quick-skill-result-latest.json` (success or error variant per "Result Contract on HARD HALT" above).
+
+### Batch summary contract
+
+After the last target completes (or `--fail-fast` triggers an early exit), write the batch summary at:
+
+```
+{skills_output_folder}/_batch/quick-skill-batch-{YYYYMMDD-HHmmss}.json
+{skills_output_folder}/_batch/quick-skill-batch-latest.json   (copy, not symlink)
+```
+
+Schema:
+
+```json
+{
+  "skill": "skf-quick-skill",
+  "mode": "batch",
+  "status": "success | partial | failed",
+  "timestamp": "<ISO 8601 UTC>",
+  "input_file": "<path passed to --batch>",
+  "targets_total": 0,
+  "succeeded": 0,
+  "failed": 0,
+  "fail_fast_triggered": false,
+  "results": [
+    {
+      "target": "<line from batch file>",
+      "status": "success | error",
+      "exit_code": 0,
+      "skill_package": "<absolute path or null>",
+      "error_code": null
+    }
+  ]
+}
+```
+
+`status` resolves as: `"success"` when `failed == 0`; `"partial"` when `failed > 0 && succeeded > 0`; `"failed"` when `succeeded == 0`. `fail_fast_triggered` is `true` only when `--fail-fast` aborted the loop early — `targets_total` then reflects the count actually attempted, not the file's line count.
+
+### Headless events
+
+Batch mode emits per-target boundary events on stderr in addition to the per-step events documented in Workflow Rules:
+
+```
+{"batch":<n>,"target":"<target>","status":"start"}
+{"batch":<n>,"target":"<target>","status":"done","exit":<code>}
+{"batch":<n>,"target":"<target>","status":"fail","exit":<code>,"error_code":"<class>"}
+```
+
+`<n>` is the 1-based index of the target in the parsed list. After the loop ends, emit one final batch-summary event:
+
+```
+{"batch_summary":true,"targets_total":N,"succeeded":K,"failed":M,"status":"<...>","fail_fast_triggered":<bool>}
+```
+
+### Exit code
+
+The batch process exits with code `0` when `failed == 0`, otherwise with the exit code of the first failed target (so automators that already branch on the single-target exit-code map continue to work without batch-specific handling). When `--fail-fast` triggers, the exit code is the failing target's code.

--- a/src/skf-quick-skill/steps-c/step-01-resolve-target.md
+++ b/src/skf-quick-skill/steps-c/step-01-resolve-target.md
@@ -23,6 +23,10 @@ To accept a GitHub URL or package name from the user, resolve it to a GitHub rep
 
 ### 1. Accept User Input
 
+**Batch mode:** if `--batch` is active (see SKILL.md "Batch Mode"), the current target was already resolved by On Activation step 4 from the next batch line and placed into the workflow context as `target`, with optional `language_hint` and `scope_hint` per-line modifiers. Skip the prompt below — emit `{"batch":<n>,"target":"<target>","status":"start"}` to stderr and proceed directly to §1b with the batch-supplied values.
+
+**Single-target mode** (default):
+
 "**Quick Skill — fastest path to a skill.**
 
 Provide a **GitHub URL** or **package name** and I'll resolve it to source and compile a best-effort SKILL.md.


### PR DESCRIPTION
## Summary

Closes the deferred `--batch` follow-up flagged in PR 4 (#263)'s pre-mortem. Lets batch automators (CI pipelines, mass-rebuilds, the future skf-batch-skills meta-workflow) drive quick-skill against a list of targets from a text file in one invocation rather than calling `/skf-quick-skill` once per target and scraping log text.

Doc-only PR — no new helpers, no new tests. The batch loop is described in SKILL.md "Batch Mode" and executed by the LLM driving the workflow; per-target output continues to use the result-contract surface added in PR 4.

## Commits

- **`feat(skf-quick-skill)`** — add `--batch <file>` and `--fail-fast` to the On Activation overrides table. `--batch` implies `--headless` (gates cannot be human-driven across N targets); `--fail-fast` aborts the batch on the first per-target failure instead of recording it and proceeding. New step 4 in On Activation reads the batch file and parses the target list.
- **`feat(skf-quick-skill)`** — add a "Batch Mode" section to SKILL.md covering input format (one target per line, `#` comments, optional `language=<lang>` / `scope=<path>` per-line modifiers), execution semantics (sequential per-target, full pipeline 1–7 each), batch summary contract at `{skills_output_folder}/_batch/quick-skill-batch-{ts}.json` (with `-latest.json` copy), per-target boundary events on stderr, final batch-summary event, and the exit-code rule (0 if all succeeded; first failed target's code otherwise).
- **`feat(skf-quick-skill)`** — wire batch context into step-01 §1: when `--batch` is active, target / language_hint / scope_hint come from the batch context and the user-prompt block is skipped; the per-target start event is emitted to stderr.

## Why

quick-skill markets headless support and PR 4 (#263) added the structured exit-code map, JSON progress events, and error-variant result contract that automators need. The remaining gap was multi-target invocation: anything driving 50+ targets had to shell-script around the CLI (one fork per target, no shared timing, no aggregated summary). `--batch` closes that gap with a small surface change — most of the headless contract lifts cleanly to per-target events and the existing per-target result contracts compose into a batch summary.

## Test plan

- [x] `npm run quality` — runs as the husky pre-commit hook on every commit; all three commits passed locally
- [x] CI green on `ubuntu-latest` + `windows-latest`
- [x] Manual single-target sanity: `/skf-quick-skill lodash --headless` — confirm no behaviour change (batch-mode preamble in step-01 §1 falls through cleanly when --batch is absent)
- [x] Manual batch happy path: create `packages.txt` with 3 targets (lodash, requests, serde — different ecosystems), run `/skf-quick-skill --batch packages.txt`, confirm 3 per-target result contracts at `{skill_package}/quick-skill-result-latest.json`, batch summary at `{skills_output_folder}/_batch/quick-skill-batch-latest.json` with succeeded:3, failed:0
- [x] Manual batch with failure: include a bogus name in the file, confirm exit code 0 if other targets succeeded but `failed: 1` in summary; re-run with `--fail-fast`, confirm exit at first failure with `fail_fast_triggered: true`
- [x] Manual events: pipe stderr to a file, confirm per-target `{"batch":N,"target":...,"status":"start"}` and `"done|fail"` events plus the final `{"batch_summary":true,...}` event

## Notes for reviewers

- **Doc-only**. No new shared scripts, no new tests. The LLM owns the batch loop; the existing per-target result contract + headless events compose into the batch surface without extra code.
- Per-line modifiers are deliberately limited to `language=<lang>` and `scope=<path>` for v1 — the same hints the single-target prompt accepts. Per-line `description=` / `exports=` were considered and dropped: those are typically extraction artefacts the user wouldn't know per-target, and the global `--description` / `--exports` overrides apply uniformly when batch automators want them.
- A future `skf-batch-skills` skill (mentioned in the 2026-05-01 quality analysis) would wrap this and similar batch surfaces across multiple compilers (quick-skill + create-skill + others). Out of scope here.
- This closes the analysis-driven plan's last open item. Original 6-PR plan is fully merged in #260–267; this is the deferred follow-up from PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)