### PR TITLE
feat(skf-brief-skill): add --preset, draft checkpoint, and QMD portfolio similarity

### DIFF
--- a/src/shared/scripts/skf-validate-brief-inputs.py
+++ b/src/shared/scripts/skf-validate-brief-inputs.py
@@ -76,6 +76,7 @@ KNOWN_FIELDS = {
     "include",
     "exclude",
     "force",
+    "preset",
 }
 
 VALID_SOURCE_TYPES = {"source", "docs-only"}

--- a/src/shared/scripts/skf-validate-brief-inputs.py
+++ b/src/shared/scripts/skf-validate-brief-inputs.py
@@ -76,8 +76,12 @@ KNOWN_FIELDS = {
     "include",
     "exclude",
     "force",
-    "preset",
 }
+# `preset` is intentionally NOT in KNOWN_FIELDS — it is consumed at the step-01 §8 GATE
+# (the LLM merges the named preset YAML into the args dict and drops the `preset` key
+# before calling the validator). If the key leaks through, the validator's existing
+# unknown-field handling emits `"unrecognized field 'preset' — passed through unchanged"`
+# in `warnings[]` so the missed drop is debuggable rather than silent.
 
 VALID_SOURCE_TYPES = {"source", "docs-only"}
 VALID_SOURCE_AUTHORITIES = {"official", "community", "internal"}

--- a/src/skf-brief-skill/references/headless-args.md
+++ b/src/skf-brief-skill/references/headless-args.md
@@ -19,3 +19,4 @@ Loaded by step-01 §8 only when `{headless_mode}` is true. Canonical operator-fa
 | `assets_intent` | no | `detect` | `detect` / `none` / free-text |
 | `intent` | no | — | Free-text used to derive `description` in §7b |
 | `force` | no | — | Overwrite existing brief without prompting (consumed in step-05 §2b) |
+| `preset` | no | — | Name of a preset YAML file at `{sidecar_path}/brief-presets/{preset}.yaml`. Loaded at step-01 §8 GATE and merged as defaults; explicit args override preset values. Useful for repeated patterns (e.g. briefing 5 SaaS API SDKs with the same `source_authority`/`scope_type`/`scripts_intent`). The preset file is YAML containing any subset of the headless args above; unknown fields are ignored with a warning |

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -268,6 +268,8 @@ Display: "**Select:** [C] Continue to Target Analysis · [X] Cancel and exit"
 - ALWAYS halt and wait for user input after presenting menu
 - **GATE [default: use args]** — If `{headless_mode}`, consume pre-supplied arguments and auto-proceed. The full argument set (required/optional, defaults, halt codes, enum values) is documented in `{headlessArgsFile}` — load it now if you need to look up a specific argument. Validation is delegated to `{validateBriefInputsScript}`; the table is the canonical operator-facing documentation, the script enforces it.
 
+  **Preset merge (before validation).** If the headless args include a `preset` field, load `{sidecar_path}/brief-presets/{preset}.yaml` and merge its contents as defaults — explicit args override preset values, key by key. The preset file is YAML; if it does not exist, log `"warn: preset '{name}' not found at {path} — proceeding without preset"` and continue (do not HALT). If it parses but contains unknown fields, log per-field warnings and pass through unchanged (the validator's KNOWN_FIELDS check will catch any that survive). Drop the `preset` key itself from the merged dict before passing to the validator (it is consumed at this level and is not a brief field).
+
   **Delegate validation to `{validateBriefInputsScript}`** instead of reasoning through the table rules in prose:
 
   ```bash

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -212,13 +212,17 @@ Wait for confirmation or alternative.
 
 - Headless: log `"warn: skill name '{name}' collides with existing brief at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
 
-**Portfolio-similarity check (Forge+/Deep with QMD only, interactive only).** When the forge tier is `Forge+` or `Deep` AND `tools.qmd` is true in `forge-tier.yaml`, the brief portfolio is already indexed in QMD collections (one `{skill-name}-brief` collection per existing brief, registered by step-05 §5 of every prior Deep-tier run). Run a similarity search against that portfolio so near-duplicates are caught before the user invests scope-definition time:
+**Portfolio-similarity check (Deep tier with QMD only, interactive only).** When the forge tier is `Deep` AND `tools.qmd` is true in `forge-tier.yaml`, the brief portfolio is already indexed in QMD collections (one `{skill-name}-brief` collection per existing brief, registered by step-05 §5 of every prior Deep-tier run). Run a similarity search against that portfolio so near-duplicates are caught before the user invests scope-definition time. The qmd CLI does not support glob-style collection selection, so enumerate first then query per collection in **a single message with N parallel Bash calls**:
 
 ```bash
-qmd query --query "{name} {synthesized-or-intent-text}" --collections "*-brief" --top 3 --min-score 0.6
+# 1. Enumerate brief collections (one per existing brief)
+qmd collection list | awk '/-brief$/{print $1}'
+
+# 2. For each collection, query the proposed name + intent text:
+qmd query "{name} {synthesized-or-intent-text}" -c {collection-name} -n 1 --min-score 0.6
 ```
 
-If results come back, surface them as a heads-up — *not* a HALT. Exact-name collision is already handled above; this check catches semantic near-duplicates that exact-match misses (e.g. `markdown-renderer` proposed when `marked` already exists, or `auth-gateway` when `auth-middleware` already exists). Present:
+Aggregate the top hits across all `-brief` collections; keep the 3 highest-scoring across the union. If any results come back, surface them as a heads-up — *not* a HALT. Exact-name collision is already handled above; this check catches semantic near-duplicates that exact-match misses (e.g. `markdown-renderer` proposed when `marked` already exists, or `auth-gateway` when `auth-middleware` already exists). Present:
 
 ```
 **Heads up — these existing briefs look semantically close to `{name}`:**
@@ -228,7 +232,7 @@ If results come back, surface them as a heads-up — *not* a HALT. Exact-name co
 Continue with `{name}`, or pick a different name?
 ```
 
-On any QMD failure (binary missing, collection list empty, query times out): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. Quick / Forge tiers do not run this check (qmd is not part of their tool set). Headless does not run this check either — it would either need to HALT on duplicates (over-aggressive for an automator) or silently log (no operator to act on it); leaving it interactive-only keeps the headless path side-effect-free against the QMD index.
+On any QMD failure (binary missing, collection list empty, any per-collection query times out): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. Quick / Forge / Forge+ tiers do not run this check (qmd is Deep-tier-only per the canonical tier definition: `Deep = + ast-grep + gh + QMD` in `skf-forge-tier-rw.py`). Headless does not run this check either — it would either need to HALT on duplicates (over-aggressive for an automator) or silently log (no operator to act on it); leaving it interactive-only keeps the headless path side-effect-free against the QMD index.
 
 **Draft-resume check (interactive only).** After the name is confirmed, also check for an in-progress draft at `{forge_data_folder}/{name}/.brief-draft.json` (a step-01 §7 checkpoint from a previous run that did not reach step-05). If the file exists AND no `skill-brief.yaml` sits beside it (a finished brief uses the same dir), present:
 
@@ -238,7 +242,7 @@ On any QMD failure (binary missing, collection list empty, query times out): log
   [N] Start fresh (delete the draft and re-gather)
 ```
 
-On `[Y]`: load the JSON, restore the captured fields (target_repo, source_type, source_authority, target_version, doc_urls, intent, scope_hint, description), and jump directly to §8 — the user can still revise at step-04. On `[N]`: delete `.brief-draft.json` and continue with §6 normally. In headless mode this check is skipped — drafts are an interactive-only convenience and the headless path runs to completion in a single invocation.
+On `[Y]`: load the JSON, restore the captured fields (target_repo, source_type, source_authority, target_version, doc_urls, intent, scope_hint, description), and jump directly to §8 — **skip the rest of §6, §7, and §7b**. The restored `description` is authoritative and does not need re-synthesis (re-running §7b would overwrite the user's previously accepted description with a fresh candidate). The user can still revise any field at step-04. On `[N]`: delete `.brief-draft.json` and continue with §6 normally. In headless mode this check is skipped — drafts are an interactive-only convenience and the headless path runs to completion in a single invocation.
 
 ### 7. Summarize Gathered Intent
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -212,6 +212,24 @@ Wait for confirmation or alternative.
 
 - Headless: log `"warn: skill name '{name}' collides with existing brief at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
 
+**Portfolio-similarity check (Forge+/Deep with QMD only, interactive only).** When the forge tier is `Forge+` or `Deep` AND `tools.qmd` is true in `forge-tier.yaml`, the brief portfolio is already indexed in QMD collections (one `{skill-name}-brief` collection per existing brief, registered by step-05 §5 of every prior Deep-tier run). Run a similarity search against that portfolio so near-duplicates are caught before the user invests scope-definition time:
+
+```bash
+qmd query --query "{name} {synthesized-or-intent-text}" --collections "*-brief" --top 3 --min-score 0.6
+```
+
+If results come back, surface them as a heads-up — *not* a HALT. Exact-name collision is already handled above; this check catches semantic near-duplicates that exact-match misses (e.g. `markdown-renderer` proposed when `marked` already exists, or `auth-gateway` when `auth-middleware` already exists). Present:
+
+```
+**Heads up — these existing briefs look semantically close to `{name}`:**
+  1. {existing-name} (similarity: {score})  — {existing-description}
+  2. {existing-name} (similarity: {score})  — {existing-description}
+
+Continue with `{name}`, or pick a different name?
+```
+
+On any QMD failure (binary missing, collection list empty, query times out): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. Quick / Forge tiers do not run this check (qmd is not part of their tool set). Headless does not run this check either — it would either need to HALT on duplicates (over-aggressive for an automator) or silently log (no operator to act on it); leaving it interactive-only keeps the headless path side-effect-free against the QMD index.
+
 **Draft-resume check (interactive only).** After the name is confirmed, also check for an in-progress draft at `{forge_data_folder}/{name}/.brief-draft.json` (a step-01 §7 checkpoint from a previous run that did not reach step-05). If the file exists AND no `skill-brief.yaml` sits beside it (a finished brief uses the same dir), present:
 
 ```

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -212,6 +212,16 @@ Wait for confirmation or alternative.
 
 - Headless: log `"warn: skill name '{name}' collides with existing brief at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
 
+**Draft-resume check (interactive only).** After the name is confirmed, also check for an in-progress draft at `{forge_data_folder}/{name}/.brief-draft.json` (a step-01 §7 checkpoint from a previous run that did not reach step-05). If the file exists AND no `skill-brief.yaml` sits beside it (a finished brief uses the same dir), present:
+
+```
+**An in-progress draft for `{name}` was found** (last updated: {mtime}).
+  [Y] Resume from the saved draft (jump to §8 with prior answers restored)
+  [N] Start fresh (delete the draft and re-gather)
+```
+
+On `[Y]`: load the JSON, restore the captured fields (target_repo, source_type, source_authority, target_version, doc_urls, intent, scope_hint, description), and jump directly to §8 — the user can still revise at step-04. On `[N]`: delete `.brief-draft.json` and continue with §6 normally. In headless mode this check is skipped — drafts are an interactive-only convenience and the headless path runs to completion in a single invocation.
+
 ### 7. Summarize Gathered Intent
 
 "**Here's what I've captured:**
@@ -229,6 +239,8 @@ Wait for confirmation or alternative.
 - **Forge tier:** {tier}
 
 Ready to analyze the target repository?"
+
+**Draft checkpoint (interactive only).** After the user confirms the summary, persist the captured state to `{forge_data_folder}/{skill-name}/.brief-draft.json` so a session interruption between here and step-05 doesn't force a full re-gather. Write a single JSON object with the captured fields (target_repo, source_type, source_authority, target_version, doc_urls, intent, scope_hint, description-after-§7b, the inferred forge_tier and tier_source) atomically (write to `.brief-draft.json.tmp` then rename). The file is removed by step-05 §4 after the final brief writes successfully (a draft only exists while the workflow is in flight). In headless mode skip this checkpoint — the run completes in a single invocation, no resume is meaningful.
 
 ### 7b. Synthesize Skill Description
 

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -116,6 +116,8 @@ The script:
 
 **On success:** capture `brief_path` and `version` from the response envelope — both are needed for §4b and §6.
 
+**Draft cleanup.** After a successful write, remove `{forge_data_folder}/{skill-name}/.brief-draft.json` if it exists (`rm -f` — silent on absent). The draft was a step-01 §7 checkpoint covering the in-flight workflow window; once the brief is written it is no longer meaningful. In headless mode this rm is a no-op (drafts are only written interactively).
+
 ### 4b. Headless Result Envelope
 
 If `{headless_mode}` is true, emit the success envelope on **stdout** immediately after the write (before §5 / §6 / §7):


### PR DESCRIPTION
## Summary

**Final PR in the 7-PR series.** Theme 4 part 2 of the [skf-brief-skill quality analysis](skills/reports/skf-brief-skill/quality-analysis/20260502-201702/quality-report.md) — the last three non-first-timer affordances. After this PR, every finding from the quality report has been addressed.

- **30ed4997** — `feat(skf-brief-skill): add --preset headless arg for repeated-pattern briefs`. Preset YAMLs at `{sidecar_path}/brief-presets/{name}.yaml` capture shared defaults; explicit args override key by key. Merge happens at step-01 §8 GATE before validation; the `preset` key is consumed at the GATE level and not passed downstream.
- **942eba51** — `feat(skf-brief-skill): persist .brief-draft.json checkpoint and offer Resume? on re-entry`. Three coordinated changes — checkpoint write at end of step-01 §7, Resume? prompt at step-01 §6 after the name is confirmed and collision-checked, cleanup at step-05 §3 after successful write. Drafts are interactive-only; headless invocations skip both the write and the read.
- **a0810378** — `feat(skf-brief-skill): add QMD portfolio-similarity check at step-01 §6 (Forge+/Deep)`. Catches semantic near-duplicates that the exact-match collision check misses (e.g. `markdown-renderer` proposed when `marked` exists). Bounded on every axis: Deep-tier-only, QMD-available-only, interactive-only, never HALTs.
- **df788e9c** — `fix(skf-brief-skill): correct QMD CLI surface, tier guard, resume-jump skip, preset KNOWN_FIELDS`. In-PR review caught two critical bugs and two important issues:
  - **Critical:** the QMD snippet used three fabricated CLI flags (`--query`, `--collections "*-brief"`, `--top 3`) that don't exist. The check would have failed silently on every Deep run. Replaced with a real two-step pattern: enumerate via `qmd collection list | awk '/-brief$/'` then per-collection `qmd query "{q}" -c {name} -n 1 --min-score 0.6` calls in a single message with parallel Bash calls.
  - **Critical:** "Forge+/Deep with QMD" was wrong — QMD is Deep-only per the canonical tier definition (`Deep = + ast-grep + gh + QMD` in `skf-forge-tier-rw.py`).
  - Resume-jump prose was ambiguous about whether §7 / §7b would re-execute and potentially overwrite the user's accepted description. Added explicit skip clause.
  - `preset` in `KNOWN_FIELDS` suppressed the unknown-field warning if the LLM forgot to drop the key. Removed; the existing unknown-field path now emits the warning for debuggability.

715 Python tests pass.

## Test plan

- [x] `npm run quality` passes locally (full suite ran via pre-commit hook on every commit — green)
- [x] CI green on PR
- [x] Sanity-test `--preset`: create `{sidecar_path}/brief-presets/saas-api.yaml` with `source_authority: official`, `scope_type: public-api`, run a headless invocation with `preset: saas-api` and confirm those values land in the brief
- [x] Sanity-test draft checkpoint: start an interactive brief, abort with Ctrl-C between step-01 §7 and step-05, re-run the workflow with the same skill name, confirm Resume? appears and `[Y]` jumps directly to step-02
- [x] Sanity-test QMD similarity: on a Deep-tier setup with at least 2 existing briefs, propose a name semantically close to an existing one (e.g. `markdown-renderer` when `marked` exists) and confirm the heads-up surfaces

## Series wrap-up

This is PR 7 of 7 addressing the [quality analysis](skills/reports/skf-brief-skill/quality-analysis/20260502-201702/quality-report.md). Cumulative impact across the series:

| Theme | PR | Status |
|-------|----|----|
| 1. Lazy-load gaps | #277 | merged — ~22KB / ~6K tokens/run savings |
| 5. Prompt-craft cleanups | #278 | merged — drift fixes, alternates-template guard |
| 2a. Reference extraction | #279 | merged — step-01: 303 → 273 lines |
| 2b. Monorepo detection script | #280 | merged — new `skf-detect-workspaces.py` + 38 tests |
| 3. Headless heuristics | #281 | merged — auto-resolve vs blanket defaults |
| 4a. Cancel + write probe | #282 | merged — exit code 6, fail-fast disk check |
| 4b. Preset/draft/QMD | this PR | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)