### PR TITLE
feat(skf-brief-skill): close out quality-analysis findings (broken + 5 themes + R7)

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -32,7 +32,7 @@ These rules apply to every step in this workflow:
 | 3 | Scope Definition | steps-c/step-03-scope-definition.md | No (interactive) |
 | 4 | Confirm Brief | steps-c/step-04-confirm-brief.md | No (confirm) |
 | 5 | Write Brief | steps-c/step-05-write-brief.md | Yes |
-| 6 | Workflow Health Check | steps-c/step-06-health-check.md | Yes |
+| 6 | Workflow Health Check (terminal — chains to `shared/health-check.md`) | steps-c/step-06-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -7,7 +7,11 @@ description: Design a skill scope through guided discovery. Use when the user re
 
 ## Overview
 
-Helps the user define what to skill — target repo, scope, language, inclusion/exclusion patterns — and produces a skill-brief.yaml that drives create-skill. This is the first step in the skill creation pipeline. The brief becomes the input contract for create-skill, which performs the actual compilation.
+Helps the user define what to skill — target repo, scope, language, inclusion/exclusion patterns — and produces a `skill-brief.yaml` that drives create-skill. This is the first step in the skill creation pipeline; the brief is the input contract for create-skill, which performs the actual compilation.
+
+A good skill brief sets a tight, cohesive boundary: one capability with 3-8 primary functions, an unambiguous public API surface, and a description short enough to fit in a registry row. Briefs that try to cover several unrelated concerns (e.g. authentication *and* data visualization) compile into skills that no agent can route to confidently — a brief covering too much is a worse failure mode than a brief covering too little, and this workflow steers toward the smaller, sharper version when scope is unclear.
+
+Brief-skill is split from create-skill so the scoping conversation runs *once*, on cheap signals (manifests, top-level exports, intent), without paying for AST extraction. Compilation is expensive; scoping decisions are cheap to revise. Keeping them in separate workflows lets a user iterate on the brief, share it for review, and re-run create-skill against the same brief whenever the upstream version moves.
 
 ## Role
 

--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -38,10 +38,33 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | target_repo [required], skill_name [required], scope_hint [optional], language_hint [optional] |
+| **Inputs** | `target_repo` [required], `skill_name` [required], `scope_hint` [optional], `language_hint` [optional], `target_version` [optional], `source_authority` [optional: official/community/internal, default community], `source_type` [optional: source/docs-only, default source], `doc_urls` [optional: list of `url[,label]` for source_type=docs-only or supplemental], `scope_type` [optional: full-library/specific-modules/public-api/component-library/reference-app/docs-only], `include` [optional: comma-separated globs], `exclude` [optional: comma-separated globs], `scripts_intent` [optional: detect/none/free-text, default detect], `assets_intent` [optional: detect/none/free-text, default detect], `intent` [optional: free-text used to derive description], `force` [optional: overwrite existing brief without prompting] |
 | **Gates** | step-01: Input Gate [use args] | step-03: Confirm Gate [C] | step-04: Confirm Gate [C] |
-| **Outputs** | skill-brief.yaml |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Outputs** | `skill-brief.yaml` at `{forge_data_folder}/{skill-name}/skill-brief.yaml`; final `SKF_BRIEF_RESULT_JSON` line on stdout when `{headless_mode}` is true |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true; pre-supplied inputs consumed at the gates that would otherwise prompt; existing briefs are preserved unless `--force` was supplied (HALT with `overwrite-cancelled` otherwise) |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                  |
+| ---- | -------------------- | ------------------------------------------------------------------------------------------ |
+| 0    | success              | step-06 (terminal)                                                                         |
+| 2    | input-missing        | step-01 GATE — required headless arg absent (`target_repo`, `skill_name`)                  |
+| 3    | resolution-failure   | step-01 §1 (`forge-tier.yaml` missing); step-02 §1 (target inaccessible / `gh auth` fails) |
+| 4    | write-failure        | step-05 §4 (write to `{forge_data_folder}/{skill-name}/skill-brief.yaml` failed)           |
+| 5    | overwrite-cancelled  | step-05 §2 (existing brief, `force` not supplied)                                          |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step-05 emits a single-line JSON envelope on **stdout** before chaining to step-06, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_BRIEF_RESULT_JSON: {"status":"success|error","brief_path":"…|null","skill_name":"…","version":"…|null","language":"…|null","scope_type":"…|null","exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 

--- a/src/skf-brief-skill/references/version-resolution.md
+++ b/src/skf-brief-skill/references/version-resolution.md
@@ -1,0 +1,46 @@
+# Version Resolution
+
+Single source of truth for how brief-skill resolves the `version` field of `skill-brief.yaml`. Loaded by steps 01 (gather), 02 (auto-detect), and 05 (resolve & write) so that all three operate on the same precedence rules and invariant.
+
+**Aligned with** `assets/skill-brief-schema.md` "Version Detection" section. If you change one, change the other.
+
+## Detection Algorithm
+
+For the detected source language, attempt the lookups in order. Stop at the first match.
+
+- **Python:** `pyproject.toml` `[project] version` (static) → if `dynamic = ["version"]`, check `__init__.py` for `__version__` → `_version.py` if exists → `setup.py` `version=` → `git describe --tags --abbrev=0`
+- **JavaScript / TypeScript:** root `package.json` (`"version"`). If the root has `"private": true` with a `"workspaces"` array or lacks a `"version"` field, fall back to a primary workspace package's `package.json` (e.g. `code/core/package.json`, or the first matching `packages/*/package.json`). For GitHub sources, prefer `gh api repos/{owner}/{repo}/releases/latest` → `tag_name` when a non-pre-release tag exists, over a default-branch pre-release. Treat a version containing `-alpha`, `-beta`, `-rc`, `-next`, or `-canary` as a pre-release.
+- **Rust:** `Cargo.toml` `[package] version` (static). If `version = { workspace = true }`, resolve from workspace root `Cargo.toml` → `git describe --tags --abbrev=0`.
+- **Go:** version tag from `go.mod`, or `git describe --tags --abbrev=0`.
+
+For remote GitHub sources, fetch version-bearing files via `gh api repos/{owner}/{repo}/contents/{file}` (decode base64). For local sources, read the file directly.
+
+If every step fails or returns a non-semver value, the detected version is `null` — the resolver below falls back to `"1.0.0"`.
+
+**Pre-release handling:** preserve detected pre-release tags (`1.0.0-beta.0`, `2.0.0-rc.1`) verbatim. Do not strip them.
+
+## Precedence — Resolving the `version` Field
+
+The brief's `version` field is resolved from three candidate sources, in priority order:
+
+1. **`target_version`** — collected interactively in step-01 §3b or supplied as a headless argument. When present, this value wins outright. The auto-detection above still runs for informational purposes (the user sees both "Target version" and "Detected version" side-by-side at the analysis summary), but the brief's `version` field is set from `target_version`.
+2. **Auto-detected version** — from §"Detection Algorithm" above. Used when `target_version` is absent.
+3. **Default** — `"1.0.0"` when both of the above fail or yield a non-semver value.
+
+## Invariant
+
+When `target_version` is set, the written brief MUST satisfy:
+
+```
+brief.target_version == brief.version
+```
+
+Step-05 §3 enforces this by setting both fields to the same string when `target_version` is present. Downstream tooling (e.g. `skf-create-skill`) can distinguish "user-requested" from "auto-detected" by the presence of `target_version` without re-deriving provenance — but the values themselves are identical. Different values are a contract violation and a bug.
+
+## Step-Level Responsibilities
+
+| Step | Responsibility |
+|------|----------------|
+| 01 §3b | Collect `target_version` (interactive prompt, or headless arg). Do not auto-detect — that is step 02's job. |
+| 02 §4b | Run the detection algorithm regardless of whether `target_version` is set. If `target_version` is set and the detected version differs, surface the disagreement to the user — but the precedence above is unchanged: `target_version` wins. |
+| 05 §3 | Apply the precedence rules and write `version`. If `target_version` is set, also write the `target_version` field with the identical value. Enforce the invariant. |

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -30,9 +30,13 @@ Attempt to load `{forgeTierFile}`:
 
 **Apply tier override:** Read `{sidecar_path}/preferences.yaml`. If `tier_override` is set and is a valid tier value (Quick, Forge, Forge+, or Deep), use it instead of the detected tier.
 
+**If found but the YAML cannot be parsed (corrupted or truncated):**
+- Display: "**Cannot read forge-tier.yaml** at `{forgeTierFile}` — the file exists but failed to parse: `{parser error message}`. The setup workflow can rewrite it cleanly. Until then, the brief workflow falls back to **Quick** tier (no extra tools assumed)."
+- Continue with `tier = "Quick"` and `tools = {}` — do not HALT. Record `tier_source: "fallback-corrupted-config"` for later diagnostics.
+
 **If not found:**
 - "**Cannot proceed.** forge-tier.yaml not found at `{forgeTierFile}`. Please run the **setup** workflow first to configure your forge tier (Quick/Forge/Forge+/Deep)."
-- HALT — do not proceed.
+- HALT (exit code 3, `halt_reason: "forge-tier-missing"`) — do not proceed.
 
 ### 2. Welcome and Explain
 
@@ -69,6 +73,9 @@ Wait for user response.
 **If user provides documentation URLs (not a repo):**
 - Set `source_type: "docs-only"` in the brief data
 - Collect one or more doc URLs with optional labels
+- For each collected URL, perform a `HEAD` request (or `curl -sI`) to verify the URL resolves with a 2xx/3xx status:
+  - On 2xx/3xx: silently accept.
+  - On 4xx/5xx, DNS failure, or timeout: warn `"Could not reach {url} — {status or error}. Confirm the URL is correct, or proceed anyway."` Interactive: re-prompt for a corrected URL or `[K] Keep anyway`. Headless: keep the URL and log the warning — the brief still records it but the failure is now visible at brief-creation time instead of materializing hours later in skf-create-skill.
 - Note: `source_authority` will be forced to `community` (T3 external documentation)
 - Note: `source_repo` becomes optional (can be set to the main doc site URL for reference)
 
@@ -142,6 +149,11 @@ Based on the target repo and intent, propose a skill name:
 This will be used for the output directory and file naming. Want to use this name or suggest something different?"
 
 Wait for confirmation or alternative.
+
+**Collision check (interactive and headless):** before locking the name, check whether `{forge_data_folder}/{name}/skill-brief.yaml` or `~/.claude/skills/{name}/SKILL.md` already exists. If either does:
+
+- Interactive: "**Heads up — a skill named `{name}` already exists at `{path(s)}`.** Pick a different name to keep the new brief separate, or confirm to continue (the existing brief's overwrite prompt fires in step 05)."
+- Headless: log `"warn: skill name '{name}' collides with existing artifact at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
 
 ### 7. Summarize Gathered Intent
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -1,6 +1,7 @@
 ---
 nextStepFile: './step-02-analyze-target.md'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
+versionResolutionFile: '../references/version-resolution.md'
 ---
 
 # Step 1: Gather Intent
@@ -95,6 +96,8 @@ Default to `"community"` if user does not specify or skips. For `docs-only` skil
 Confirm the target.
 
 ### 3b. Gather Target Version
+
+Load `{versionResolutionFile}` for the canonical precedence and invariant rules — this step only collects `target_version`; auto-detection runs in step 02 and resolution lands in step 05.
 
 **Headless:** if `target_version` was supplied as an argument, store it and skip the interactive prompt below. If `doc_urls` were also supplied, treat the version-vs-doc-URL confirmation prompt as auto-confirmed (Y).
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -89,6 +89,8 @@ Confirm the target.
 
 ### 3b. Gather Target Version
 
+**Headless:** if `target_version` was supplied as an argument, store it and skip the interactive prompt below. If `doc_urls` were also supplied, treat the version-vs-doc-URL confirmation prompt as auto-confirmed (Y).
+
 "**Are you targeting a specific version of this library?**
 (Leave blank to auto-detect from source)"
 
@@ -171,7 +173,7 @@ Display: "**Select:** [C] Continue to Target Analysis"
 #### EXECUTION RULES:
 
 - ALWAYS halt and wait for user input after presenting menu
-- **GATE [default: use args]** — If `{headless_mode}`: consume pre-supplied arguments (target_repo, skill_name, scope_hint, language_hint) and auto-proceed. If required args missing, HALT: "headless mode requires target_repo and skill_name arguments."
+- **GATE [default: use args]** — If `{headless_mode}`: consume pre-supplied arguments and auto-proceed. Required: `target_repo`, `skill_name`. Optional, applied to the matching brief field when present: `scope_hint`, `language_hint`, `target_version`, `source_authority` (default `community`), `source_type` (default `source`; if `docs-only`, `doc_urls` becomes required), `doc_urls` (list of `url` or `url,label`), `scope_type`, `include`, `exclude`, `scripts_intent` (default `detect`), `assets_intent` (default `detect`), `intent` (free-text used to derive `description`). If `target_repo` or `skill_name` is missing, HALT with exit code 2 (`halt_reason: "input-missing"`): "headless mode requires target_repo and skill_name arguments." If `source_type=docs-only` and no `doc_urls` supplied, same HALT with `halt_reason: "input-missing"`.
 - ONLY proceed to next step when user selects 'C'
 
 ## CRITICAL STEP COMPLETION NOTE

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -14,6 +14,7 @@ To initialize the brief-skill workflow by discovering the forge tier configurati
 - Focus only on gathering intent — do not analyze the repo yet (Step 02)
 - Do not examine source code or list exports in this step
 - Open-ended discovery facilitation — collect target repo, user intent, scope hints, skill name
+- All user-facing output in `{communication_language}`
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -176,6 +176,28 @@ Wait for confirmation or alternative.
 
 Ready to analyze the target repository?"
 
+### 7b. Synthesize Skill Description
+
+The schema's `description` field is 1-3 sentences and surfaces in skill registries — it must exist by the time step-04 presents the brief. Synthesize it explicitly here, while the user's intent is fresh, instead of letting it fall out implicitly later.
+
+Compose a candidate 1-3 sentence description from the gathered material. Pattern (adjust naturally — do not template-stamp):
+
+```
+{What the skill enables an agent to do, in active voice}, drawn from {target}{ at version {target_version}, if set}{ for {scope hint summary}, if any scope hints were captured}. Use when {one-sentence trigger condition derived from intent — what task or question routes to this skill}.
+```
+
+Present:
+
+"**Proposed skill description:**
+
+> {synthesized description}
+
+This is what shows up when agents discover the skill. Edit it, replace it, or accept as-is."
+
+Wait for user confirmation or alternative. Store the accepted text as the brief's `description` field. The same field is re-presented in step-04 §4 for a final review pass — refinements there flow back to this value.
+
+**Headless:** if the `intent` argument was supplied, run the same synthesis against it and store the result. If `intent` was not supplied, derive from `target_repo` + `skill_name` (`"Use the {skill_name} skill to work with code or content from {target_repo}."`) and log `"warn: description synthesized without intent — narrow registry text."`
+
 ### 8. Present MENU OPTIONS
 
 Display: "**Select:** [C] Continue to Target Analysis"

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -1,7 +1,7 @@
 ---
 nextStepFile: './step-02-analyze-target.md'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
-versionResolutionFile: '../references/version-resolution.md'
+versionResolutionFile: 'references/version-resolution.md'
 ---
 
 # Step 1: Gather Intent
@@ -153,10 +153,10 @@ This will be used for the output directory and file naming. Want to use this nam
 
 Wait for confirmation or alternative.
 
-**Collision check (interactive and headless):** before locking the name, check whether `{forge_data_folder}/{name}/skill-brief.yaml` or `~/.claude/skills/{name}/SKILL.md` already exists. If either does:
+**Collision check (interactive and headless):** before locking the name, check whether `{forge_data_folder}/{name}/skill-brief.yaml` already exists. If it does:
 
-- Interactive: "**Heads up — a skill named `{name}` already exists at `{path(s)}`.** Pick a different name to keep the new brief separate, or confirm to continue (the existing brief's overwrite prompt fires in step 05)."
-- Headless: log `"warn: skill name '{name}' collides with existing artifact at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
+- Interactive: "**Heads up — a brief for `{name}` already exists at `{path}`.** Pick a different name to keep the new brief separate, or confirm to continue (the existing brief's overwrite prompt fires in step 05)."
+- Headless: log `"warn: skill name '{name}' collides with existing brief at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
 
 ### 7. Summarize Gathered Intent
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -1,5 +1,6 @@
 ---
 nextStepFile: './step-03-scope-definition.md'
+versionResolutionFile: '../references/version-resolution.md'
 ---
 
 # Step 2: Analyze Target
@@ -161,29 +162,18 @@ If CCC is unavailable or returns no results: skip this subsection silently.
 
 ### 4b. Detect Source Version
 
+Load `{versionResolutionFile}` and follow its "Detection Algorithm" section for the language detected in §3. Run the detection regardless of whether `target_version` is set — when `target_version` is present, the precedence rules in the reference make `target_version` win, but the detected value is still surfaced to the user as informational context.
+
 **If `target_version` was provided in step 01:**
 - Display: "**Target version:** {target_version} (user-specified)"
-- Still run auto-detection below for informational purposes.
-
-Attempt to auto-detect the source version using the rules from the skill-brief-schema.md Version Detection section:
-
-**For Python:** Check `pyproject.toml` `[project] version` (static) → if `dynamic = ["version"]`, check `__init__.py` for `__version__` → `_version.py` if exists → `setup.py` `version=` → `git describe --tags --abbrev=0`
-**For JavaScript/TypeScript:** Check root `package.json` `"version"` field → if root has `"private": true` with a `"workspaces"` array or lacks a `"version"` field, fall back to a primary workspace package's `package.json` (e.g., `code/core/package.json`, or the first matching `packages/*/package.json`). For GitHub sources, prefer `gh api repos/{owner}/{repo}/releases/latest` → `tag_name` when a non-pre-release tag exists, over a default-branch pre-release. Treat a version containing `-alpha`, `-beta`, `-rc`, `-next`, or `-canary` as a pre-release.
-**For Rust:** Check `Cargo.toml` `[package] version` (static) → if `version = { workspace = true }`, resolve from workspace root `Cargo.toml` → `git describe --tags --abbrev=0`
-**For Go:** Check `go.mod` or `git describe --tags --abbrev=0`
-
-**For GitHub repos:** Use `gh api repos/{owner}/{repo}/contents/{file}` to read version files (decode base64 content).
-**For local repos:** Read the file directly.
+- Still run the detection algorithm below for informational purposes.
 
 Display: "**Detected version:** {version or 'Not detected — will default to 1.0.0'}"
 
 {If target_version was provided AND auto-detected version differs:}
-"**Note:** Detected version ({detected_version}) differs from your target version ({target_version}). Using target version."
+"**Note:** Detected version ({detected_version}) differs from your target version ({target_version}). Using target version (per `references/version-resolution.md` precedence rules)."
 
-{If target_version was provided:}
-Store `target_version` as the brief's `version` field (overrides auto-detection).
-
-If detection fails or returns a non-semver value: note that version will default to `"1.0.0"` and the user can override in step 04.
+If detection fails or returns a non-semver value: note that version will default to `"1.0.0"` and the user can override in step 04. The actual write happens in step 05.
 
 ### 5. Report Analysis Summary
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -1,6 +1,6 @@
 ---
 nextStepFile: './step-03-scope-definition.md'
-versionResolutionFile: '../references/version-resolution.md'
+versionResolutionFile: 'references/version-resolution.md'
 extractPublicApiScript: '{project-root}/src/shared/scripts/skf-extract-public-api.py'
 ---
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -1,6 +1,7 @@
 ---
 nextStepFile: './step-03-scope-definition.md'
 versionResolutionFile: '../references/version-resolution.md'
+extractPublicApiScript: '{project-root}/src/shared/scripts/skf-extract-public-api.py'
 ---
 
 # Step 2: Analyze Target
@@ -113,30 +114,57 @@ If confidence is low or ambiguous: flag for user override in step 03.
 
 ### 4. List Top-Level Modules and Exports
 
-Based on detected language, identify public API surface:
+Identify the public API surface. **Delegate the parsing to `{extractPublicApiScript}` whenever the detected language is supported** — the script is the single source of truth for manifest parsing, export discovery, and version detection across the whole SKF pipeline. Hand-rolling these in prose creates drift seams the LLM cannot fully close.
 
-**For JavaScript/TypeScript:**
-- Check `package.json` for `main`, `exports`, `module` fields
-- Look for `index.ts`/`index.js` in `src/`
-- List directories under `src/` as potential modules
+**Script-supported languages** (use the script): `js`, `ts`, `javascript`, `typescript`, `python`, `rust`, `go`, `java`, `kotlin`.
 
-**For Python:**
-- Check `__init__.py` files for public exports
-- List top-level packages under the source directory
+**Procedure when supported:**
 
-**For Rust:**
-- Check `lib.rs` for `pub mod` declarations
-- List modules from `src/` directory
+1. Read the relevant files into memory (no parsing yet — just collect content). For GitHub sources use `gh api repos/{owner}/{repo}/contents/{file}` with base64 decode; for local sources read directly.
 
-**For other languages:**
-- List top-level source directories as potential modules
-- Note any obvious entry points
+   | Language | Manifest | Entry points (mode=quick) |
+   |----------|----------|--------------------------|
+   | js / ts / javascript / typescript | `package.json` (root, or primary workspace package per `references/version-resolution.md`) | `index.{ts,js}` and/or `src/index.{ts,js}` if present |
+   | python | `pyproject.toml` (or `setup.py` / `setup.cfg` if no `pyproject.toml`) | top-level `__init__.py` of the package, plus `_version.py` if present |
+   | rust | `Cargo.toml` (`[package]` — workspace root if `version = { workspace = true }`) | `src/lib.rs` |
+   | go | `go.mod` | top-level `*.go` exporting the package surface |
+   | java | `pom.xml` | (manifest alone is sufficient for the modules listing) |
+   | kotlin | `build.gradle` / `build.gradle.kts` | (manifest alone) |
+
+2. Build a JSON payload matching the script contract:
+
+   ```json
+   {
+     "language": "<one of the supported values>",
+     "manifest": {"path": "<relative path>", "content": "<file contents>"},
+     "entries":  [{"path": "<relative path>", "content": "<file contents>"}, ...],
+     "mode":     "quick"
+   }
+   ```
+
+3. Invoke the script and parse its JSON stdout:
+
+   ```bash
+   echo '<payload-json>' | uv run {extractPublicApiScript} --language <lang> --mode quick
+   ```
+
+   On a non-zero exit (codes 1 or 2 per the script's docstring), capture stderr, log it, and fall through to the prose-fallback path below — never HALT just because the script choked on an unusual manifest.
+
+4. Render the returned `package_name`, `exports` (each entry's `name`/`type`/`source_file`), `dependencies`, and any `warnings` to the user. The script also returns `version` — feed that into §4b instead of re-deriving.
+
+5. The script does not enumerate directories under `src/`. The LLM still lists those as "Top-Level Modules/Directories" so the user sees structural context (Maven and Gradle are the exception — for those, the script returns a `modules` array which IS the list).
+
+**Procedure when not supported** (Ruby / C# / Swift / etc.):
+
+Fall back to ad-hoc inspection — `Gemfile` / `*.csproj` / `*.sln` / `Package.swift` / file extension frequency. List top-level source directories as potential modules and note any obvious entry points. Flag the limitation in the analysis summary so the user knows scoping is on coarser signals.
+
+**Output format (both paths):**
 
 "**Top-Level Modules/Directories:**
 {numbered list of modules with brief description of each}
 
 **Detected Exports/Entry Points:**
-{numbered list of public-facing items found}"
+{numbered list of public-facing items found — from script output when available, ad-hoc inspection otherwise}"
 
 **Semantic Signals (Forge+ and Deep with ccc only):**
 
@@ -162,11 +190,16 @@ If CCC is unavailable or returns no results: skip this subsection silently.
 
 ### 4b. Detect Source Version
 
-Load `{versionResolutionFile}` and follow its "Detection Algorithm" section for the language detected in §3. Run the detection regardless of whether `target_version` is set — when `target_version` is present, the precedence rules in the reference make `target_version` win, but the detected value is still surfaced to the user as informational context.
+Load `{versionResolutionFile}` for the canonical precedence and invariant rules.
+
+**When the language was script-supported (§4 took the script path):** the `version` field returned by `{extractPublicApiScript}` IS the detected version — do not re-derive it. The script already implements the language-specific lookups documented in `{versionResolutionFile}`.
+
+**When the language was not script-supported:** follow the prose Detection Algorithm in `{versionResolutionFile}` directly (Ruby / C# / Swift / etc. fall outside the script's coverage).
+
+Surface the result regardless of which path produced it:
 
 **If `target_version` was provided in step 01:**
 - Display: "**Target version:** {target_version} (user-specified)"
-- Still run the detection algorithm below for informational purposes.
 
 Display: "**Detected version:** {version or 'Not detected — will default to 1.0.0'}"
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -28,9 +28,20 @@ To analyze the target repository by resolving its location, reading its structur
 **Truncation detection:** After receiving the tree response, check the `truncated` field in the JSON output. If `truncated: true`:
 - Display: "Note: GitHub API returned a truncated tree response ({count} items). Full analysis may require a local clone."
 - Record in analysis summary: "Tree listing is partial — some files may not appear in the analysis."
-- For very large repos (>1000 files in tree response): suggest local clone for complete analysis.
+- For very large repos (>1000 files in tree response): offer a recovery path instead of just warning. Interactive — present:
+  ```
+  Tree is truncated. How would you like to proceed?
+    [L] Clone locally and re-analyze (slower but complete)
+    [P] Proceed with the partial tree (faster, may miss exports under deeper paths)
+  ```
+  On `[L]`: shallow-clone (`git clone --depth 1 {url} {tmp_dir}`), restart this section against the local path, and remove `{tmp_dir}` after the analysis summary in §5. On `[P]` (or under headless): record `tree_truncated: true` in the analysis summary and continue without HALT.
 
-- If inaccessible: **HALT** — "**Error:** Cannot access repository at {url}. Please verify the URL is correct and you have access. If private, ensure `gh auth` is configured."
+**On API failure (non-200 from `gh api`):**
+
+Distinguish the failure class before reporting:
+- Auto-run `gh auth status` and capture its output. If it reports an unauthenticated state or expired token: HALT (exit code 3, `halt_reason: "gh-auth-failed"`) — "**Error:** GitHub CLI is not authenticated. `gh auth status` says: `{captured output}`. Run `gh auth login` and retry."
+- If `gh auth status` reports authenticated but the call still failed (404/403): HALT (exit code 3, `halt_reason: "target-inaccessible"`) — "**Error:** Cannot access repository at `{url}`. The CLI is authenticated but the API returned `{status}`. Check the URL and that the account has access to private repositories if applicable."
+- If `gh auth status` itself fails to run (binary missing): HALT (exit code 3, `halt_reason: "gh-auth-failed"`) — "**Error:** `gh` CLI not found on PATH. Install it from <https://cli.github.com> and re-run."
 
 **For local paths:**
 - Verify the directory exists
@@ -38,6 +49,31 @@ To analyze the target repository by resolving its location, reading its structur
 - If path doesn't exist: **HALT** — "**Error:** Directory not found at {path}. Please verify the path is correct."
 
 Display: "**Resolving target...**"
+
+### 1b. Detect Monorepo / Workspace Layout
+
+Before listing the structure, check whether the root manifest declares a workspace layout:
+
+- **JavaScript/TypeScript:** root `package.json` has a `"workspaces"` array, OR a `pnpm-workspace.yaml` / `lerna.json` exists at the root.
+- **Rust:** root `Cargo.toml` has `[workspace]` with a `members = [...]` list.
+- **Python:** repo contains multiple `pyproject.toml` under `packages/*/` or `apps/*/`.
+- **Generic:** top-level `apps/`, `packages/`, `code/`, or `libs/` directory each containing manifests.
+
+If a workspace layout is detected, list the discovered workspaces and ask:
+
+```
+This looks like a monorepo with these workspaces:
+  1. {workspace_name} ({path})
+  2. {workspace_name} ({path})
+  ...
+Which one should the skill cover? Pick a number, type 'all' to scope at the repo root, or 'list' to keep listing more.
+```
+
+Interactive: wait for the user choice. On a numbered choice, store `monorepo_workspace: {path}` and rebase §2-§4b against that path. On `'all'`, leave `monorepo_workspace` unset and proceed at the repo root with a note in the analysis summary that scope is unfiltered.
+
+Headless: if the input contract supplied an `include` glob that begins with one of the workspace paths, auto-select that workspace (log `"headless: auto-selected workspace {name} from include glob"`). Otherwise default to repo root and log `"warn: monorepo detected but no workspace pre-selected — analyzing at repo root"`.
+
+If no workspace layout is detected, skip this section silently.
 
 ### 2. Read Repository Structure
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -13,6 +13,7 @@ To analyze the target repository by resolving its location, reading its structur
 - Focus only on analysis — do not define scope yet (Step 03)
 - Do not make scoping decisions or recommendations
 - Do not hallucinate or guess about repository contents
+- All user-facing output in `{communication_language}`
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -66,6 +66,8 @@ Add, remove, or confirm these URLs."
 
 Wait for confirmation. Record any changes to `doc_urls`.
 
+For each URL in the final list (newly added or carried over), HEAD-check it (`curl -sI {url}` or equivalent). On a 4xx/5xx, DNS failure, or timeout, warn `"Could not reach {url} — {status or error}."` and offer the same correct/keep choice as step-01 §3. The check is best-effort — never HALT on a failed HEAD — but the failure must surface here so it is not discovered downstream during compilation.
+
 **If no supplemental doc_urls were collected:** Skip this subsection.
 
 **Scope guidance for first-time users:** A well-scoped skill covers one cohesive capability with 3-8 primary functions. If the scope includes unrelated concerns (e.g., authentication AND data visualization), suggest splitting into separate briefs. If the scope is too narrow (single utility function), suggest expanding to the surrounding capability surface.

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -141,7 +141,12 @@ Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Conti
 #### EXECUTION RULES:
 
 - ALWAYS halt and wait for user input after presenting menu
-- **GATE [default: C]** — If `{headless_mode}`: accept auto-detected scope (full-repo or manifest-based) and auto-proceed, log: "headless: using auto-detected scope"
+- **GATE [default: C]** — If `{headless_mode}`: consume the headless inputs from step-01 in priority order:
+  - If `scope_type` was supplied, use it (must match one of the six valid types) and skip the §2c template menu.
+  - Otherwise auto-select based on `source_type`: `docs-only` → `scope.type: "docs-only"`; `source` → `full-library` (default).
+  - If `include`/`exclude` were supplied, use them verbatim (split on comma) instead of running the boundary prompts in §3.
+  - If `scripts_intent`/`assets_intent` were supplied, record them and skip §5b; otherwise default to `detect`.
+  - Log: `"headless: scope_type={value} include={n} exclude={n} scripts_intent={value} assets_intent={value}"`.
 - ONLY proceed to next step when user selects 'C'
 - After other menu items execution, return to this menu
 - User can chat or ask questions — always respond and then redisplay menu

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -16,6 +16,7 @@ To collaboratively define the skill's inclusion and exclusion boundaries using t
 - Focus only on defining scope boundaries — do not write the brief yet (Step 05)
 - Do not make scope decisions unilaterally — user drives all scope choices
 - Produce: scope type, include patterns, exclude patterns
+- All user-facing output in `{communication_language}`
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -17,6 +17,7 @@ To collaboratively define the skill's inclusion and exclusion boundaries using t
 - Do not make scope decisions unilaterally — user drives all scope choices
 - Produce: scope type, include patterns, exclude patterns
 - All user-facing output in `{communication_language}`
+- **Re-entry from step-04 [R] revise:** prior selections (`scope.type`, `scope.include`, `scope.exclude`, `scope.notes`, `scripts_intent`, `assets_intent`, supplemental `doc_urls`) are preserved as the current state. Re-present them at each section as the existing answer; the user only re-confirms or overrides. Do not reset to the §2c template menu unless the user explicitly asks to start scope over.
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -105,8 +105,7 @@ Flag any fields that may need review:
 {If language was overridden or low confidence:}
 "**Note:** Language was {auto-detected / manually overridden}."
 
-{If description was derived (not stated by user):}
-"**Note:** Description was derived from your stated intent. Adjust if needed."
+"**Description:** synthesized and confirmed in step-01 §7b. Refine here if you want to tighten it now that the full brief is visible."
 
 {If forge tier was defaulted:}
 "**Note:** Forge tier defaulted to Quick (no forge-tier.yaml found)."

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -16,6 +16,7 @@ To present the complete skill brief in human-readable format, highlighting all f
 
 - Focus only on presenting and confirming — do not write files yet (Step 05)
 - Do not proceed without explicit user approval (P2 confirmation gate)
+- All user-facing output in `{communication_language}`
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -33,6 +33,29 @@ If `{forge_data_folder}` is not set or doesn't exist:
 - Fall back to `{output_folder}/forge-data/{skill-name}/`
 - Inform user: "**Note:** forge_data_folder not configured. Writing to {output_folder}/forge-data/{skill-name}/ instead."
 
+### 2b. Existing Brief — Overwrite Policy
+
+Before writing, check whether `{forge_data_folder}/{skill-name}/skill-brief.yaml` already exists.
+
+**Interactive (`{headless_mode}` is false):**
+
+If the file exists, present:
+
+"**An existing brief was found at `{path}`.**
+Overwrite it with the brief you just approved? [Y/N]"
+
+- **[Y]** Overwrite — proceed to §3.
+- **[N]** Cancel — emit a single-line stderr log `brief-skill: overwrite-cancelled at {path}` and HALT with exit code 5 (do not chain to step-06; the run produced no new artifact).
+
+**Headless (`{headless_mode}` is true):**
+
+If the file exists:
+
+- If `force` was supplied as a headless argument: log `"headless: force-overwriting existing brief at {path}"` and proceed to §3.
+- Otherwise: emit the error-variant `SKF_BRIEF_RESULT_JSON` envelope (see §4b) on stderr with `halt_reason: "overwrite-cancelled"`, exit code 5, and HALT.
+
+If the file does not exist, proceed normally.
+
 ### 3. Generate skill-brief.yaml
 
 **Resolve the `version` field before generating the YAML:**
@@ -103,7 +126,21 @@ source_authority: "{official|community|internal}"
 
 Write the generated YAML to `{forge_data_folder}/{skill-name}/skill-brief.yaml`.
 
-If write fails: **HALT** — "**Error:** Failed to write skill-brief.yaml. Please check that the directory is writable and try again."
+If write fails:
+- Interactive: **HALT** — "**Error:** Failed to write skill-brief.yaml. Please check that the directory is writable and try again."
+- Headless: emit the error-variant `SKF_BRIEF_RESULT_JSON` envelope (see §4b) on stderr with `halt_reason: "write-failed"`, exit code 4, and HALT.
+
+### 4b. Headless Result Envelope
+
+If `{headless_mode}` is true, emit a single-line JSON envelope on **stdout** immediately after the successful write (before §5 / §6 / §7) so pipeline schedulers can parse the outcome without grepping the prose summary:
+
+```
+SKF_BRIEF_RESULT_JSON: {"status":"success","brief_path":"{abs_path}","skill_name":"{name}","version":"{resolved version}","language":"{language}","scope_type":"{scope.type}","exit_code":0,"halt_reason":null}
+```
+
+The envelope shape on HARD HALT (any phase, written to **stderr**) uses the same keys with `status: "error"`, `brief_path: null` when no file was written, the matching `exit_code` from the table in `SKILL.md`, and `halt_reason` set to one of: `"input-missing"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`.
+
+When `{headless_mode}` is false, skip this section silently — no envelope is emitted.
 
 ### 5. QMD Collection Registration (Deep Tier Only)
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -1,5 +1,6 @@
 ---
 briefSchemaFile: 'assets/skill-brief-schema.md'
+versionResolutionFile: '../references/version-resolution.md'
 nextStepFile: './step-06-health-check.md'
 ---
 
@@ -58,12 +59,13 @@ If the file does not exist, proceed normally.
 
 ### 3. Generate skill-brief.yaml
 
-**Resolve the `version` field before generating the YAML:**
+**Resolve the `version` field per `{versionResolutionFile}` precedence:**
 
-- If `target_version` was set in step 01 (the user explicitly asked for a specific version), use `target_version` as the value of the `version` field. This is the authoritative version for create-skill.
-- Otherwise, use the auto-detected source version from step 02, or `1.0.0` if none was detected.
+- `target_version` (set in step 01) wins outright when present.
+- Otherwise: auto-detected version from step 02.
+- Otherwise: `"1.0.0"`.
 
-`target_version` and `version` must never carry different values in the written brief. When the user provided a `target_version`, also include it as a separate `target_version` field so downstream tooling can distinguish "user-requested" from "auto-detected" without re-deriving the provenance — but its value must be identical to `version`.
+The reference's invariant section is binding: when `target_version` is set, the written brief MUST satisfy `brief.target_version == brief.version`. Set both fields to the identical string. Different values are a contract violation.
 
 Generate the YAML file using the approved field values and the schema template:
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -15,6 +15,7 @@ To generate the complete skill-brief.yaml from the approved brief data and write
 - Do not change any field values without user request — the brief was already approved
 - Create the output directory if it doesn't exist
 - Chains to the local health-check step via `{nextStepFile}` after completion — the user-facing success summary is NOT the terminal step
+- All user-facing output in `{communication_language}`; written artifact (`description`, `notes`) in `{document_output_language}`
 
 ## MANDATORY SEQUENCE
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -1,6 +1,6 @@
 ---
 briefSchemaFile: 'assets/skill-brief-schema.md'
-versionResolutionFile: '../references/version-resolution.md'
+versionResolutionFile: 'references/version-resolution.md'
 nextStepFile: './step-06-health-check.md'
 ---
 

--- a/src/skf-brief-skill/steps-c/step-06-health-check.md
+++ b/src/skf-brief-skill/steps-c/step-06-health-check.md
@@ -1,7 +1,7 @@
 ---
 # `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# (`{project-root}/_bmad/skf/` when installed, `{project-root}/src/`
+# during development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
 

--- a/src/skf-brief-skill/steps-c/step-06-health-check.md
+++ b/src/skf-brief-skill/steps-c/step-06-health-check.md
@@ -20,3 +20,7 @@ Chain to the shared workflow self-improvement health check at `{nextStepFile}`. 
 ## MANDATORY SEQUENCE
 
 Load `{nextStepFile}`, read it fully, then execute it.
+
+## CRITICAL STEP COMPLETION NOTE
+
+Step 06 is the terminal stage of brief-skill. After `{nextStepFile}` returns control, the brief-skill workflow is fully complete — do not re-enter step-05 or step-06, do not load any further step file, and do not loop back into the workflow.

--- a/src/skf-brief-skill/steps-c/step-06-health-check.md
+++ b/src/skf-brief-skill/steps-c/step-06-health-check.md
@@ -16,6 +16,7 @@ Chain to the shared workflow self-improvement health check at `{nextStepFile}`. 
 - No user-facing reports, file writes, or result contracts in this step — those belong in step-05
 - Delegate directly to `{nextStepFile}` with no additional commentary
 - Do not attempt any other action between loading this step and executing `{nextStepFile}`
+- All user-facing output in `{communication_language}`
 
 ## MANDATORY SEQUENCE
 


### PR DESCRIPTION
## Summary

Closes the bmad-workflow-builder quality-analysis findings on `skf-brief-skill` (full report: `skills/reports/skf-brief-skill/quality-analysis/20260502-174302/quality-report.md`). Original grade **Good** with 2 broken items + 5 opportunity themes + R7 overview gap. This PR resolves all of them in 10 commits, one per finding/theme where the work cleaved cleanly.

- 2 broken items (path-standards lint hard-fail, terminal-step completion sentinel)
- Theme 1 (integration debt) — prose half: wired existing `skf-extract-public-api.py` into step-02 §3/§4/§4b. The two new scripts (`render-skill-brief.py`, `validate-skill-brief.py`) are deferred to a follow-up PR per the analysis report's design boundary
- Theme 2 (headless contract) — Invocation Contract expanded from 4 to 16 inputs, exit-code table, `SKF_BRIEF_RESULT_JSON` envelope on stdout/stderr, explicit overwrite policy
- Theme 3 (language directive) — added to every step's Rules block; step-05 also gets `{document_output_language}` for the written artifact
- Theme 4 (HITL diagnostics) — `gh auth status` on API failure, HEAD-check on doc URLs, `[L] Clone locally` on truncated trees, monorepo workspace prompt, skill-name collision check, corrupted-forge-tier fallback
- Theme 5 (description + version provenance) — explicit `description` synthesis sub-step at end of step-01 with confirmation; version-resolution rules consolidated into `references/version-resolution.md` loaded by steps 01/02/05; step-03 re-entry preserves prior selections
- R7 (Overview) — expanded from 3 to 9 lines with scoping theory and brief↔create-skill split rationale

## Verification

- `npm run quality` green at every commit
- Re-scan with bmad-workflow-builder:
  - path-standards: 1 high → 0 issues
  - workflow-integrity prepass: 12 findings → 6 low (only "polite please" stylistic items remain — covered by the Tier-C followup)
  - 6 medium "config-header" issues from prepass: all resolved by Theme 3
  - Final scanner-synthesized report at `skills/reports/skf-brief-skill/quality-analysis/20260502-181518/`

The re-scan flipped the lens — with the original 5 themes resolved, scanners now spotlight a different cluster (more script-opportunities, parallel batching in step-02, edit-existing-brief flow, scope split-suggestion machinery, polish). The original analysis is fully resolved here; the new findings belong in a follow-up PR.

## Commit map

| Commit | Finding |
|--------|---------|
| `e9ea448f` | Broken #1 — bare `_bmad/` path |
| `60846c29` | Broken #2 — terminal-step completion sentinel |
| `4068ba39` | Theme 3 — language directive (7 obs) |
| `840ee8bd` | Theme 2 — headless contract (4 obs) |
| `45797cc6` | Theme 4 — diagnostic-on-failure (6 obs) |
| `cb284725` | Theme 5 obs#2/#3 — version-resolution consolidation + step-03 re-entry |
| `0d495986` | Theme 5 obs#1 — description synthesis |
| `8b922f3b` | R7 — Overview expansion |
| `12eb1dc4` | Theme 1 (prose half) — wire `skf-extract-public-api.py` into step-02 |
| `753a7484` | Re-scan regressions — parent-dir frontmatter paths and `~/` reference |

## Deferred to follow-up PR

- Theme 1 obs#2/#3/#4 — new shared scripts (`render-skill-brief.py`, `validate-skill-brief.py`) with PEP 723 + unit tests
- Re-scan Theme 1 — additional shared scripts surfaced by the re-scan (`skf-brief-parse-args.py`, `skf-detect-workspaces.py`, `skf-detect-language.py`) and wiring of existing `skf-emit-result-envelope.py` / `skf-atomic-write.py`
- Re-scan Theme 3 — edit-existing-brief / view-draft / re-target entry points
- Re-scan Theme 4 — first-timer scope-template scaffolding
- Re-scan Theme 5 — enforced quality floor on headless `intent`
- Re-scan Theme 6 polish — drop boilerplate, replace 5 `please` instances

## Test plan

- [x] `npm run quality` passes locally
- [x] CI green
- [x] Manual smoke: invoke `@Ferris BS` interactively, confirm step-01 synthesis prompt, step-04 confirmation flow, and step-05 overwrite prompt fire as documented
- [x] Manual smoke (headless): `@Ferris BS --headless --target_repo=... --skill_name=foo --intent="..."` produces `SKF_BRIEF_RESULT_JSON` envelope on stdout
- [x] Re-run quality-analysis on the merged branch to confirm grade

🤖 Generated with [Claude Code](https://claude.com/claude-code)