### PR TITLE
refactor(skf-brief-skill): PR B — extract step-01 conditional sub-flows to lazy refs

### DIFF
--- a/src/skf-brief-skill/references/draft-checkpoint.md
+++ b/src/skf-brief-skill/references/draft-checkpoint.md
@@ -1,0 +1,46 @@
+# Draft Checkpoint Lifecycle
+
+The `.brief-draft.json` file at `{forge_data_folder}/{skill-name}/.brief-draft.json` is a step-01 in-flight-state checkpoint. It exists only while the workflow has progressed past §7 but not yet completed step-05 — once the final brief writes successfully, step-05 §4 removes it.
+
+**Headless mode skips this entire lifecycle** — the run completes in a single invocation, so no resume is meaningful and no checkpoint is written.
+
+The two halves of the lifecycle (resume on entry, write on §7 confirmation) form a pair. This file documents both so a single load covers them.
+
+## Half 1 — Resume Check (loaded from §6 after name confirmation)
+
+After the skill name is confirmed in §6, check for an in-progress draft at `{forge_data_folder}/{name}/.brief-draft.json`. **Only present the resume prompt** when the file exists AND no `skill-brief.yaml` sits beside it (a finished brief uses the same dir; if a finished brief exists, the draft is stale and step-05's overwrite gate is the right control point).
+
+When the precondition is met, present:
+
+```
+**An in-progress draft for `{name}` was found** (last updated: {mtime}).
+  [Y] Resume from the saved draft (jump to §8 with prior answers restored)
+  [N] Start fresh (delete the draft and re-gather)
+```
+
+### `[Y]` — Resume
+
+Load the JSON and restore the captured fields: `target_repo`, `source_type`, `source_authority`, `target_version`, `doc_urls`, `intent`, `scope_hint`, `description`, `forge_tier`, `tier_source`. Then jump directly to §8 — **skip the rest of §6, all of §7, and all of §7b**.
+
+The skip rule for §7b is load-bearing: re-running §7b would overwrite the user's previously accepted `description` with a fresh candidate synthesized from the seed material. The restored `description` is authoritative.
+
+The user can still revise any field at step-04 §3 if a refinement is needed after the full brief is visible.
+
+### `[N]` — Start fresh
+
+Delete `.brief-draft.json` and continue forward to §7 — the collision check and portfolio-similarity check have already executed earlier in §6 (before the resume prompt fired) and do not repeat. §7 / §7b then proceed in their normal order.
+
+## Half 2 — Checkpoint Write (loaded from §7 after summary confirmation)
+
+After the user confirms the §7 summary, persist the captured state atomically. Write a single JSON object with all of:
+
+- `target_repo`, `source_type`, `source_authority`
+- `target_version` (if set)
+- `doc_urls` (if collected)
+- `intent`, `scope_hint`
+- `description` (the §7b accepted text)
+- `forge_tier`, `tier_source` (for diagnostics)
+
+Atomic-write protocol: write to `.brief-draft.json.tmp` first, then `mv .brief-draft.json.tmp .brief-draft.json`. The rename is atomic on a single filesystem; a partial write never becomes visible as `.brief-draft.json`.
+
+The file is removed by step-05 §4 after the final brief writes successfully.

--- a/src/skf-brief-skill/references/headless-source-authority-detection.md
+++ b/src/skf-brief-skill/references/headless-source-authority-detection.md
@@ -1,0 +1,26 @@
+# Headless Source-Authority Detection
+
+Loaded by step-01 §8 only when **all three** preconditions hold:
+
+1. `{headless_mode}` is true
+2. `source_authority` is absent from the validator's `normalized` output (the validator intentionally leaves it absent so detection can run here — when it was supplied in args, the supplied value wins and detection does not run)
+3. `source_type=source` AND `target_repo` is a GitHub URL
+
+When any precondition is unmet, skip this entire procedure: docs-only forces `community` in §3.2; local-path targets default to `community` directly; non-GitHub source URLs are not classifiable from `gh api user` and also default to `community`.
+
+## Procedure
+
+Probe the operator's GitHub login:
+
+```bash
+gh api user --jq .login
+```
+
+Compare the result to the `owner` segment of `target_repo` (URL pattern `https://github.com/<owner>/<repo>`) — **lower-case both values before comparing**. GitHub owner matching is case-insensitive but the API preserves case in responses, so a literal-string comparison would miss the match.
+
+| Outcome | Set | Rationale |
+|---------|-----|-----------|
+| login matches owner (case-insensitive) | `source_authority: "official"` | The operator is the repo's GitHub owner |
+| login does not match | `source_authority: "community"` | The operator is a downstream consumer |
+| `gh api user` errors (unauthenticated, network failure, missing binary) | `source_authority: "community"` (fallback) | Log `"warn: source-authority detection skipped — gh api user failed"` |
+| Local-path target | `source_authority: "community"` (no probe) | Comparison does not apply |

--- a/src/skf-brief-skill/references/portfolio-similarity-check.md
+++ b/src/skf-brief-skill/references/portfolio-similarity-check.md
@@ -1,0 +1,35 @@
+# Portfolio-Similarity Check
+
+Loaded by step-01 §6 only when **all three** preconditions hold:
+
+1. Forge tier is `Deep`
+2. `tools.qmd` is true in `forge-tier.yaml`
+3. The flow is interactive (the headless path skips this check entirely — it would either need to HALT on duplicates [over-aggressive for an automator] or silently log [no operator to act on it]; either choice has a side effect on the QMD index that is best avoided headlessly)
+
+This check catches **semantic near-duplicates** that exact-name collision misses (e.g. `markdown-renderer` proposed when `marked` already exists, or `auth-gateway` when `auth-middleware` already exists). Exact-name collision is handled separately at §6 before this check runs.
+
+## Procedure
+
+The brief portfolio is already indexed in QMD collections — one `{skill-name}-brief` collection per existing brief, registered by step-05 §5 of every prior Deep-tier run. The qmd CLI does not support glob-style collection selection, so enumerate first then query per collection in **a single message with N parallel Bash calls**:
+
+```bash
+# 1. Enumerate brief collections (one per existing brief)
+qmd collection list | awk '/-brief$/{print $1}'
+
+# 2. For each collection, query the proposed name + intent text:
+qmd query "{name} {synthesized-or-intent-text}" -c {collection-name} -n 1 --min-score 0.6
+```
+
+Aggregate the top hits across all `-brief` collections; keep the 3 highest-scoring across the union. If any results come back, surface them as a heads-up — *not* a HALT:
+
+```
+**Heads up — these existing briefs look semantically close to `{name}`:**
+  1. {existing-name} (similarity: {score})  — {existing-description}
+  2. {existing-name} (similarity: {score})  — {existing-description}
+
+Continue with `{name}`, or pick a different name?
+```
+
+## Failure modes
+
+On any QMD failure (binary missing, collection list empty, any per-collection query times out): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. Quick / Forge / Forge+ tiers do not run this check (qmd is Deep-tier-only per the canonical tier definition: `Deep = + ast-grep + gh + QMD` in `skf-forge-tier-rw.py`).

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -4,6 +4,7 @@ forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 descriptionVoiceExamplesFile: 'assets/description-voice-examples.md'
 headlessArgsFile: 'references/headless-args.md'
 headlessSourceAuthorityDetectionFile: 'references/headless-source-authority-detection.md'
+portfolioSimilarityCheckFile: 'references/portfolio-similarity-check.md'
 validateBriefInputsScript: '{project-root}/src/shared/scripts/skf-validate-brief-inputs.py'
 emitBriefEnvelopeScript: '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
 ---
@@ -213,27 +214,7 @@ Wait for confirmation or alternative.
 
 - Headless: log `"warn: skill name '{name}' collides with existing brief at {path}"` and proceed; the existing-brief overwrite policy in step-05 §2b is the canonical gate (HALT with `overwrite-cancelled` unless `force` was supplied).
 
-**Portfolio-similarity check (Deep tier with QMD only, interactive only).** When the forge tier is `Deep` AND `tools.qmd` is true in `forge-tier.yaml`, the brief portfolio is already indexed in QMD collections (one `{skill-name}-brief` collection per existing brief, registered by step-05 §5 of every prior Deep-tier run). Run a similarity search against that portfolio so near-duplicates are caught before the user invests scope-definition time. The qmd CLI does not support glob-style collection selection, so enumerate first then query per collection in **a single message with N parallel Bash calls**:
-
-```bash
-# 1. Enumerate brief collections (one per existing brief)
-qmd collection list | awk '/-brief$/{print $1}'
-
-# 2. For each collection, query the proposed name + intent text:
-qmd query "{name} {synthesized-or-intent-text}" -c {collection-name} -n 1 --min-score 0.6
-```
-
-Aggregate the top hits across all `-brief` collections; keep the 3 highest-scoring across the union. If any results come back, surface them as a heads-up — *not* a HALT. Exact-name collision is already handled above; this check catches semantic near-duplicates that exact-match misses (e.g. `markdown-renderer` proposed when `marked` already exists, or `auth-gateway` when `auth-middleware` already exists). Present:
-
-```
-**Heads up — these existing briefs look semantically close to `{name}`:**
-  1. {existing-name} (similarity: {score})  — {existing-description}
-  2. {existing-name} (similarity: {score})  — {existing-description}
-
-Continue with `{name}`, or pick a different name?
-```
-
-On any QMD failure (binary missing, collection list empty, any per-collection query times out): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. Quick / Forge / Forge+ tiers do not run this check (qmd is Deep-tier-only per the canonical tier definition: `Deep = + ast-grep + gh + QMD` in `skf-forge-tier-rw.py`). Headless does not run this check either — it would either need to HALT on duplicates (over-aggressive for an automator) or silently log (no operator to act on it); leaving it interactive-only keeps the headless path side-effect-free against the QMD index.
+**Portfolio-similarity check.** When the flow is interactive AND forge tier is `Deep` AND `tools.qmd` is true in `forge-tier.yaml`, load `{portfolioSimilarityCheckFile}` and follow the procedure there to catch semantic near-duplicates that exact-name collision misses. Otherwise (headless, or tier below Deep, or qmd unavailable) skip the load — the check does not run.
 
 **Draft-resume check (interactive only).** After the name is confirmed, also check for an in-progress draft at `{forge_data_folder}/{name}/.brief-draft.json` (a step-01 §7 checkpoint from a previous run that did not reach step-05). If the file exists AND no `skill-brief.yaml` sits beside it (a finished brief uses the same dir), present:
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -3,6 +3,7 @@ nextStepFile: './step-02-analyze-target.md'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 descriptionVoiceExamplesFile: 'assets/description-voice-examples.md'
 headlessArgsFile: 'references/headless-args.md'
+headlessSourceAuthorityDetectionFile: 'references/headless-source-authority-detection.md'
 validateBriefInputsScript: '{project-root}/src/shared/scripts/skf-validate-brief-inputs.py'
 emitBriefEnvelopeScript: '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
 ---
@@ -317,14 +318,7 @@ Display: "**Select:** [C] Continue to Target Analysis · [X] Cancel and exit"
 
   The script's `KNOWN_FIELDS` set must stay in sync with the table in `{headlessArgsFile}`.
 
-  **Headless source-authority detection** — the validator intentionally leaves `source_authority` ABSENT from `normalized` when not supplied (so detection can run here). After consuming `normalized`, if `source_authority` is absent AND `source_type=source` AND `target_repo` is a GitHub URL, run signal-driven detection:
-
-  ```bash
-  gh api user --jq .login
-  ```
-
-  Compare the result to the `owner` segment of `target_repo` (URL pattern `https://github.com/<owner>/<repo>`) — **lower-case both values before comparing** (GitHub owner matching is case-insensitive but the API preserves case in responses). If they match, set `source_authority: "official"` — the operator is the repo's GitHub owner. Otherwise set `source_authority: "community"`. On any error from `gh api user` (unauthenticated, network failure, missing binary), log `"warn: source-authority detection skipped — gh api user failed"` and fall back to `"community"`. For local-path targets the comparison cannot apply; set `"community"` directly. (When `source_authority` was already supplied in `normalized`, the supplied value wins — no detection runs.)
-
+  **Headless source-authority detection.** After consuming `normalized`, if `source_authority` is absent AND `source_type=source` AND `target_repo` is a GitHub URL, load `{headlessSourceAuthorityDetectionFile}` and follow the procedure there. Otherwise (precondition unmet, value already supplied, docs-only, or local-path) skip the load — `community` is the implicit default for the unmet branches.
 
 - ONLY proceed to next step when user selects 'C'
 

--- a/src/skf-brief-skill/steps-c/step-01-gather-intent.md
+++ b/src/skf-brief-skill/steps-c/step-01-gather-intent.md
@@ -5,6 +5,7 @@ descriptionVoiceExamplesFile: 'assets/description-voice-examples.md'
 headlessArgsFile: 'references/headless-args.md'
 headlessSourceAuthorityDetectionFile: 'references/headless-source-authority-detection.md'
 portfolioSimilarityCheckFile: 'references/portfolio-similarity-check.md'
+draftCheckpointFile: 'references/draft-checkpoint.md'
 validateBriefInputsScript: '{project-root}/src/shared/scripts/skf-validate-brief-inputs.py'
 emitBriefEnvelopeScript: '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
 ---
@@ -216,15 +217,7 @@ Wait for confirmation or alternative.
 
 **Portfolio-similarity check.** When the flow is interactive AND forge tier is `Deep` AND `tools.qmd` is true in `forge-tier.yaml`, load `{portfolioSimilarityCheckFile}` and follow the procedure there to catch semantic near-duplicates that exact-name collision misses. Otherwise (headless, or tier below Deep, or qmd unavailable) skip the load — the check does not run.
 
-**Draft-resume check (interactive only).** After the name is confirmed, also check for an in-progress draft at `{forge_data_folder}/{name}/.brief-draft.json` (a step-01 §7 checkpoint from a previous run that did not reach step-05). If the file exists AND no `skill-brief.yaml` sits beside it (a finished brief uses the same dir), present:
-
-```
-**An in-progress draft for `{name}` was found** (last updated: {mtime}).
-  [Y] Resume from the saved draft (jump to §8 with prior answers restored)
-  [N] Start fresh (delete the draft and re-gather)
-```
-
-On `[Y]`: load the JSON, restore the captured fields (target_repo, source_type, source_authority, target_version, doc_urls, intent, scope_hint, description), and jump directly to §8 — **skip the rest of §6, §7, and §7b**. The restored `description` is authoritative and does not need re-synthesis (re-running §7b would overwrite the user's previously accepted description with a fresh candidate). The user can still revise any field at step-04. On `[N]`: delete `.brief-draft.json` and continue with §6 normally. In headless mode this check is skipped — drafts are an interactive-only convenience and the headless path runs to completion in a single invocation.
+**Draft-resume check.** When the flow is interactive AND `{forge_data_folder}/{name}/.brief-draft.json` exists AND no `skill-brief.yaml` sits beside it, load `{draftCheckpointFile}` and follow Half 1 (Resume Check). On `[Y]` resume, the procedure jumps directly to §8 with prior answers restored — **the rest of §6, all of §7, and all of §7b are skipped**. Otherwise (headless, or no draft file, or a finished brief sits beside the draft) skip the load and continue with §6 normally.
 
 ### 7. Summarize Gathered Intent
 
@@ -244,7 +237,7 @@ On `[Y]`: load the JSON, restore the captured fields (target_repo, source_type, 
 
 Ready to analyze the target repository?"
 
-**Draft checkpoint (interactive only).** After the user confirms the summary, persist the captured state to `{forge_data_folder}/{skill-name}/.brief-draft.json` so a session interruption between here and step-05 doesn't force a full re-gather. Write a single JSON object with the captured fields (target_repo, source_type, source_authority, target_version, doc_urls, intent, scope_hint, description-after-§7b, the inferred forge_tier and tier_source) atomically (write to `.brief-draft.json.tmp` then rename). The file is removed by step-05 §4 after the final brief writes successfully (a draft only exists while the workflow is in flight). In headless mode skip this checkpoint — the run completes in a single invocation, no resume is meaningful.
+**Draft checkpoint.** When the flow is interactive, load `{draftCheckpointFile}` (or reuse it if already loaded for the §6 resume check) and follow Half 2 (Checkpoint Write) to persist the captured state atomically. Headless mode skips this — the run completes in a single invocation, no resume is meaningful.
 
 ### 7b. Synthesize Skill Description
 


### PR DESCRIPTION
## Summary

PR **B of 4** — restructure \`step-01-gather-intent.md\` from 334 → 302 lines by extracting three conditional sub-flows into lazy-loaded references. Each ref only loads when its preconditions actually fire — every other run pays nothing for that block. No behavior change.

| Commit | Extraction | Preconditions for load |
|---|---|---|
| 2a20c121 | \`references/headless-source-authority-detection.md\` | headless + \`source_authority\` absent + \`source_type=source\` + GitHub URL |
| af3fb73d | \`references/portfolio-similarity-check.md\` | interactive + Deep tier + \`tools.qmd\` |
| 4ba5f446 | \`references/draft-checkpoint.md\` (Half 1 = Resume Check, Half 2 = Checkpoint Write) | interactive + draft file exists |

The draft-checkpoint ref co-locates resume (§6) and write (§7) because they're a coherent in-flight-state lifecycle pair operating on the same \`.brief-draft.json\` — a single load covers both halves of a session that uses them.

The §6 stub still surfaces the load-bearing skip rule (on \`[Y]\` resume, skip rest of §6 / all of §7 / all of §7b and jump to §8) so the flow-control intent is reachable without loading the ref.

## Test plan

- [x] Full repo test suite passed on each commit via pre-commit hook
- [x] Code-reviewer agent ran on the diff — caught one real issue (the \`[N]\` start-fresh branch wording in draft-checkpoint.md implied re-running collision/similarity checks that had already executed); fixed via amend before push
- [x] Verified each ref is a strict superset of the inline text it replaced (no behavior dropped on extraction)
- [x] Verified each stub gates the load on the same preconditions that previously gated the inline block (no reachability regression — every path that previously hit the logic still does)
- [x] Manual smoke: run the workflow once interactively at Deep tier with a draft file present to confirm the resume prompt + portfolio check render correctly through the new ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)