### PR TITLE
refactor(skf-brief-skill): PR A — cleanup quick wins (envelope canonicalization, HEAD-recheck cache, schema anti-load, On Activation reorder)

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -28,6 +28,15 @@ These rules apply to every step in this workflow:
 - Always communicate in `{communication_language}` (the language for user-facing prose). Written artifact text — the `description`, `notes`, and other free-form fields persisted into `skill-brief.yaml` — is in `{document_output_language}`; per-step rules call this out where it applies (see step-05). The two values may be the same.
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
+## On Activation
+
+1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
+   - `project_name`, `output_folder`, `user_name`, `communication_language`, `forge_data_folder`, `sidecar_path`
+
+2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+
+3. Load, read the full file, and execute `./steps-c/step-01-gather-intent.md`.
+
 ## Stages
 
 | # | Step | File | Auto-proceed |
@@ -71,12 +80,3 @@ SKF_BRIEF_RESULT_JSON: {"status":"success|error","brief_path":"…|null","skill_
 ```
 
 `status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`, `"user-cancelled"`. `exit_code` matches the table above.
-
-## On Activation
-
-1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
-   - `project_name`, `output_folder`, `user_name`, `communication_language`, `forge_data_folder`, `sidecar_path`
-
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
-
-3. Load, read the full file, and then execute `./steps-c/step-01-gather-intent.md` to begin the workflow.

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -34,7 +34,7 @@ mkdir -p "{forge_data_folder}" && \
   rm "{forge_data_folder}/.skf-write-probe"
 ```
 
-`mkdir -p` succeeds on a pre-existing read-only mount, but the `printf > file` redirect actually attempts a write — that catches read-only, disk-full, and permissions-denied uniformly. **On any non-zero exit:** HALT (exit code 4, `halt_reason: "write-failed"`) — `"**Error:** {forge_data_folder} is not writable: {captured stderr}. Verify the path exists, the mount is writable, and there is free disk space, then re-run."` In headless mode, invoke `{emitBriefEnvelopeScript} emit --target stderr` with envelope-context `{"status":"error","skill_name":"<name-or-pre-resolution-placeholder>","halt_reason":"write-failed"}` before exiting (matches the §8 GATE / step-05 emit pattern — never hand-assemble the envelope JSON). On success, continue silently to the forge-tier load below.
+`mkdir -p` succeeds on a pre-existing read-only mount, but the `printf > file` redirect actually attempts a write — that catches read-only, disk-full, and permissions-denied uniformly. **On any non-zero exit:** HALT (exit code 4, `halt_reason: "write-failed"`) — `"**Error:** {forge_data_folder} is not writable: {captured stderr}. Verify the path exists, the mount is writable, and there is free disk space, then re-run."` In headless mode, emit the error envelope per **step-05 §4b** with `halt_reason: "write-failed"` (skill_name is not yet resolved here — use the placeholder convention documented in §4b). On success, continue silently to the forge-tier load below.
 
 Attempt to load `{forgeTierFile}`:
 
@@ -312,7 +312,7 @@ Display: "**Select:** [C] Continue to Target Analysis · [X] Cancel and exit"
 
   The script returns a JSON envelope: `{valid, errors[], warnings[], normalized, halt_reason}`. Apply the result deterministically:
 
-  - **`valid: false`** — emit the error-variant `SKF_BRIEF_RESULT_JSON` envelope on stderr with `exit_code: 2` and the script's `halt_reason` (`"input-missing"` for absent required args / docs-only without doc_urls; `"input-invalid"` for enum violations, malformed semver, malformed kebab-case skill_name). Surface `errors[]` to the operator log so the failure is debuggable. HALT.
+  - **`valid: false`** — emit the error envelope per **step-05 §4b** with the script's `halt_reason` (`"input-missing"` for absent required args / docs-only without doc_urls; `"input-invalid"` for enum violations, malformed semver, malformed kebab-case skill_name). Surface `errors[]` to the operator log so the failure is debuggable. HALT.
   - **`valid: true`** — consume the `normalized` object as the source of truth (it has defaults applied per the table). Surface `warnings[]` to the operator log but do not HALT. Auto-proceed.
 
   The script's `KNOWN_FIELDS` set must stay in sync with the table in `{headlessArgsFile}`.

--- a/src/skf-brief-skill/steps-c/step-03-scope-definition.md
+++ b/src/skf-brief-skill/steps-c/step-03-scope-definition.md
@@ -69,6 +69,8 @@ Wait for confirmation. Record any changes to `doc_urls`.
 
 HEAD-check the URLs in parallel — issue all N `curl -sI --max-time 5 {url}` calls in a **single message with N parallel Bash calls**, then process the responses together. On a 4xx/5xx, DNS failure, or timeout per URL, warn `"Could not reach {url} — {status or error}."` and offer the same correct/keep choice as step-01 §3. The check is best-effort — never HALT on a failed HEAD — but the failure must surface here so it is not discovered downstream during compilation.
 
+**On re-entry from step-04 [R]:** if `doc_urls` is byte-identical to the list that was probed on the previous pass through this subsection AND the prior per-URL probe results are still recoverable from conversation context, skip the parallel HEAD-check and reuse those results. Re-running the probes when the list has not changed wastes round-trips and can flap on transient failures. Any addition, removal, or edit to a URL invalidates the cache — re-probe the entire updated set. If the prior results are not recoverable (long session, compaction, etc.), re-probe — never cache-hit on a list whose results you cannot cite.
+
 **If no supplemental doc_urls were collected:** Skip this subsection.
 
 **Scope guidance for first-time users:** A well-scoped skill covers one cohesive capability with 3-8 primary functions. If the scope includes unrelated concerns (e.g., authentication AND data visualization), suggest splitting into separate briefs. If the scope is too narrow (single utility function), suggest expanding to the surrounding capability surface.

--- a/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
+++ b/src/skf-brief-skill/steps-c/step-04-confirm-brief.md
@@ -24,6 +24,8 @@ To present the complete skill brief in human-readable format, highlighting all f
 
 ### 1. Assemble Complete Brief
 
+Use the values already accepted in steps 01-03 directly — do not re-load `{briefSchemaFile}` here. The 18 fields below are all in conversation; the schema is only consulted in §4 if an inline adjustment needs a specific field's validation rule cited.
+
 Compile all gathered data from steps 01-03 into the complete brief:
 
 - **name:** {skill name from step 01}

--- a/src/skf-brief-skill/steps-c/step-05-write-brief.md
+++ b/src/skf-brief-skill/steps-c/step-05-write-brief.md
@@ -59,7 +59,7 @@ Overwrite it with the brief you just approved? [Y/N]"
 If the file exists:
 
 - If `force` was supplied as a headless argument: log `"headless: force-overwriting existing brief at {path}"` and proceed to §3.
-- Otherwise: invoke `{emitBriefEnvelopeScript}` to emit the error-variant envelope on stderr (see §4b) with `halt_reason: "overwrite-cancelled"`, then HALT with exit code 5.
+- Otherwise: emit the error envelope per §4b with `halt_reason: "overwrite-cancelled"`, then HALT with exit code 5.
 
 If the file does not exist, proceed normally.
 
@@ -109,27 +109,40 @@ The script:
 **On script failure (non-zero exit):**
 - Exit 1 (validation/invariant): The error JSON on stderr names the offending field. This indicates a context-assembly bug, not a user error — surface the message to the user, log it, then HALT.
   - Interactive: **HALT** — display the error JSON's `message` field.
-  - Headless: invoke `{emitBriefEnvelopeScript} emit --target stderr` with envelope-context `halt_reason: "input-invalid"` (the script derives `exit_code: 2` automatically — do NOT pass `exit_code` in the JSON payload), then `exit 2`.
+  - Headless: emit the error envelope per §4b with `halt_reason: "input-invalid"`, then `exit 2`.
 - Exit 2 (I/O failure): The atomic write failed (target unwritable, disk full, etc.).
   - Interactive: **HALT** — "**Error:** Failed to write skill-brief.yaml. Check that the directory is writable and try again."
-  - Headless: invoke `{emitBriefEnvelopeScript} emit --target stderr` with envelope-context `halt_reason: "write-failed"` (script derives `exit_code: 4` automatically), then `exit 4`.
+  - Headless: emit the error envelope per §4b with `halt_reason: "write-failed"`, then `exit 4`.
 
 **On success:** capture `brief_path` and `version` from the response envelope — both are needed for §4b and §6.
 
 **Draft cleanup.** After a successful write, remove `{forge_data_folder}/{skill-name}/.brief-draft.json` if it exists (`rm -f` — silent on absent). The draft was a step-01 §7 checkpoint covering the in-flight workflow window; once the brief is written it is no longer meaningful. In headless mode this rm is a no-op (drafts are only written interactively).
 
-### 4b. Headless Result Envelope
+### 4b. Headless Result Envelope (Canonical)
 
-If `{headless_mode}` is true, emit the success envelope on **stdout** immediately after the write (before §5 / §6 / §7):
+This section is the canonical envelope-emission reference for the workflow. Every headless emission — the success terminal here and every HARD HALT in step-01/02/05 — uses this contract. Remote sites point here instead of restating it.
+
+**Success (this call site only — emitted from §3 directly):**
 
 ```bash
 echo '{"status":"success","brief_path":"<from §3 response>","skill_name":"<name>","version":"<from §3 response>","language":"<language>","scope_type":"<scope.type>","halt_reason":null}' | \
   uv run {emitBriefEnvelopeScript} emit
 ```
 
-The script derives `exit_code` deterministically from `halt_reason` (the canonical mapping is null→0, input-missing/input-invalid→2, forge-tier-missing/target-inaccessible/gh-auth-failed→3, write-failed→4, overwrite-cancelled→5, user-cancelled→6 [interactive-only — headless never raises this]), validates against `src/shared/scripts/schemas/skf-brief-result-envelope.v1.json`, and prints the prefixed `SKF_BRIEF_RESULT_JSON: {…}` line.
+**Error (used by every HARD HALT site):**
 
-The envelope shape on HARD HALT (any phase) is the same call with `--target stderr`, `status: "error"`, and the matching `halt_reason` (one of `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"target-inaccessible"`, `"gh-auth-failed"`, `"write-failed"`, `"overwrite-cancelled"`) — see the §3, §2b, §5 (no-halt) branches above and the §1/§2 HALTs in step-01/step-02 for invocation sites. The script enforces the success/error halt_reason invariant (success requires null halt_reason; error requires non-null). The `user-cancelled` halt_reason is also accepted by the script for completeness (interactive `[X]` Cancel sites in step-01/03/04 use it) but never appears on the headless code path.
+```bash
+echo '{"status":"error","skill_name":"<name>","halt_reason":"<reason>"}' | \
+  uv run {emitBriefEnvelopeScript} emit --target stderr
+```
+
+When the HALT fires before `skill_name` has been resolved (step-01 §1 pre-flight write probe, step-01 §8 input-missing on a malformed args bundle), pass the partially-gathered value or the literal `"unknown"` — the script accepts any non-empty string at this position.
+
+The script derives `exit_code` deterministically from `halt_reason` (null→0, input-missing/input-invalid→2, forge-tier-missing/target-inaccessible/gh-auth-failed→3, write-failed→4, overwrite-cancelled→5, user-cancelled→6 [interactive-only — headless never raises this]), validates against `src/shared/scripts/schemas/skf-brief-result-envelope.v1.json`, and prints the prefixed `SKF_BRIEF_RESULT_JSON: {…}` line.
+
+The script enforces the success/error halt_reason invariant (success requires null halt_reason; error requires non-null). The `user-cancelled` halt_reason is accepted for completeness (interactive `[X]` Cancel sites in step-01/03/04) but never appears on the headless code path.
+
+Invocation sites (each pointed at this block, not duplicated): step-01 §1 (write-failed pre-resolution), step-01 §8 (input-missing/input-invalid GATE), step-05 §2b (overwrite-cancelled), step-05 §3 (input-invalid/write-failed from script). Step-01 §1 forge-tier-missing and step-02 §1 (target-inaccessible/gh-auth-failed) currently HALT without emitting an envelope — pre-existing gaps tracked separately, not addressed by this canonicalization.
 
 When `{headless_mode}` is false, skip this section silently — no envelope is emitted.
 


### PR DESCRIPTION
## Summary

PR **A of 4** — cleanup quick wins from the 2026-05-02 quality scan of \`skf-brief-skill\`. Three independent low-risk findings, one commit per finding. No behavior change.

- **Move \`On Activation\` block above \`Stages\`** in \`SKILL.md\` so the LLM resolves \`{headless_mode}\` before reading the stage table. Trim trailing meta-phrasing on step 3 (Rank 7).
- **Canonicalize the headless envelope-emission contract in step-05 §4b** — promote §4b to be the single canonical block (now documents both success and error call shapes plus the pre-name-resolution \`skill_name\` placeholder convention) and replace the four remote sites in step-01 §1, step-01 §8, step-05 §2b, and step-05 §3 with short pointers. Note pre-existing emission gaps (step-01 §1 \`forge-tier-missing\`, step-02 §1 \`target-inaccessible\`/\`gh-auth-failed\`) for a follow-up; not addressed here (Rank 5).
- **Cache step-03 §2b supplemental-doc HEAD probe across [R] re-entry** with a byte-identical-list check, an explicit safe-fallback to re-probe when prior results are not recoverable from context, and an explicit cache-bust on any add/remove/edit. First entry still probes (step-01 §3.3 collects supplemental URLs without probing them, so first-entry behavior is unchanged). **Add step-04 §1 anti-load guard** so the LLM doesn't reload the 17 KB \`skill-brief-schema.md\` for the assembly pass — schema is only consulted in §4 for inline-adjustment validation citations (Rank 6).

## Test plan

- [x] Full repo test suite passed on each commit via pre-commit hook (\`npm run test\` → schemas, install, cli, workflow, python, knowledge, validate, lint, lint:md, format:check)
- [x] Two passes of the \`feature-dev:code-reviewer\` agent on the diff — first pass caught 3 issues (registry inaccuracy, registry attribution error, false claim about §3.3 probing supplemental URLs), all addressed before push; second pass clean modulo one comment about cache-recovery fallback that has been written into the §2b text
- [x] Sanity-check that \`gh pr view\` and downstream automation still parse the \`SKF_BRIEF_RESULT_JSON\` line in error mode after the §4b minimal-payload restructure (the script's \`assemble()\` uses \`ctx.get(...)\` for optional fields and fills nulls — schema accepts those — verified inline during review)
- [x] Manual smoke: run the workflow interactively once to confirm the rendered §4b heading, the new step-04 §1 line, and the step-03 §2b cache clause all read sensibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)