### PR TITLE
feat(skf-brief-skill): add [X] Cancel affordance and pre-flight write probe

### DIFF
--- a/src/shared/scripts/schemas/skf-brief-result-envelope.v1.json
+++ b/src/shared/scripts/schemas/skf-brief-result-envelope.v1.json
@@ -36,8 +36,8 @@
     },
     "exit_code": {
       "type": "integer",
-      "enum": [0, 2, 3, 4, 5],
-      "description": "Process exit code matching the SKILL.md Exit Codes table. Derived deterministically from halt_reason: null→0, input-missing/input-invalid→2, forge-tier-missing/target-inaccessible/gh-auth-failed→3, write-failed→4, overwrite-cancelled→5."
+      "enum": [0, 2, 3, 4, 5, 6],
+      "description": "Process exit code matching the SKILL.md Exit Codes table. Derived deterministically from halt_reason: null→0, input-missing/input-invalid→2, forge-tier-missing/target-inaccessible/gh-auth-failed→3, write-failed→4, overwrite-cancelled→5, user-cancelled→6."
     },
     "halt_reason": {
       "type": ["string", "null"],
@@ -49,7 +49,8 @@
         "target-inaccessible",
         "gh-auth-failed",
         "write-failed",
-        "overwrite-cancelled"
+        "overwrite-cancelled",
+        "user-cancelled"
       ],
       "description": "Null on success. One of the documented HALT classes on error. Pipelines branch on this to surface the right operator message without grepping the prose error."
     }

--- a/src/shared/scripts/skf-emit-brief-result-envelope.py
+++ b/src/shared/scripts/skf-emit-brief-result-envelope.py
@@ -44,13 +44,13 @@ Context payload shape (consumed by `emit`):
     "halt_reason": null | "input-missing" | "input-invalid" |
                    "forge-tier-missing" | "target-inaccessible" |
                    "gh-auth-failed" | "write-failed" |
-                   "overwrite-cancelled"
+                   "overwrite-cancelled" | "user-cancelled"
   }
 
 The caller does NOT supply exit_code — the script derives it from
 halt_reason via the canonical mapping (null→0; input-*→2;
 forge-tier-missing/target-inaccessible/gh-auth-failed→3;
-write-failed→4; overwrite-cancelled→5).
+write-failed→4; overwrite-cancelled→5; user-cancelled→6).
 
 Cross-platform: pure stdlib, no third-party deps.
 
@@ -80,6 +80,7 @@ VALID_HALT_REASONS = {
     "gh-auth-failed",
     "write-failed",
     "overwrite-cancelled",
+    "user-cancelled",
 }
 VALID_SCOPE_TYPES = {
     None,
@@ -101,6 +102,7 @@ HALT_TO_EXIT = {
     "gh-auth-failed": 3,
     "write-failed": 4,
     "overwrite-cancelled": 5,
+    "user-cancelled": 6,
 }
 
 # Envelope key order — fixed so byte-stable diffs are possible.

--- a/src/shared/scripts/skf-emit-brief-result-envelope.py
+++ b/src/shared/scripts/skf-emit-brief-result-envelope.py
@@ -181,7 +181,7 @@ def validate(envelope: dict[str, Any]) -> None:
         _die(f"halt_reason invalid: {envelope.get('halt_reason')!r}")
     if envelope.get("scope_type") not in VALID_SCOPE_TYPES:
         _die(f"scope_type invalid: {envelope.get('scope_type')!r}")
-    if envelope.get("exit_code") not in {0, 2, 3, 4, 5}:
+    if envelope.get("exit_code") not in {0, 2, 3, 4, 5, 6}:
         _die(f"exit_code invalid: {envelope.get('exit_code')!r}")
     expected_exit = HALT_TO_EXIT[envelope.get("halt_reason")]
     if envelope.get("exit_code") != expected_exit:

--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -60,6 +60,7 @@ Every HARD HALT in this workflow exits with a stable code so headless automators
 | 3    | resolution-failure   | step-01 §1 (`forge-tier.yaml` missing); step-02 §1 (target inaccessible / `gh auth` fails) |
 | 4    | write-failure        | step-05 §4 (write to `{forge_data_folder}/{skill-name}/skill-brief.yaml` failed)           |
 | 5    | overwrite-cancelled  | step-05 §2 (existing brief, `force` not supplied)                                          |
+| 6    | user-cancelled       | any interactive menu in step-01/03/04 (user selected `[X]` Cancel and exit)                |
 
 ## Result Contract (Headless)
 
@@ -69,7 +70,7 @@ When `{headless_mode}` is true, step-05 emits a single-line JSON envelope on **s
 SKF_BRIEF_RESULT_JSON: {"status":"success|error","brief_path":"…|null","skill_name":"…","version":"…|null","language":"…|null","scope_type":"…|null","exit_code":0,"halt_reason":null}
 ```
 
-`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`. `exit_code` matches the table above.
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 

--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -58,7 +58,7 @@ Every HARD HALT in this workflow exits with a stable code so headless automators
 | 0    | success              | step-06 (terminal)                                                                         |
 | 2    | input-missing / input-invalid | step-01 GATE — required headless arg absent (`target_repo`, `skill_name`, or `doc_urls` when `source_type=docs-only`) → `input-missing`; enum violation, malformed semver, non-kebab `skill_name`, or step-05 brief-context schema validation failure → `input-invalid` |
 | 3    | resolution-failure   | step-01 §1 (`forge-tier.yaml` missing); step-02 §1 (target inaccessible / `gh auth` fails) |
-| 4    | write-failure        | step-05 §4 (write to `{forge_data_folder}/{skill-name}/skill-brief.yaml` failed)           |
+| 4    | write-failure        | step-01 §1 pre-flight write probe (data folder unwritable: read-only mount, disk full, permissions denied); step-05 §4 (write to `{forge_data_folder}/{skill-name}/skill-brief.yaml` failed) |
 | 5    | overwrite-cancelled  | step-05 §2 (existing brief, `force` not supplied)                                          |
 | 6    | user-cancelled       | any interactive menu in step-01/03/04 (user selected `[X]` Cancel and exit)                |
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -25,6 +25,16 @@ To initialize the brief-skill workflow by discovering the forge tier configurati
 
 ### 1. Discover Forge Tier
 
+**Pre-flight write probe.** Before any conversational state accumulates, verify `{forge_data_folder}` is writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces at step-05's atomic write — by then the user has invested 5–15 minutes. Run a single-byte write-and-remove probe:
+
+```bash
+mkdir -p "{forge_data_folder}" && \
+  printf 'probe' > "{forge_data_folder}/.skf-write-probe" && \
+  rm "{forge_data_folder}/.skf-write-probe"
+```
+
+`mkdir -p` succeeds on a pre-existing read-only mount, but the `printf > file` redirect actually attempts a write — that catches read-only, disk-full, and permissions-denied uniformly. **On any non-zero exit:** HALT (exit code 4, `halt_reason: "write-failed"`) — `"**Error:** {forge_data_folder} is not writable: {captured stderr}. Verify the path exists, the mount is writable, and there is free disk space, then re-run."` In headless mode, emit the error-variant `SKF_BRIEF_RESULT_JSON` envelope on stderr with `halt_reason: "write-failed"` (per the SKILL.md Result Contract) before exiting. On success, continue silently to the forge-tier load below.
+
 Attempt to load `{forgeTierFile}`:
 
 **If found:**

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -244,11 +244,12 @@ Wait for user confirmation or alternative. Store the accepted text as the brief'
 
 ### 8. Present MENU OPTIONS
 
-Display: "**Select:** [C] Continue to Target Analysis"
+Display: "**Select:** [C] Continue to Target Analysis · [X] Cancel and exit"
 
 #### Menu Handling Logic:
 
 - IF C: Load, read entire file, then execute {nextStepFile}
+- IF X: Treat as user-cancellation. Display `"Cancelled — no brief was written."` and HALT (exit code 6, `halt_reason: "user-cancelled"`). When `{headless_mode}` is true the GATE auto-proceeds and never reaches this branch — `[X]` is interactive-only. Cancellation here is non-destructive: no files have been written yet by step-01.
 - IF Any other: Help user, then [Redisplay Menu Options](#8-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -4,6 +4,7 @@ forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 descriptionVoiceExamplesFile: 'assets/description-voice-examples.md'
 headlessArgsFile: 'references/headless-args.md'
 validateBriefInputsScript: '{project-root}/src/shared/scripts/skf-validate-brief-inputs.py'
+emitBriefEnvelopeScript: '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
 ---
 
 # Step 1: Gather Intent
@@ -33,7 +34,7 @@ mkdir -p "{forge_data_folder}" && \
   rm "{forge_data_folder}/.skf-write-probe"
 ```
 
-`mkdir -p` succeeds on a pre-existing read-only mount, but the `printf > file` redirect actually attempts a write — that catches read-only, disk-full, and permissions-denied uniformly. **On any non-zero exit:** HALT (exit code 4, `halt_reason: "write-failed"`) — `"**Error:** {forge_data_folder} is not writable: {captured stderr}. Verify the path exists, the mount is writable, and there is free disk space, then re-run."` In headless mode, emit the error-variant `SKF_BRIEF_RESULT_JSON` envelope on stderr with `halt_reason: "write-failed"` (per the SKILL.md Result Contract) before exiting. On success, continue silently to the forge-tier load below.
+`mkdir -p` succeeds on a pre-existing read-only mount, but the `printf > file` redirect actually attempts a write — that catches read-only, disk-full, and permissions-denied uniformly. **On any non-zero exit:** HALT (exit code 4, `halt_reason: "write-failed"`) — `"**Error:** {forge_data_folder} is not writable: {captured stderr}. Verify the path exists, the mount is writable, and there is free disk space, then re-run."` In headless mode, invoke `{emitBriefEnvelopeScript} emit --target stderr` with envelope-context `{"status":"error","skill_name":"<name-or-pre-resolution-placeholder>","halt_reason":"write-failed"}` before exiting (matches the §8 GATE / step-05 emit pattern — never hand-assemble the envelope JSON). On success, continue silently to the forge-tier load below.
 
 Attempt to load `{forgeTierFile}`:
 

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -154,13 +154,14 @@ Record the response as `scripts_intent` and `assets_intent` in the brief. Defaul
 
 ### 6. Present MENU OPTIONS
 
-Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Brief Confirmation
+Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Brief Confirmation [X] Cancel and exit
 
 #### Menu Handling Logic:
 
 - IF A: Invoke {advancedElicitationSkill}, and when finished redisplay the menu
 - IF P: Invoke {partyModeSkill}, and when finished redisplay the menu
 - IF C: Load, read entire file, then execute {nextStepFile}
+- IF X: Treat as user-cancellation. Display `"Cancelled — no brief was written."` and HALT (exit code 6, `halt_reason: "user-cancelled"`). Cancellation here is non-destructive — no files have been written yet. `[X]` is interactive-only; the headless GATE never reaches this branch.
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#6-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -143,7 +143,7 @@ If the user requests changes to specific fields (name, description, version, etc
 
 ### 5. Present MENU OPTIONS
 
-Display: **Select an Option:** [R] Revise Scope [A] Advanced Elicitation [P] Party Mode [C] Approve and Write
+Display: **Select an Option:** [R] Revise Scope [A] Advanced Elicitation [P] Party Mode [C] Approve and Write [X] Cancel and exit
 
 #### Menu Handling Logic:
 
@@ -151,6 +151,7 @@ Display: **Select an Option:** [R] Revise Scope [A] Advanced Elicitation [P] Par
 - IF A: Invoke {advancedElicitationSkill}, and when finished redisplay the menu
 - IF P: Invoke {partyModeSkill}, and when finished redisplay the menu
 - IF C: Load, read entire file, then execute {nextStepFile}
+- IF X: Treat as user-cancellation. Display `"Cancelled — no brief was written."` and HALT (exit code 6, `halt_reason: "user-cancelled"`). Cancellation here is non-destructive — step-05 has not run, no skill-brief.yaml file exists yet. `[X]` is interactive-only; the headless GATE never reaches this branch.
 - IF Any other comments or queries: help user respond, apply any field adjustments, re-present brief if changed, then [Redisplay Menu Options](#5-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -125,9 +125,9 @@ echo '{"status":"success","brief_path":"<from §3 response>","skill_name":"<name
   uv run {emitBriefEnvelopeScript} emit
 ```
 
-The script derives `exit_code` deterministically from `halt_reason` (the canonical mapping is null→0, input-missing/input-invalid→2, forge-tier-missing/target-inaccessible/gh-auth-failed→3, write-failed→4, overwrite-cancelled→5), validates against `src/shared/scripts/schemas/skf-brief-result-envelope.v1.json`, and prints the prefixed `SKF_BRIEF_RESULT_JSON: {…}` line.
+The script derives `exit_code` deterministically from `halt_reason` (the canonical mapping is null→0, input-missing/input-invalid→2, forge-tier-missing/target-inaccessible/gh-auth-failed→3, write-failed→4, overwrite-cancelled→5, user-cancelled→6 [interactive-only — headless never raises this]), validates against `src/shared/scripts/schemas/skf-brief-result-envelope.v1.json`, and prints the prefixed `SKF_BRIEF_RESULT_JSON: {…}` line.
 
-The envelope shape on HARD HALT (any phase) is the same call with `--target stderr`, `status: "error"`, and the matching `halt_reason` (one of `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`) — see the §3, §2b, §5 (no-halt) branches above and the §1/§2 HALTs in step-01/step-02 for invocation sites. The script enforces the success/error halt_reason invariant (success requires null halt_reason; error requires non-null).
+The envelope shape on HARD HALT (any phase) is the same call with `--target stderr`, `status: "error"`, and the matching `halt_reason` (one of `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`) — see the §3, §2b, §5 (no-halt) branches above and the §1/§2 HALTs in step-01/step-02 for invocation sites. The script enforces the success/error halt_reason invariant (success requires null halt_reason; error requires non-null). The `user-cancelled` halt_reason is also accepted by the script for completeness (interactive `[X]` Cancel sites in step-01/03/04 use it) but never appears on the headless code path.
 
 When `{headless_mode}` is false, skip this section silently — no envelope is emitted.
 

--- a/test/test-skf-emit-brief-result-envelope.py
+++ b/test/test-skf-emit-brief-result-envelope.py
@@ -80,6 +80,7 @@ class TestAssemble:
             ("gh-auth-failed", 3),
             ("write-failed", 4),
             ("overwrite-cancelled", 5),
+            ("user-cancelled", 6),
         ],
     )
     def test_halt_reason_to_exit_code_mapping(self, halt, expected_exit):

--- a/test/test-skf-emit-brief-result-envelope.py
+++ b/test/test-skf-emit-brief-result-envelope.py
@@ -208,6 +208,19 @@ class TestValidate:
         }
         mod.validate(env)
 
+    def test_exit_code_6_for_user_cancelled(self):
+        env = {
+            "status": "error",
+            "brief_path": None,
+            "skill_name": "foo",
+            "version": None,
+            "language": None,
+            "scope_type": None,
+            "exit_code": 6,
+            "halt_reason": "user-cancelled",
+        }
+        mod.validate(env)  # must not raise — user-cancelled→6 is canonical
+
 
 # --------------------------------------------------------------------------
 # CLI: emit


### PR DESCRIPTION
## Summary

Theme 4 part 1 of the [skf-brief-skill quality analysis](skills/reports/skf-brief-skill/quality-analysis/20260502-201702/quality-report.md) — two of the five non-first-timer affordances. The remaining three (`--preset`, draft checkpoint, QMD similarity) ship in the next PR for isolated review.

- **c44cc55d** — `feat(skf-brief-skill): add [X] Cancel and exit affordance with stable exit code 6`. Adds `[X] Cancel and exit` to every interactive menu (step-01 §8, step-03 §6, step-04 §5). Cancellation emits the standard `SKF_BRIEF_RESULT_JSON` envelope with new `halt_reason: "user-cancelled"` mapped to exit code 6. Non-destructive at every site (step-05 has not run, no skill-brief.yaml exists). Contract surface updated in lockstep: SKILL.md Exit Codes table, SKILL.md Result Contract, schema enum, emit-script `VALID_HALT_REASONS` + `HALT_TO_EXIT`, parametrized assemble-mapping test.
- **caaab468** — `feat(skf-brief-skill): add 50ms pre-flight write probe at step-01 §1`. Single-byte `mkdir -p` + `printf > file` + `rm` probe runs before any conversational state accumulates. Catches read-only mounts, disk-full, and permissions-denied uniformly. Reuses the existing `write-failed` halt_reason / exit code 4 — no new contract surface.
- **6fb5df20** — `fix(skf-brief-skill): close contract gaps for [X] cancel and write probe`. In-PR review caught one critical bug, two prose drifts, and one factually-incomplete cross-reference:
  - **Critical:** `skf-emit-brief-result-envelope.py validate()` had a hardcoded `{0,2,3,4,5}` allowlist that I missed when extending the canonical maps — `assemble()` produced exit_code 6 correctly but `validate()` rejected the same envelope. Added 6 + a regression test (`test_exit_code_6_for_user_cancelled`) so the divergence cannot recur silently.
  - Step-05 §4b inline mapping enumeration omitted `user-cancelled→6`. Annotated as `[interactive-only — headless never raises this]`.
  - Step-01 §1 probe HALT prose said only "emit the SKF_BRIEF_RESULT_JSON envelope on stderr" — replaced with the explicit `{emitBriefEnvelopeScript} emit --target stderr` delegation pattern that step-05 §2b/§3 already use, and added the alias to step-01 frontmatter. Avoids the schema-drift footgun the emit script was built to prevent.
  - SKILL.md Exit Codes table credited only step-05 §4 as the raiser of exit 4. Step-01 §1 is now also a raiser; updated the row to list both sites.

715 Python tests pass.

## Test plan

- [x] `npm run quality` passes locally (full suite ran via pre-commit hook on every commit — green)
- [x] CI green on PR
- [x] Sanity-test [X] cancel: start a brief interactively, type `[X]` at any of the three menus, confirm it exits cleanly with exit code 6 and emits the user-cancelled envelope
- [x] Sanity-test write probe: temporarily set `forge_data_folder` in config to a path on a read-only mount (e.g. `/proc/skf-test`) or with a chmod 000 directory, confirm step-01 §1 HALTs immediately with exit 4 and `halt_reason: "write-failed"` before any forge-tier work begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)