### PR TITLE
fix(skf-create-skill): allow empty references/ when Tier-2 is inline

### DIFF
--- a/src/skf-create-skill/steps-c/step-07-generate-artifacts.md
+++ b/src/skf-create-skill/steps-c/step-07-generate-artifacts.md
@@ -106,10 +106,18 @@ The helper returns non-zero (exit 2) if `{skill_group}/active` already exists as
 ### 5. Verify Write Completion
 
 After all files are written, verify:
-- All 4 deliverable artifact types exist (SKILL.md, context-snippet.md, metadata.json, at least one file in references/), all 3 workspace artifacts exist (provenance-map.json, evidence-report.md, extraction-rules.yaml), plus scripts/ and assets/ files when inventories are non-empty
+- All 4 deliverable artifact types exist (SKILL.md, context-snippet.md, metadata.json, **and** either at least one file in `references/` **or** `references/` is empty AND Tier-2 content is inline in SKILL.md — see "Empty `references/` exception" below), all 3 workspace artifacts exist (provenance-map.json, evidence-report.md, extraction-rules.yaml), plus scripts/ and assets/ files when inventories are non-empty
 - The `active` symlink at `{skill_group}/active` resolves to `{version}`
 - Store `ref_count` = count of files written to `references/` for use in step-08 report
 - List each file with its path and size
+
+**Empty `references/` exception (Tier-2 inline):** `ref_count == 0` is a valid completion state when step-06 kept Tier-2 content inline in SKILL.md — e.g., the body was already under the size limit, or `skill-check` was unavailable and the manual fallback (step-06 §3) skipped the split. In that case, append a single line to `{forge_version}/evidence-report.md` recording the inline state so downstream tooling and audits can distinguish "inline by design" from "split-body skipped due to error":
+
+```
+ref_count: 0  # Tier-2 kept inline in SKILL.md (no split performed in step-06)
+```
+
+When `ref_count > 0` is expected (because step-06 ran a split) but no files were written, halt with: "Split-body produced zero reference files. Investigate step-06 output before retrying — empty `references/` after a split is never a valid state."
 
 **If any write failed:**
 Halt with: "Artifact generation failed: could not write `{file_path}`. Check permissions and disk space."


### PR DESCRIPTION
## Summary

- Step-07 §5 verification required at least one file in `references/`, but step-06's manual fallback (when `skill-check` is unavailable) keeps Tier-2 inline and writes nothing to `references/` — a complete and valid skill that nevertheless failed verification.
- Add an explicit exception: `ref_count == 0` is valid when Tier-2 is inline, recorded as a single line in `evidence-report.md` so audits can distinguish "inline by design" from "split-body skipped due to error".
- Add the inverse guard — if a split was attempted but produced zero files, halt rather than silently passing (the issue's "Suggested Fix" path was lossy on this).

Fixes #292

## Test plan

- [x] `npm test` passes (pre-commit hook ran the full suite).
- [x] `node tools/validate-skills.js src/skf-create-skill` is clean.
- [x] Manual reviewer pass: scenario where step-06 manual fallback runs (no split) — §5 now accepts the empty `references/` instead of failing.