### PR TITLE
feat(skf-brief-skill): surface skill opinions at decision time

### DIFF
--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -182,11 +182,21 @@ Ready to analyze the target repository?"
 
 The schema's `description` field is 1-3 sentences and surfaces in skill registries — it must exist by the time step-04 presents the brief. Synthesize it explicitly here, while the user's intent is fresh, instead of letting it fall out implicitly later.
 
-Compose a candidate 1-3 sentence description from the gathered material. Pattern (adjust naturally — do not template-stamp):
+Compose a candidate 1-3 sentence description from the gathered material. **Write like a human library maintainer would** — what does an agent get from this skill, and when should it route here? Two facts must come through (what the skill is, when to use it); everything else is voice. Resist filling in the same skeleton every time.
 
-```
-{What the skill enables an agent to do, in active voice}, drawn from {target}{ at version {target_version}, if set}{ for {scope hint summary}, if any scope hints were captured}. Use when {one-sentence trigger condition derived from intent — what task or question routes to this skill}.
-```
+Examples of the range — note that voice, structure, lead, and emphasis all vary:
+
+> Render Markdown to HTML using the marked library. Use when the user pastes raw Markdown and wants formatted output, or asks how to convert MD files in a build pipeline.
+
+> Stripe API client for Node.js — payment intents, subscriptions, customer portal, webhooks. Triggers on tasks involving Stripe-managed payments, subscription billing, or webhook event handling.
+
+> Charts and visualizations powered by D3.js. Reach for this when the user asks to plot data, build interactive graphs, or wants bare D3 control instead of a React-charts abstraction.
+
+> Lint Python code with Ruff. Use when the user wants to add or configure Ruff in a Python project, debug rule selectors, or understand why a specific check fired.
+
+> Date and time arithmetic via Luxon — parsing, formatting, time zones, durations, intervals. Use when working with dates in ways that exceed `Date.toISOString()` but you don't want a full Moment.js footprint.
+
+Notice how each one leads differently (verb / noun / "Charts and..." / verb / noun-phrase) and how the trigger ("Use when...", "Triggers on...", "Reach for this when...") is matched to the voice rather than copy-pasted. Compose in that spirit using the gathered material — the target repo, the user's intent, the version if set, and any scope hints — but do not template-stamp.
 
 Present:
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -52,9 +52,11 @@ We'll work through this together:
 4. **Finally:** Confirm and write the brief
 
 {If tier override was applied:}
-**Your forge tier:** {override tier} (overridden from {original tier}) — this determines what compilation capabilities are available.
+**Your forge tier:** {override tier} (overridden from {original tier}) — {tier_gloss}
 {Else:}
-**Your forge tier:** {detected tier} — this determines what compilation capabilities are available.
+**Your forge tier:** {detected tier} — {tier_gloss}
+
+(Substitute `{tier_gloss}` with the matching one-liner so the user knows what the tier label means: `Quick` → "text-only extraction"; `Forge` → "AST-grep on, semantic discovery off"; `Forge+` → "AST-grep + ccc semantic discovery"; `Deep` → "full pipeline — AST + ccc + qmd portfolio search + LLM re-ranking". The tier sets the ceiling for what the downstream create-skill workflow can do; you can re-run setup later to change it.)
 
 Let's get started."
 

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -77,11 +77,29 @@ For each URL in the final list (newly added or carried over), HEAD-check it (`cu
 
 Load `{scopeTemplatesFile}` for the scope type options ([F], [M], [P], [C], [R]) and their descriptions.
 
-Present: "**How broadly should this skill cover the library?**" followed by the scope type options from the loaded reference.
+**Recommend a scope type — don't present the five options as equal weight.** SKILL.md states this workflow "steers toward the smaller, sharper version when scope is unclear" — surface that opinion at decision time. Use the analysis from step-02 and the user's intent from step-01 to pick the best-fit recommendation, then present the menu with that option marked as the suggested default.
 
-Ask: "Which scope type fits your needs?"
+Heuristics for the recommendation (apply in order, pick the first that matches):
 
-Wait for user selection.
+- **Component registry detected** (file matching `registry.ts` / `components.ts` with 10+ entries, or `Component[]` type annotation) → **[C] Component Library**
+- **User intent mentions "wiring", "integration example", "starter", "lifecycle", "build config"** OR the analysis identified the source as an example/demo app → **[R] Reference App**
+- **Intent names specific module(s)** (e.g. "just the auth module", "only the streaming part") OR the analysis surfaced a large library (≥6 top-level modules with weakly-related concerns) → **[M] Specific Modules**
+- **Library has a clear, narrow public API** (≤8 named exports from the manifest, intent points at "the API" / "the SDK") → **[P] Public API Only**
+- **Otherwise** (small focused library, intent says "everything", or no strong signal either way) → **[F] Full Library**
+
+Present:
+
+"**Recommended scope type: [{letter}] {Name}** — {one-sentence rationale tying the recommendation to a specific signal from step-01/02, e.g. 'because the analysis found a 47-entry component registry under src/components/registry.ts'}.
+
+How broadly should this skill cover the library?
+
+{full menu from `{scopeTemplatesFile}` with the recommended letter marked, e.g. '[F] Full Library', '[M] Specific Modules', '[P] Public API Only ← recommended', '[C] Component Library', '[R] Reference App'}
+
+Press Enter to accept the recommendation, or pick a different letter."
+
+Wait for user selection. Empty input or just Enter accepts the recommendation; any of the five letters overrides.
+
+**Headless:** if `scope_type` was supplied, use it (consumed at the GATE in §6). If not supplied, the headless GATE auto-selects per the existing rule (`docs-only` → `docs-only`; `source` → `full-library`); the recommendation here is interactive-only.
 
 ### 3. Define Boundaries Based on Selection
 

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -63,7 +63,7 @@ Skill Brief: {name}
 
 Target:      {source_repo}
 Language:    {language}
-Forge Tier:  {forge_tier}
+Forge Tier:  {forge_tier} — {tier_gloss}
 Description: {description}
 
 Scope: {scope.type}
@@ -80,9 +80,8 @@ Doc URLs:
 Supplemental Docs:
   {doc_urls, one per line with labels}
 
-{If scripts_intent or assets_intent was explicitly set (not default "detect"):}
-Scripts:    {scripts_intent}
-Assets:     {assets_intent}
+Scripts:    {scripts_intent} — {scripts_gloss}
+Assets:     {assets_intent} — {assets_gloss}
 
 Source Authority: {source_authority}
 
@@ -96,7 +95,22 @@ Created:    {created}
 Created by: {created_by}
 ```
 
----"
+---
+
+Glosses (substitute the matching one-liner for `{tier_gloss}`, `{scripts_gloss}`, `{assets_gloss}` above so the user can decode each value at a glance):
+
+- **Forge tier glosses** —
+  - `Quick`: text-only extraction; AST and semantic discovery off
+  - `Forge`: AST-grep on; semantic and re-ranking off
+  - `Forge+`: AST-grep + ccc semantic discovery; re-ranking off
+  - `Deep`: full pipeline — AST + ccc + qmd portfolio search + LLM re-ranking
+
+- **`scripts_intent` / `assets_intent` glosses** —
+  - `detect`: SKF will scan source for the standard `scripts/`/`bin/`/`tools/`/`cli/` (or `assets/`/`templates/`/`schemas/`/`configs/`) directories during create-skill and decide automatically
+  - `none`: no script/asset packaging — create-skill will skip the detection pass
+  - free-text (anything else): a description of what to package; create-skill treats it as the user's spec
+
+(For `docs-only` and `public-api` scope types the scripts/assets prompt is skipped in step-03 §5b — the values default to `detect` but the create-skill detection pass also no-ops for these scope types, so the gloss just clarifies that the recorded value will not actually fire any scan.)"
 
 ### 4. Highlight Items Needing Attention
 


### PR DESCRIPTION
## Summary

Theme 3 of the skf-brief-skill quality analysis (2026-05-02): four content edits that pull the workflow's existing opinions and defaults into view at the moment a user is being asked to decide.

- **step-03 §2c — Recommend a scope-type.** SKILL.md openly says this workflow \"steers toward the smaller, sharper version when scope is unclear\" but the menu presented [F] [M] [P] [C] [R] as five equal options. Add a recommendation rule (component-registry detection / intent keywords / module count / public-API size) that picks one option, marks it in the menu, and lets Enter accept it. Headless still auto-selects via the existing GATE.
- **step-04 §3 — Always show scripts_intent / assets_intent / forge_tier with one-line glosses.** Previously hid these whenever they sat at the default `detect`, meaning a first-timer approved the brief without ever seeing what behaviour they were agreeing to. Now always shown with a gloss block explaining what each value does.
- **step-01 §2 — Gloss the forge tier in the welcome banner.** Previously \"Your forge tier: Forge+\" with no indication of capability differences. Now substitutes a one-liner (Quick / Forge / Forge+ / Deep ladder) and notes it is re-runnable via the setup workflow.
- **step-01 §7b — Replace the structured description template with voice-varied examples.** The prescribed sentence shape (\"{What ... in active voice}, drawn from {target} ... Use when {trigger}.\") was producing near-identical bot-prose across the registry. Replaced with five examples spanning varied voice (Markdown / Stripe / D3 / Ruff / Luxon) plus an explicit \"write like a human library maintainer\" instruction.

## What this is not

- **Not** a behaviour change for headless. All headless GATE rules, exit codes, halt_reasons, and the SKF_BRIEF_RESULT_JSON contract are unchanged.
- **Not** a schema change. brief.yaml shape stays identical — these edits change *what is shown to the user during the conversation*, not what gets written to disk.

## Test plan

- [x] `npm run quality` passes locally on every commit (markdownlint + lint + format + schema validation)
- [x] Spot-check on CI
- [x] Manual interactive run to confirm the recommendation triggers correctly across at least one full-library and one specific-modules target

🤖 Generated with [Claude Code](https://claude.com/claude-code)