### PR TITLE
fix(skf-brief-skill): cosmetic polish — terminal-step keyword, please-imperatives, sub-sectioning, GATE table

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skf-brief-skill
-description: Design a skill scope through guided discovery. Use when the user requests to "create a skill brief" or "brief a skill."
+description: Design a skill scope through guided discovery. Use when the user requests to "create a skill brief" or "brief a skill".
 ---
 
 # Brief Skill
@@ -36,7 +36,7 @@ These rules apply to every step in this workflow:
 | 3 | Scope Definition | steps-c/step-03-scope-definition.md | No (interactive) |
 | 4 | Confirm Brief | steps-c/step-04-confirm-brief.md | No (confirm) |
 | 5 | Write Brief | steps-c/step-05-write-brief.md | Yes |
-| 6 | Workflow Health Check (terminal — chains to `shared/health-check.md`) | steps-c/step-06-health-check.md | Yes |
+| 6 | Workflow Health Check (terminal) | steps-c/step-06-health-check.md | Yes |
 
 ## Invocation Contract
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -224,7 +224,25 @@ Display: "**Select:** [C] Continue to Target Analysis"
 #### EXECUTION RULES:
 
 - ALWAYS halt and wait for user input after presenting menu
-- **GATE [default: use args]** — If `{headless_mode}`: consume pre-supplied arguments and auto-proceed. Required: `target_repo`, `skill_name`. Optional, applied to the matching brief field when present: `scope_hint`, `language_hint`, `target_version`, `source_authority` (default `community`), `source_type` (default `source`; if `docs-only`, `doc_urls` becomes required), `doc_urls` (list of `url` or `url,label`), `scope_type`, `include`, `exclude`, `scripts_intent` (default `detect`), `assets_intent` (default `detect`), `intent` (free-text used to derive `description`). If `target_repo` or `skill_name` is missing, HALT with exit code 2 (`halt_reason: "input-missing"`): "headless mode requires target_repo and skill_name arguments." If `source_type=docs-only` and no `doc_urls` supplied, same HALT with `halt_reason: "input-missing"`.
+- **GATE [default: use args]** — If `{headless_mode}`, consume pre-supplied arguments per the table below and auto-proceed. Any missing required arg → HALT with exit code 2, `halt_reason: "input-missing"`, message: `"headless mode requires target_repo and skill_name arguments."` (Same HALT applies when `source_type=docs-only` and `doc_urls` is empty.)
+
+  | Argument | Required | Default | Notes |
+  |----------|----------|---------|-------|
+  | `target_repo` | yes | — | HALT (exit 2) if absent |
+  | `skill_name` | yes | — | HALT (exit 2) if absent |
+  | `source_type` | no | `source` | If `docs-only`, `doc_urls` becomes required |
+  | `doc_urls` | conditional | — | Required when `source_type=docs-only`. List of `url` or `url,label` |
+  | `source_authority` | no | `community` | `official` / `community` / `internal`; forced to `community` when `source_type=docs-only` |
+  | `target_version` | no | — | Auto-detected in step-02 if absent |
+  | `scope_hint` | no | — | Free-text steering for §5 |
+  | `language_hint` | no | — | Overrides language detection in step-02/03 |
+  | `scope_type` | no | — | `full-library` / `specific-modules` / `public-api` / `component-library` / `reference-app` / `docs-only` |
+  | `include` | no | — | Comma-separated globs (used by step-03 §3) |
+  | `exclude` | no | — | Comma-separated globs (used by step-03 §3) |
+  | `scripts_intent` | no | `detect` | `detect` / `none` / free-text |
+  | `assets_intent` | no | `detect` | `detect` / `none` / free-text |
+  | `intent` | no | — | Free-text used to derive `description` in §7b |
+  | `force` | no | — | Overwrite existing brief without prompting (consumed in step-05 §2b) |
 - ONLY proceed to next step when user selects 'C'
 
 ## CRITICAL STEP COMPLETION NOTE

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -36,7 +36,7 @@ Attempt to load `{forgeTierFile}`:
 - Continue with `tier = "Quick"` and `tools = {}` — do not HALT. Record `tier_source: "fallback-corrupted-config"` for later diagnostics.
 
 **If not found:**
-- "**Cannot proceed.** forge-tier.yaml not found at `{forgeTierFile}`. Please run the **setup** workflow first to configure your forge tier (Quick/Forge/Forge+/Deep)."
+- "**Cannot proceed.** forge-tier.yaml not found at `{forgeTierFile}`. Run the **setup** workflow first to configure your forge tier (Quick/Forge/Forge+/Deep)."
 - HALT (exit code 3, `halt_reason: "forge-tier-missing"`) — do not proceed.
 
 ### 2. Welcome and Explain
@@ -117,7 +117,7 @@ Wait for user response.
 "**You're targeting version {target_version}. Do these documentation URLs correspond to that version?** [Y/N]"
 
 - **If Y:** Proceed.
-- **If N:** "Please provide the correct documentation URLs for version {target_version}." Re-collect doc_urls.
+- **If N:** "Provide the correct documentation URLs for version {target_version}." Re-collect doc_urls.
 
 ### 4. Gather User Intent
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -60,6 +60,10 @@ Let's get started."
 
 ### 3. Gather Target Repository
 
+This section has three sub-flows. Execute exactly one branch — 3.2 *or* 3.3 — based on the user's response in 3.1, then end with the shared confirmation. Do not mix branches.
+
+#### 3.1 Collect target
+
 "**What repository or documentation do you want to create a skill for?**
 
 Provide one of:
@@ -69,29 +73,39 @@ Provide one of:
 
 **Target:**"
 
-Wait for user response.
+Wait for user response. Branch on the response:
 
-**If user provides documentation URLs (not a repo):**
+- Documentation URLs only (no source location) → §3.2
+- GitHub URL or local filesystem path → §3.3
+
+#### 3.2 Branch — Documentation URLs (docs-only)
+
 - Set `source_type: "docs-only"` in the brief data
 - Collect one or more doc URLs with optional labels
 - For each collected URL, perform a `HEAD` request (or `curl -sI`) to verify the URL resolves with a 2xx/3xx status:
   - On 2xx/3xx: silently accept.
   - On 4xx/5xx, DNS failure, or timeout: warn `"Could not reach {url} — {status or error}. Confirm the URL is correct, or proceed anyway."` Interactive: re-prompt for a corrected URL or `[K] Keep anyway`. Headless: keep the URL and log the warning — the brief still records it but the failure is now visible at brief-creation time instead of materializing hours later in skf-create-skill.
-- Note: `source_authority` will be forced to `community` (T3 external documentation)
+- Set `source_authority: "community"` (forced for docs-only — T3 external documentation; the §3.3 source-authority prompt is skipped)
 - Note: `source_repo` becomes optional (can be set to the main doc site URL for reference)
 
-**If user provides a GitHub URL or local path:**
+Skip §3.3 and continue at "Confirm the target" below.
+
+#### 3.3 Branch — Source (GitHub URL or local path)
+
 - Set `source_type: "source"` (default)
 - Optionally ask: "Are there any documentation URLs you'd like to include for supplemental context? (These will be fetched as T3 external references.)"
 - If yes: collect doc URLs into `doc_urls`
 
-**Source authority (for all source-type skills):**
+**Source authority (this branch only — docs-only forces `community` in §3.2):**
+
 "**Are you the maintainer of this library, or creating a community skill?**"
 - If maintainer: set `source_authority: "official"`
 - If community user: set `source_authority: "community"` (default)
 - If internal/proprietary: set `source_authority: "internal"`
 
-Default to `"community"` if user does not specify or skips. For `docs-only` skills, `source_authority` is always forced to `"community"`.
+Default to `"community"` if user does not specify or skips.
+
+---
 
 Confirm the target.
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -48,7 +48,7 @@ Distinguish the failure class before reporting:
 **For local paths:**
 - Verify the directory exists
 - List the directory tree
-- If path doesn't exist: **HALT** — "**Error:** Directory not found at {path}. Please verify the path is correct."
+- If path doesn't exist: **HALT** — "**Error:** Directory not found at {path}. Verify the path is correct."
 
 Display: "**Resolving target...**"
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -118,7 +118,9 @@ Identify the public API surface. **Delegate the parsing to `{extractPublicApiScr
 
 **Script-supported languages** (use the script): `js`, `ts`, `javascript`, `typescript`, `python`, `rust`, `go`, `java`, `kotlin`.
 
-**Procedure when supported:**
+This section runs exactly one of §4.1 (script path) or §4.2 (fallback path) based on the detected language, then always emits §4.3 (output format) and conditionally §4.4 (semantic signals).
+
+#### 4.1 Procedure — script-supported languages
 
 1. Read the relevant files into memory (no parsing yet — just collect content). For GitHub sources use `gh api repos/{owner}/{repo}/contents/{file}` with base64 decode; for local sources read directly.
 
@@ -148,17 +150,19 @@ Identify the public API surface. **Delegate the parsing to `{extractPublicApiScr
    echo '<payload-json>' | uv run {extractPublicApiScript} --language <lang> --mode quick
    ```
 
-   On a non-zero exit (codes 1 or 2 per the script's docstring), capture stderr, log it, and fall through to the prose-fallback path below — never HALT just because the script choked on an unusual manifest.
+   On a non-zero exit (codes 1 or 2 per the script's docstring), capture stderr, log it, and fall through to §4.2 (the prose-fallback path) — never HALT just because the script choked on an unusual manifest.
 
 4. Render the returned `package_name`, `exports` (each entry's `name`/`type`/`source_file`), `dependencies`, and any `warnings` to the user. The script also returns `version` — feed that into §4b instead of re-deriving.
 
 5. The script does not enumerate directories under `src/`. The LLM still lists those as "Top-Level Modules/Directories" so the user sees structural context (Maven and Gradle are the exception — for those, the script returns a `modules` array which IS the list).
 
-**Procedure when not supported** (Ruby / C# / Swift / etc.):
+#### 4.2 Procedure — fallback (not script-supported)
+
+Languages outside the script coverage (Ruby / C# / Swift / etc.) take this path. The §4.1 fall-through on script error also lands here.
 
 Fall back to ad-hoc inspection — `Gemfile` / `*.csproj` / `*.sln` / `Package.swift` / file extension frequency. List top-level source directories as potential modules and note any obvious entry points. Flag the limitation in the analysis summary so the user knows scoping is on coarser signals.
 
-**Output format (both paths):**
+#### 4.3 Output format (both paths)
 
 "**Top-Level Modules/Directories:**
 {numbered list of modules with brief description of each}
@@ -166,7 +170,7 @@ Fall back to ad-hoc inspection — `Gemfile` / `*.csproj` / `*.sln` / `Package.s
 **Detected Exports/Entry Points:**
 {numbered list of public-facing items found — from script output when available, ad-hoc inspection otherwise}"
 
-**Semantic Signals (Forge+ and Deep with ccc only):**
+#### 4.4 Semantic Signals (Forge+/Deep with ccc only)
 
 **Remote source guard:** If the target source was resolved via GitHub API (remote URL, not a local file path), skip this CCC subsection — CCC requires a local source index and cannot operate on remote-only sources. Note: "CCC semantic discovery skipped — target is remote. CCC discovery will run automatically during create-skill after the source is cloned."
 

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -53,7 +53,7 @@ Compile all gathered data from steps 01-03 into the complete brief:
 
 Using the presentation format from the schema:
 
-"**Please review the complete skill brief before I write it.**
+"**Review the complete skill brief before I write it.**
 
 ---
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -129,7 +129,7 @@ source_authority: "{official|community|internal}"
 Write the generated YAML to `{forge_data_folder}/{skill-name}/skill-brief.yaml`.
 
 If write fails:
-- Interactive: **HALT** — "**Error:** Failed to write skill-brief.yaml. Please check that the directory is writable and try again."
+- Interactive: **HALT** — "**Error:** Failed to write skill-brief.yaml. Check that the directory is writable and try again."
 - Headless: emit the error-variant `SKF_BRIEF_RESULT_JSON` envelope (see §4b) on stderr with `halt_reason: "write-failed"`, exit code 4, and HALT.
 
 ### 4b. Headless Result Envelope

--- a/src/skf-brief-skill/steps-c/step-06-health-check.md
+++ b/src/skf-brief-skill/steps-c/step-06-health-check.md
@@ -22,6 +22,10 @@ Chain to the shared workflow self-improvement health check at `{nextStepFile}`. 
 
 Load `{nextStepFile}`, read it fully, then execute it.
 
+## Completion criteria
+
+This is the terminal step of brief-skill. The workflow is complete when `{nextStepFile}` returns control — do not transition to any further step.
+
 ## CRITICAL STEP COMPLETION NOTE
 
 Step 06 is the terminal stage of brief-skill. After `{nextStepFile}` returns control, the brief-skill workflow is fully complete — do not re-enter step-05 or step-06, do not load any further step file, and do not loop back into the workflow.


### PR DESCRIPTION
## Summary

Theme 5 of the skf-brief-skill quality analysis (2026-05-02): seven low-risk surface fixes, six commits.

- **SKILL.md** — period inside the second trigger-phrase quote moved outside; long parenthetical removed from the stage table
- **5x `Please` → imperative** — direct-imperative prose convention applied across step-01/02/04/05 user-facing prompts
- **step-06** — added an explicit `## Completion criteria` line so the prepass-workflow-integrity heuristic sees the terminal-step vocabulary it expects (behaviour unchanged)
- **step-01 §3** — three nested conditionals (docs-only / source / source-authority) split into §3.1/§3.2/§3.3 with an upfront branch-decision rule
- **step-01 §8 headless GATE** — 280-word paragraph enumerating 14 inline arguments converted to a 4-column table; also surfaces `force` (was previously only in the SKILL.md Invocation Contract)
- **step-02 §4** — script-supported / fallback / output-format / semantic-signals concerns split into §4.1–4.4 with explicit branch-of-one rule

## What this is not

- **Not** a behaviour change. No HALT codes, gate defaults, headless contracts, or output formats moved.
- **Not** a fix for the L2 \"dangling `knowledge/tool-resolution.md`\" finding — verified false positive (the bare `knowledge/...` path is the standard SKF convention used by every workflow; the file exists at `src/knowledge/tool-resolution.md`).

## Cross-ref preservation

External references to \"step-01 §3\", \"step-01 §3b\", \"step-01 §7b\", \"step-02 §4\" all still resolve — only internal sub-headings were added/renamed, not top-level section anchors.

## Test plan

- [x] `npm run quality` passes locally (pre-commit hook ran on every commit; full test suite green)
- [x] markdownlint clean on all 198 files
- [x] No content drift in the YAML schema, brief.yaml shape, or headless contract — verify by reading the diff for any HALT/exit-code/`SKF_BRIEF_RESULT_JSON` change (none present)
- [x] Spot-check on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)