### PR TITLE
refactor(skf-brief-skill): prompt-craft cleanups for design-discipline drift

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -25,7 +25,7 @@ These rules apply to every step in this workflow:
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - **Lazy-load references and assets:** `references/*.md` and `assets/*.md` files are loaded inside the section that needs them, not at step entry. If a section is skipped (e.g. `version-resolution.md` when `{extractPublicApiScript}` already returned a version, `scope-templates.md` for the `docs-only` branch that bypasses §2c), do not load that file. Each unnecessary load costs context (~5-10 KB per reference) and biases the LLM toward consulting material the current path does not need.
-- Always communicate in `{communication_language}`
+- Always communicate in `{communication_language}` (the language for user-facing prose). Written artifact text — the `description`, `notes`, and other free-form fields persisted into `skill-brief.yaml` — is in `{document_output_language}`; per-step rules call this out where it applies (see step-05). The two values may be the same.
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -95,7 +95,7 @@ Skip §3.3 and continue at "Confirm the target" below.
 #### 3.3 Branch — Source (GitHub URL or local path)
 
 - Set `source_type: "source"` (default)
-- **Pre-validate the target before continuing — fail fast at point of capture, not 5+ minutes later in step-02.** Issue these probes in a single message with parallel Bash calls:
+- **Pre-validate the target before continuing.** Issue these probes in a single message with parallel Bash calls:
   - **GitHub URL:** `curl -sI --max-time 5 {url}`. On a 4xx (typically 404 for a typo'd repo or org), warn `"GitHub returned {status} for {url} — confirm the URL is correct."` and re-prompt. On 2xx, accept. (The full `gh api repos/{owner}/{repo}` check still runs in step-02 §1 to catch private-repo access issues — this HEAD probe is just for typo catch.)
   - **GitHub URL, in parallel with the above:** `gh auth status` — if it reports unauthenticated or the binary is missing, warn `"GitHub CLI not authenticated; step-02 will HALT when it tries to fetch the tree. Run 'gh auth login' before continuing, or supply a local clone path instead."` (Do not HALT here — let the user choose to fix or proceed; the canonical HALT still happens in step-02 §1's failure-class triage.)
   - **Local path:** verify the directory exists (`test -d {path}`). If not, warn `"Local path {path} does not exist."` and re-prompt.
@@ -129,7 +129,7 @@ This step only collects `target_version` and validates its shape with the regex 
 
 Wait for user response.
 
-**If user provides a version:** Validate the shape against `^v?\d+\.\d+\.\d+([.\-+][0-9A-Za-z][0-9A-Za-z.\-+]*)?$` (full X.Y.Z form, with optional `v` prefix and pre-release / build suffix; CalVer like `2024.04.01` accepted; partial forms like `1`, `1.2`, `v2`, `latest` rejected). On a match, store as `target_version` and set `version` to this value. On a non-match, warn `"'{value}' doesn't look like semver — write the explicit triple (e.g. 1.0.0). Fix it now or skip auto-detection?"` and re-prompt for a corrected value or blank to fall through to step-02 auto-detection. Catching this here prevents the step-05 invariant check (`brief.target_version == brief.version` per `references/version-resolution.md`) from blowing up after the user has already approved the brief.
+**If user provides a version:** Validate the shape against `^v?\d+\.\d+\.\d+([.\-+][0-9A-Za-z][0-9A-Za-z.\-+]*)?$` (full X.Y.Z form, with optional `v` prefix and pre-release / build suffix; CalVer like `2024.04.01` accepted; partial forms like `1`, `1.2`, `v2`, `latest` rejected). On a match, store as `target_version` and set `version` to this value. On a non-match, warn `"'{value}' doesn't look like semver — write the explicit triple (e.g. 1.0.0). Fix it now or skip auto-detection?"` and re-prompt for a corrected value or blank to fall through to step-02 auto-detection.
 **If blank:** Proceed without `target_version` — version will be auto-detected in step 02.
 
 {If target_version was set AND doc_urls are being collected (either docs-only primary or supplemental):}

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -175,19 +175,19 @@ Wait for confirmation or alternative.
 
 **Collision check (interactive and headless):** before locking the name, check whether `{forge_data_folder}/{name}/skill-brief.yaml` already exists. If it does:
 
-- Interactive: generate 2–3 non-colliding candidate alternates by scanning sibling directories under `{forge_data_folder}/`. Apply each rule that fires; skip rules whose precondition isn't met:
+- Interactive: generate 1–3 non-colliding candidate alternates by scanning sibling directories under `{forge_data_folder}/`. Apply each rule that fires; skip rules whose precondition isn't met:
   1. `{name}-v{N}` where `N` is the smallest positive integer that doesn't collide (e.g. `{name}-v2`, `{name}-v3`) — always applies
   2. `{name}-{target_version}` if `target_version` is set and the suffix wouldn't collide (e.g. `marked-1.2.3`)
   3. `{name}-{source_authority}` if `source_authority` is not `community` (e.g. `marked-internal` for an internal fork)
 
-  Number the surviving alternates `[1] [2] [3]…` in the order produced (typically 2 alternates for community-authority briefs, 3 otherwise). Then present:
+  Number the surviving alternates `[1] [2] [3]…` in the order produced (1 alternate for a community-authority brief with no `target_version`; 2–3 otherwise). Then present:
 
   ```
   **Heads up — a brief for `{name}` already exists at `{path}`.**
 
   Suggested alternates (none collide):
     [1] {alternate-1}
-    [2] {alternate-2}
+    {if a second alternate was produced:} [2] {alternate-2}
     {if a third alternate was produced:} [3] {alternate-3}
 
   Pick a number to use that name, type a different name, or press Enter to keep `{name}` and let step-05 §2b handle the overwrite prompt.

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -175,12 +175,12 @@ Wait for confirmation or alternative.
 
 **Collision check (interactive and headless):** before locking the name, check whether `{forge_data_folder}/{name}/skill-brief.yaml` already exists. If it does:
 
-- Interactive: generate three candidate alternates by scanning sibling directories under `{forge_data_folder}/`:
-  1. `{name}-v{N}` where `N` is the smallest positive integer that doesn't collide (e.g. `{name}-v2`, `{name}-v3`)
+- Interactive: generate 2–3 non-colliding candidate alternates by scanning sibling directories under `{forge_data_folder}/`. Apply each rule that fires; skip rules whose precondition isn't met:
+  1. `{name}-v{N}` where `N` is the smallest positive integer that doesn't collide (e.g. `{name}-v2`, `{name}-v3`) — always applies
   2. `{name}-{target_version}` if `target_version` is set and the suffix wouldn't collide (e.g. `marked-1.2.3`)
-  3. `{name}-{source_authority}` if not `community` (e.g. `marked-internal` for an internal fork)
+  3. `{name}-{source_authority}` if `source_authority` is not `community` (e.g. `marked-internal` for an internal fork)
 
-  Then present:
+  Number the surviving alternates `[1] [2] [3]…` in the order produced (typically 2 alternates for community-authority briefs, 3 otherwise). Then present:
 
   ```
   **Heads up — a brief for `{name}` already exists at `{path}`.**
@@ -188,7 +188,7 @@ Wait for confirmation or alternative.
   Suggested alternates (none collide):
     [1] {alternate-1}
     [2] {alternate-2}
-    [3] {alternate-3}
+    {if a third alternate was produced:} [3] {alternate-3}
 
   Pick a number to use that name, type a different name, or press Enter to keep `{name}` and let step-05 §2b handle the overwrite prompt.
   ```

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -100,7 +100,7 @@ echo '<context-json>' | uv run {writeSkillBriefScript} write --target {resolved-
 
 The script:
 - Validates the context against `src/shared/scripts/schemas/skill-brief.v1.json`
-- Applies the version-precedence rule from `{versionResolutionFile}` (target_version > detected_version > 1.0.0)
+- Applies the version-precedence rule from `{versionResolutionFile}`
 - Enforces the `target_version == version` invariant (refuses to write a brief that violates it)
 - Renders YAML in canonical key order (byte-stable across runs)
 - Atomically writes the file via temp + fsync + rename (no half-written file ever visible)


### PR DESCRIPTION
## Summary

Theme 5 of the skf-brief-skill quality analysis (low severity, 4 findings + 1 reviewer follow-up). Pure prompt-craft drift — none affect correctness, but together they remove apparent contradictions, drop invitations to second-guess deterministic scripts, and align prescriptions with what the rules actually generate.

- **657def2e** — `docs(skf-brief-skill): clarify communication_language vs document_output_language in Workflow Rules`. Promotes the distinction one level up so step-05's local rule reads as a refinement, not a contradiction.
- **7334e872** — `refactor(skf-brief-skill): drop version-precedence restatement in step-05 §3`. Removes the parenthetical `(target_version > detected_version > 1.0.0)` — the rule lives in `{versionResolutionFile}` and is enforced by the writer script.
- **ae21df1e** — `refactor(skf-brief-skill): soften "three alternates" to "2-3 non-colliding" in step-01 §6`. Aligns the prescription with what the rules generate (rule 3 only fires when `source_authority` isn't `community`).
- **e3ee08a8** — `refactor(skf-brief-skill): trim maintainer-rationale narrative from step-01 runtime instructions`. Drops two phrases that explained *why* without changing LLM behaviour.
- **ccc431a0** — `refactor(skf-brief-skill): guard [2] alternate render in step-01 §6 collision template`. In-PR review caught that the template guarded `[3]` but left `[2]` unconditional — a community-authority brief with no `target_version` produces only 1 alternate.

## Test plan

- [x] `npm run quality` passes locally (full suite ran via pre-commit hook on every commit — green)
- [x] CI green on PR
- [x] Sanity-run the workflow against a target where collision logic fires (a community-authority brief whose name already exists in `{forge_data_folder}`) and confirm the alternate-presentation block renders [1] only when target_version is unset — i.e. no orphan `[2] {alternate-2}` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)