### PR TITLE
refactor(skf-brief-skill): close lazy-load discipline gaps in steps 01/04/05

### DIFF
--- a/src/skf-brief-skill/assets/skill-brief-schema.md
+++ b/src/skf-brief-skill/assets/skill-brief-schema.md
@@ -171,46 +171,7 @@ scope:
 
 ## Human-Readable Presentation Format
 
-When presenting the brief for confirmation (brief-skill step 04 only — not applicable to analyze-source batch generation), display as:
-
-```
-Skill Brief: {name}
-====================
-
-Target:      {source_repo}
-Language:    {language}
-Forge Tier:  {forge_tier}
-Description: {description}
-
-Scope: {scope.type}
-  Include: {scope.include patterns, one per line}
-  Exclude: {scope.exclude patterns, one per line}
-  Notes:   {scope.notes}
-
-{If source_type is "docs-only":}
-Source Type: docs-only
-Doc URLs:
-  {doc_urls, one per line with labels}
-
-{If source_type is "source" AND supplemental doc_urls collected:}
-Supplemental Docs:
-  {doc_urls, one per line with labels}
-
-{If scripts_intent or assets_intent was explicitly set (not default "detect"):}
-Scripts:    {scripts_intent}
-Assets:     {assets_intent}
-
-Source Authority: {source_authority}
-
-{If target_version is set:}
-Target Version:   {target_version} (user-specified)
-Detected Version: {detected_version or "N/A"}
-{Else:}
-Version:    {version}
-{End if}
-Created:    {created}
-Created by: {created_by}
-```
+The runtime template lives in `steps-c/step-04-confirm-brief.md` §2 — that is the single source of truth for how the brief is rendered for user confirmation (brief-skill step-04 only; analyze-source batch generation does not render). If the rendering format needs to change, edit the step file. This asset documents the data contract; the step owns the presentation.
 
 ## Validation Rules
 

--- a/src/skf-brief-skill/references/qmd-collection-registration.md
+++ b/src/skf-brief-skill/references/qmd-collection-registration.md
@@ -1,0 +1,52 @@
+# QMD Collection Registration (Deep Tier)
+
+Loaded by step-05 §5 only when forge tier is Deep AND QMD is available. Skipped silently otherwise.
+
+Index the skill brief into a QMD collection so portfolio-level searches can find existing briefs and avoid duplicate skill creation across large monorepos.
+
+## Collection Creation
+
+Create a QMD collection targeting only the brief file:
+
+```bash
+qmd collection add {forge_data_folder}/{skill-name} --name {skill-name}-brief --mask "skill-brief.yaml"
+qmd embed
+```
+
+If the collection already exists (re-briefing): remove and recreate for atomic replace:
+
+```bash
+qmd collection remove {skill-name}-brief
+qmd collection add {forge_data_folder}/{skill-name} --name {skill-name}-brief --mask "skill-brief.yaml"
+qmd embed
+```
+
+## Embed Verification
+
+After `qmd embed` completes, verify the collection was embedded:
+
+- Run `qmd status` or `qmd collection list` and confirm `{skill-name}-brief` shows document count > 0
+- If verification succeeds: proceed to registry update with no `status` field
+- If verification fails: log warning "QMD embed verification failed for {skill-name}-brief — collection may not be searchable yet", proceed to registry update but include `status: "pending"` in the entry
+
+## Registry Update (Delegated to Script)
+
+Build the entry JSON and pipe it to the `register-qmd-collection` subcommand:
+
+```bash
+echo '{
+  "name": "{skill-name}-brief",
+  "type": "brief",
+  "source_workflow": "brief-skill",
+  "skill_name": "{skill-name}",
+  "created_at": "{current ISO date}"
+  // include "status": "pending" only when embed verification failed
+}' | uv run {forgeTierRwScript} register-qmd-collection --target {forgeTierFile}
+```
+
+The script handles the upsert deterministically (replace existing entry with same `name`, else append) and preserves all other forge-tier state (tools, tier, ccc_index, ccc_index_registry, other qmd_collections entries) — no need to reason about YAML re-rendering or section comments.
+
+## Error Handling
+
+- If `qmd embed` or `qmd collection add` fails: log the error. Do NOT fail the workflow — the brief file was already written successfully.
+- If the `register-qmd-collection` script call fails: log the error JSON, continue. The brief is the user-visible artifact; the registry entry is a portfolio-search optimisation.

--- a/src/skf-brief-skill/references/version-resolution.md
+++ b/src/skf-brief-skill/references/version-resolution.md
@@ -1,6 +1,6 @@
 # Version Resolution
 
-Single source of truth for how brief-skill resolves the `version` field of `skill-brief.yaml`. Loaded by steps 01 (gather), 02 (auto-detect), and 05 (resolve & write) so that all three operate on the same precedence rules and invariant.
+Single source of truth for how brief-skill resolves the `version` field of `skill-brief.yaml`. Loaded by step-02 §4b (auto-detect, fallback path only when the language is not script-supported) and step-05 §3 (resolve & write) so both operate on the same precedence rules and invariant. Step-01 §3b references this file in prose for human-readable rationale but does not load it — that step only collects `target_version` and validates its shape with an inline regex.
 
 **Aligned with** `assets/skill-brief-schema.md` "Version Detection" section. If you change one, change the other.
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -1,7 +1,6 @@
 ---
 nextStepFile: './step-02-analyze-target.md'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
-versionResolutionFile: 'references/version-resolution.md'
 validateBriefInputsScript: '{project-root}/src/shared/scripts/skf-validate-brief-inputs.py'
 ---
 
@@ -118,7 +117,7 @@ Confirm the target.
 
 ### 3b. Gather Target Version
 
-Load `{versionResolutionFile}` for the canonical precedence and invariant rules — this step only collects `target_version`; auto-detection runs in step 02 and resolution lands in step 05.
+This step only collects `target_version` and validates its shape with the regex below — auto-detection runs in step-02 and precedence/invariant resolution lands in step-05's writer script. The canonical precedence rules live in `references/version-resolution.md`; load it from step-02 / step-05 only when the relevant section needs it.
 
 **Headless:** if `target_version` was supplied as an argument, store it and skip the interactive prompt below. If `doc_urls` were also supplied, treat the version-vs-doc-URL confirmation prompt as auto-confirmed (Y).
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -244,7 +244,7 @@ Present:
 
 This is what shows up when agents discover the skill. Edit it, replace it, or accept as-is."
 
-Wait for user confirmation or alternative. Store the accepted text as the brief's `description` field. The same field is re-presented in step-04 §4 for a final review pass — refinements there flow back to this value.
+Wait for user confirmation or alternative. Store the accepted text as the brief's `description` field. The same field is re-presented in step-04 §3 for a final review pass — refinements there flow back to this value.
 
 **Headless:** if the `intent` argument was supplied, run the same synthesis against it and store the result. If `intent` was not supplied, derive from `target_repo` + `skill_name` (`"Use the {skill_name} skill to work with code or content from {target_repo}."`) and log `"warn: description synthesized without intent — narrow registry text."`
 

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -22,11 +22,7 @@ To present the complete skill brief in human-readable format, highlighting all f
 
 **CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
 
-### 1. Load Schema
-
-Load `{briefSchemaFile}` to reference required fields and the human-readable presentation format.
-
-### 2. Assemble Complete Brief
+### 1. Assemble Complete Brief
 
 Compile all gathered data from steps 01-03 into the complete brief:
 
@@ -49,9 +45,9 @@ Compile all gathered data from steps 01-03 into the complete brief:
 - **assets_intent:** {detect/none/description from step 03, or "detect" if not explicitly set}
 - **source_authority:** {official/community/internal from step 01 — default "community"}
 
-### 3. Present Brief for Review
+### 2. Present Brief for Review
 
-Using the presentation format from the schema:
+Using the format below:
 
 "**Review the complete skill brief before I write it.**
 
@@ -112,7 +108,7 @@ Glosses (substitute the matching one-liner for `{tier_gloss}`, `{scripts_gloss}`
 
 (For `docs-only` and `public-api` scope types the scripts/assets prompt is skipped in step-03 §5b — the values default to `detect` but the create-skill detection pass also no-ops for these scope types, so the gloss just clarifies that the recorded value will not actually fire any scan.)"
 
-### 4. Highlight Items Needing Attention
+### 3. Highlight Items Needing Attention
 
 Flag any fields that may need review:
 
@@ -137,14 +133,15 @@ You can:
 - Revise scope boundaries by selecting [R]
 - Proceed to write by selecting [C]"
 
-### 5. Handle Inline Adjustments
+### 4. Handle Inline Adjustments
 
 If the user requests changes to specific fields (name, description, version, etc.):
+- If the adjustment requires explaining a field's validation rule or allowed values, load `{briefSchemaFile}` now (otherwise skip the read — the common path does not need it)
 - Make the adjustment
 - Re-present the updated brief
 - Return to the menu
 
-### 6. Present MENU OPTIONS
+### 5. Present MENU OPTIONS
 
 Display: **Select an Option:** [R] Revise Scope [A] Advanced Elicitation [P] Party Mode [C] Approve and Write
 
@@ -154,7 +151,7 @@ Display: **Select an Option:** [R] Revise Scope [A] Advanced Elicitation [P] Par
 - IF A: Invoke {advancedElicitationSkill}, and when finished redisplay the menu
 - IF P: Invoke {partyModeSkill}, and when finished redisplay the menu
 - IF C: Load, read entire file, then execute {nextStepFile}
-- IF Any other comments or queries: help user respond, apply any field adjustments, re-present brief if changed, then [Redisplay Menu Options](#6-present-menu-options)
+- IF Any other comments or queries: help user respond, apply any field adjustments, re-present brief if changed, then [Redisplay Menu Options](#5-present-menu-options)
 
 #### EXECUTION RULES:
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -1,6 +1,7 @@
 ---
 briefSchemaFile: 'assets/skill-brief-schema.md'
 versionResolutionFile: 'references/version-resolution.md'
+qmdRegistrationFile: 'references/qmd-collection-registration.md'
 nextStepFile: './step-06-health-check.md'
 writeSkillBriefScript: '{project-root}/src/shared/scripts/skf-write-skill-brief.py'
 emitBriefEnvelopeScript: '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
@@ -132,54 +133,9 @@ When `{headless_mode}` is false, skip this section silently — no envelope is e
 
 ### 5. QMD Collection Registration (Deep Tier Only)
 
-**IF forge tier is Deep AND QMD tool is available:**
+**IF forge tier is Deep AND QMD tool is available:** load `{qmdRegistrationFile}` and follow the procedure there to index the brief into a QMD collection and update the forge-tier registry.
 
-Index the skill brief into a QMD collection so portfolio-level searches can find existing briefs and avoid duplicate skill creation across large monorepos.
-
-**Collection creation:**
-
-Create a QMD collection targeting only the brief file:
-```bash
-qmd collection add {forge_data_folder}/{skill-name} --name {skill-name}-brief --mask "skill-brief.yaml"
-qmd embed
-```
-
-If collection already exists (re-briefing): remove and recreate for atomic replace:
-```bash
-qmd collection remove {skill-name}-brief
-qmd collection add {forge_data_folder}/{skill-name} --name {skill-name}-brief --mask "skill-brief.yaml"
-qmd embed
-```
-
-**Embed verification:**
-
-After `qmd embed` completes, verify the collection was embedded:
-- Run `qmd status` or `qmd collection list` and confirm `{skill-name}-brief` shows document count > 0
-- If verification succeeds: proceed to registry update with no `status` field
-- If verification fails: log warning "QMD embed verification failed for {skill-name}-brief — collection may not be searchable yet", proceed to registry update but include `status: "pending"` in the entry
-
-**Registry update (delegated to script):**
-
-Build the entry JSON and pipe it to the `register-qmd-collection` subcommand:
-
-```bash
-echo '{
-  "name": "{skill-name}-brief",
-  "type": "brief",
-  "source_workflow": "brief-skill",
-  "skill_name": "{skill-name}",
-  "created_at": "{current ISO date}"
-  // include "status": "pending" only when embed verification failed
-}' | uv run {forgeTierRwScript} register-qmd-collection --target {forgeTierFile}
-```
-
-The script handles the upsert deterministically (replace existing entry with same `name`, else append) and preserves all other forge-tier state (tools, tier, ccc_index, ccc_index_registry, other qmd_collections entries) — no need to reason about YAML re-rendering or section comments.
-
-**Error handling:**
-- If `qmd embed` or `qmd collection add` fails: log the error. Do NOT fail the workflow — the brief file was already written successfully.
-- If the `register-qmd-collection` script call fails: log the error JSON, continue. The brief is the user-visible artifact; the registry entry is a portfolio-search optimisation.
-
-**IF forge tier is NOT Deep:** Skip this section silently. No messaging.
+**IF forge tier is NOT Deep OR QMD is not available:** skip this section silently — do not load `{qmdRegistrationFile}`. No messaging.
 
 ### 6. Display Success Summary
 


### PR DESCRIPTION
## Summary

Closes the four lazy-load gaps surfaced by the [skf-brief-skill quality analysis](skills/reports/skf-brief-skill/quality-analysis/20260502-201702/quality-report.md) (Theme 1 — medium severity). Each commit fixes one finding; behaviour on the common path is unchanged.

- **18f4835e** — Drop the unconditional schema-load at step-04 §1; gate it to §4 inline-adjustments only (matches step-05's existing discipline). Saves ~18 KB / ~5K tokens per typical run.
- **70500598** — Drop the unused `versionResolutionFile` load + frontmatter alias from step-01 §3b (the precedence/invariant logic lives in step-02/05 and the writer script). Saves ~3 KB / ~750 tokens per run.
- **dd6b8e06** — De-duplicate the brief presentation format. Step-04 §2 is the runtime renderer and the only consumer; reduce the schema asset's drifted copy to a one-line pointer back to the step.
- **44910ab2** — Extract step-05 §5 QMD-collection registration (~50 lines, Deep-tier-only) to `references/qmd-collection-registration.md` and replace the body with a tier-gated `Load` directive. Saves ~50 lines per non-Deep run.
- **e3f83f3d** — Doc fix from in-PR review: update `references/version-resolution.md` preamble to reflect that step-01 no longer loads it.

Aggregate: ~22 KB / ~6K tokens of context savings per typical run, no behaviour change on the common path.

## Test plan

- [x] `npm run quality` passes locally (full suite ran via pre-commit hook on every commit — green)
- [x] CI green on PR
- [x] Sanity-run the workflow (interactive) on a small target to confirm step-04 still renders the brief and step-05 still writes; tier-gated QMD branch only fires on Deep tier as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)