### PR TITLE
perf(skf-brief-skill): parallel HEAD/gh-api batching and lazy reference loading

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -24,6 +24,7 @@ These rules apply to every step in this workflow:
 - Read each step file completely before taking any action
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
+- **Lazy-load references and assets:** `references/*.md` and `assets/*.md` files are loaded inside the section that needs them, not at step entry. If a section is skipped (e.g. `version-resolution.md` when `{extractPublicApiScript}` already returned a version, `scope-templates.md` for the `docs-only` branch that bypasses §2c), do not load that file. Each unnecessary load costs context (~5-10 KB per reference) and biases the LLM toward consulting material the current path does not need.
 - Always communicate in `{communication_language}`
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -74,7 +74,7 @@ Wait for user response.
 **If user provides documentation URLs (not a repo):**
 - Set `source_type: "docs-only"` in the brief data
 - Collect one or more doc URLs with optional labels
-- For each collected URL, perform a `HEAD` request (or `curl -sI`) to verify the URL resolves with a 2xx/3xx status:
+- HEAD-check the collected URLs in parallel — do not loop sequentially. Issue all N `curl -sI {url}` (or equivalent) calls in a **single message with N parallel Bash calls**, then process the responses together. Each call must use a 5-second timeout (`curl -sI --max-time 5 {url}`) to bound worst-case wall-time on hung hosts. Per response:
   - On 2xx/3xx: silently accept.
   - On 4xx/5xx, DNS failure, or timeout: warn `"Could not reach {url} — {status or error}. Confirm the URL is correct, or proceed anyway."` Interactive: re-prompt for a corrected URL or `[K] Keep anyway`. Headless: keep the URL and log the warning — the brief still records it but the failure is now visible at brief-creation time instead of materializing hours later in skf-create-skill.
 - Note: `source_authority` will be forced to `community` (T3 external documentation)

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -192,11 +192,9 @@ If CCC is unavailable or returns no results: skip this subsection silently.
 
 ### 4b. Detect Source Version
 
-Load `{versionResolutionFile}` for the canonical precedence and invariant rules.
+**When the language was script-supported (§4 took the script path):** the `version` field returned by `{extractPublicApiScript}` IS the detected version — do not re-derive it and do not load `{versionResolutionFile}`. The script already implements the language-specific lookups documented in that reference, so loading the reference here only burns context.
 
-**When the language was script-supported (§4 took the script path):** the `version` field returned by `{extractPublicApiScript}` IS the detected version — do not re-derive it. The script already implements the language-specific lookups documented in `{versionResolutionFile}`.
-
-**When the language was not script-supported:** follow the prose Detection Algorithm in `{versionResolutionFile}` directly (Ruby / C# / Swift / etc. fall outside the script's coverage).
+**When the language was not script-supported:** load `{versionResolutionFile}` and follow the prose Detection Algorithm directly (Ruby / C# / Swift / etc. fall outside the script's coverage).
 
 Surface the result regardless of which path produced it:
 

--- a/src/skf-brief-skill/steps-c/step-02-analyze-target.md
+++ b/src/skf-brief-skill/steps-c/step-02-analyze-target.md
@@ -24,8 +24,10 @@ To analyze the target repository by resolving its location, reading its structur
 ### 1. Resolve Target Location
 
 **For GitHub URLs:**
-- Use `gh api repos/{owner}/{repo}` to verify the repository exists
-- Use `gh api repos/{owner}/{repo}/git/trees/HEAD?recursive=1` to get the file tree
+- Issue both probes in **one message with two parallel Bash calls** — they are independent:
+  - `gh api repos/{owner}/{repo}` (verify repo exists)
+  - `gh api repos/{owner}/{repo}/git/trees/HEAD?recursive=1` (fetch file tree)
+- If the repo-existence probe fails, fall through to the failure-class triage below; the tree response from the parallel call is discarded in that case.
 
 **Truncation detection:** After receiving the tree response, check the `truncated` field in the JSON output. If `truncated: true`:
 - Display: "Note: GitHub API returned a truncated tree response ({count} items). Full analysis may require a local clone."
@@ -120,7 +122,7 @@ Identify the public API surface. **Delegate the parsing to `{extractPublicApiScr
 
 **Procedure when supported:**
 
-1. Read the relevant files into memory (no parsing yet — just collect content). For GitHub sources use `gh api repos/{owner}/{repo}/contents/{file}` with base64 decode; for local sources read directly.
+1. Read the relevant files into memory (no parsing yet — just collect content). For GitHub sources, issue **all N `gh api repos/{owner}/{repo}/contents/{file}` calls in a single message with N parallel Bash calls** (one per manifest + each entry point), then base64-decode the responses together — these are 2-4 independent fetches per typical run. For local sources read directly (also parallelisable, but local reads are fast enough that serial Read tool calls are acceptable).
 
    | Language | Manifest | Entry points (mode=quick) |
    |----------|----------|--------------------------|

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -67,7 +67,7 @@ Add, remove, or confirm these URLs."
 
 Wait for confirmation. Record any changes to `doc_urls`.
 
-For each URL in the final list (newly added or carried over), HEAD-check it (`curl -sI {url}` or equivalent). On a 4xx/5xx, DNS failure, or timeout, warn `"Could not reach {url} — {status or error}."` and offer the same correct/keep choice as step-01 §3. The check is best-effort — never HALT on a failed HEAD — but the failure must surface here so it is not discovered downstream during compilation.
+HEAD-check the URLs in parallel — issue all N `curl -sI --max-time 5 {url}` calls in a **single message with N parallel Bash calls**, then process the responses together. On a 4xx/5xx, DNS failure, or timeout per URL, warn `"Could not reach {url} — {status or error}."` and offer the same correct/keep choice as step-01 §3. The check is best-effort — never HALT on a failed HEAD — but the failure must surface here so it is not discovered downstream during compilation.
 
 **If no supplemental doc_urls were collected:** Skip this subsection.
 


### PR DESCRIPTION
## Summary

Theme 4 of the skf-brief-skill quality analysis (2026-05-02): three commits, all prose-only, no behaviour change.

- **Parallel doc_urls HEAD checks** in step-01 §3 and step-03 §2b — was sequential, now \"single message with N parallel Bash calls\" plus a 5s `--max-time` per call so a single hung host can't stall the workflow.
- **Parallel `gh api` calls** in step-02 §1 (repo-existence + recursive tree fetch) and §4 (manifest + entry-point file reads) — was sequential, now batched in one message with a discard rule for §1 if the repo-existence probe fails.
- **Lazy reference loading** — added a Workflow Rule to SKILL.md codifying \"load `references/*.md` and `assets/*.md` inside the section that needs them, not at step entry\", and tightened step-02 §4b to skip loading `version-resolution.md` when the script path of §4 already returned a version.

## What this is not

- **Not** a script change. The `--repo+--ref` extension to `skf-extract-public-api.py` (Theme 4 finding 4 — \"parent reads file content into context only to hand it to a script\") is deferred to a follow-up because it's a structural change to a shared script, not a brief-skill content edit. Filing as a separate issue would be the right call.
- **Not** a contract change. All headless inputs, exit codes, halt_reasons, and the SKF_BRIEF_RESULT_JSON envelope are byte-for-byte unchanged.

## Test plan

- [x] `npm run quality` passes on every commit
- [x] Spot-check on CI
- [x] Manual run against a public GitHub repo to confirm the parallel `gh api` batching actually fires (Bash tool collapses two calls into one round trip when sent in one message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)