### PR TITLE
fix(skf-setup): reject {project-root} placeholders in ccc-exclusions merge

### DIFF
--- a/src/shared/scripts/skf-merge-ccc-exclusions.py
+++ b/src/shared/scripts/skf-merge-ccc-exclusions.py
@@ -33,6 +33,11 @@ Validation rules for the 2 conditional values (PR #248):
     → produces `**//abs/path`, `**/~/x`, or `**/./rel` — malformed glob
   - REJECT values containing glob meta-characters (`*`, `?`, `[`)
     → interpolation collides with the surrounding pattern syntax
+  - REJECT values containing unresolved `{project-root}`-style placeholders
+    (any `{` or `}` character) — produces `**/{project-root}/x`, which
+    cocoindex accepts as a literal-segment glob and silently never matches.
+    This is the bug from issue #293: the step file was passing template
+    strings straight through.
 
 Rejected values are SKIPPED (the pattern is not added) and a warning
 is appended to the output. The 4 always-include patterns are applied
@@ -96,6 +101,7 @@ ALWAYS_INCLUDE = (
     "**/_skf-learn",
 )
 GLOB_META_CHARS = set("*?[")
+PLACEHOLDER_CHARS = set("{}")
 
 
 def _die(code: int, message: str) -> None:
@@ -161,6 +167,14 @@ def validate_config_value(key: str, raw_value: str) -> tuple[str | None, str | N
             f"{key} contains glob meta-character (*, ?, [); refused for ccc "
             f"exclusion because interpolation collides with the surrounding "
             f"pattern syntax — fix the value in {{project-root}}/_bmad/skf/config.yaml"
+        )
+
+    if any(ch in PLACEHOLDER_CHARS for ch in value):
+        return None, (
+            f"{key} contains an unresolved template placeholder ({{ or }}); "
+            f"refused for ccc exclusion because the step file is supposed to "
+            f"substitute {{project-root}} and reduce to a basename before "
+            f"invoking the helper — see step-01b §3 in src/skf-setup/steps-c/"
         )
 
     return value, None

--- a/src/skf-setup/steps-c/step-01b-ccc-index.md
+++ b/src/skf-setup/steps-c/step-01b-ccc-index.md
@@ -60,13 +60,20 @@ Check the `ccc_index` section:
 
 SKF infrastructure and output directories must be excluded from the CCC index — they contain workflow instructions, build artifacts, and generated skills that pollute semantic search results with zero extraction value.
 
-Run the merge helper, forwarding the resolved config values from the workflow activation context. Invoke via `uv run` so PEP 723 inline metadata resolves the script's PyYAML dependency automatically (per `docs/getting-started.md`'s prereq list — uv exists for this exact purpose). Bare `python3` will fail on a fresh Python with `ModuleNotFoundError: No module named 'yaml'`.
+**Pre-process the config values before invocation.** `skills_output_folder` and `forge_data_folder` come from `{project-root}/_bmad/skf/config.yaml` as template strings literally containing `{project-root}` (e.g. `'{project-root}/skills'`, `'{project-root}/forge-data'`). The merge helper interpolates each value into a `**/{value}` glob, so passing the raw template produces the malformed pattern `**/{project-root}/skills`. Before invoking the helper:
+
+1. Substitute `{project-root}` in each value with the resolved absolute project root.
+2. Reduce the substituted value to its last path segment (basename) — `**/skills`, `**/forge-data` are the patterns the script is designed to emit. Sub-paths under `{project-root}` (e.g. `_bmad-output/forge-data`) keep the segments below `{project-root}` (`_bmad-output/forge-data`), not the full absolute path.
+
+Concretely: given `skills_output_folder: '{project-root}/skills'`, pass `skills`. Given `forge_data_folder: '{project-root}/_bmad-output/forge-data'`, pass `_bmad-output/forge-data`. The script's PR #248 validator rejects unresolved placeholders (`{`, `}`) and absolute paths (`/abs/...`) as a backstop, but the step is responsible for delivering values the script can interpolate cleanly — surfacing a warning and silently dropping the pattern is worse than getting the pre-processing right here.
+
+Run the merge helper, forwarding the **resolved** config values. Invoke via `uv run` so PEP 723 inline metadata resolves the script's PyYAML dependency automatically (per `docs/getting-started.md`'s prereq list — uv exists for this exact purpose). Bare `python3` will fail on a fresh Python with `ModuleNotFoundError: No module named 'yaml'`.
 
 ```bash
 uv run {mergeCccExclusionsHelper} \
     --project-root "{project-root}" \
-    --skills-output-folder "{skills_output_folder}" \
-    --forge-data-folder "{forge_data_folder}"
+    --skills-output-folder "{resolved_skills_basename}" \
+    --forge-data-folder "{resolved_forge_data_path}"
 ```
 
 The script (see `src/shared/scripts/skf-merge-ccc-exclusions.py` docstring for the full schema) builds the SKF exclusion list (4 always-include hardcoded patterns + 2 conditional from validated config), applies the PR #248 validation rules to reject empty / absolute / glob-meta config values with actionable warnings, and performs an idempotent set-union merge into `{project-root}/.cocoindex_code/settings.yml`. User customizations are preserved. When the file does not exist yet (first-time setup before `ccc init`) the script creates it; when nothing new needs adding the script skips the write entirely (mtime preserved).

--- a/test/test-skf-merge-ccc-exclusions.py
+++ b/test/test-skf-merge-ccc-exclusions.py
@@ -68,6 +68,12 @@ def _read_settings(project: Path) -> dict:
     ("?ile",                         False),
     ("dir[abc]",                     False),
     ("**/wildcard",                  False),
+    # Invalid — unresolved {project-root}-style template placeholders (issue #293)
+    ("{project-root}/skills",        False),
+    ("{project-root}/forge-data",    False),
+    ("prefix/{var}/suffix",          False),
+    ("trailing}",                    False),
+    ("{leading",                     False),
 ])
 def test_validate_config_value(value, is_valid):
     cleaned, warning = mod.validate_config_value("skills_output_folder", value)
@@ -93,6 +99,12 @@ def test_validate_warning_messages_are_actionable():
 
     _, w = mod.validate_config_value("forge_data_folder", "x*")
     assert "glob meta" in w.lower()
+
+    # Issue #293: unresolved {project-root}-style placeholder names step-01b §3
+    _, w = mod.validate_config_value("skills_output_folder", "{project-root}/skills")
+    assert "skills_output_folder" in w
+    assert "placeholder" in w.lower()
+    assert "step-01b" in w  # Points the operator at the step that must do substitution
 
 
 def test_validate_strips_surrounding_whitespace():
@@ -305,6 +317,28 @@ def test_cli_pr248_glob_meta_in_forge_data_folder(tmp_project):
     settings = _read_settings(tmp_project)
     assert "**/forge-*" not in settings["exclude_patterns"]
     assert any("forge_data_folder" in w and "glob meta" in w.lower() for w in payload["warnings"])
+
+
+def test_cli_issue293_unresolved_placeholder_in_skills_folder(tmp_project):
+    """Issue #293 reproduction: step-01b passed '{project-root}/skills' literally
+    when it should have substituted and reduced to a basename. The resulting
+    `**/{project-root}/skills` glob silently never matched, so the SKF skills
+    directory was indexed by ccc anyway. Validator must reject the placeholder."""
+    rc, payload, _ = _run(tmp_project, skills="{project-root}/skills",
+                          forge_data="{project-root}/forge-data")
+    assert rc == 0
+    settings = _read_settings(tmp_project)
+    # The malformed placeholder-globs must NOT be present
+    assert "**/{project-root}/skills" not in settings["exclude_patterns"]
+    assert "**/{project-root}/forge-data" not in settings["exclude_patterns"]
+    # Always-include patterns survive
+    for p in mod.ALWAYS_INCLUDE:
+        assert p in settings["exclude_patterns"]
+    # Both rejected values produce actionable warnings
+    assert any("skills_output_folder" in w and "placeholder" in w.lower()
+               for w in payload["warnings"])
+    assert any("forge_data_folder" in w and "placeholder" in w.lower()
+               for w in payload["warnings"])
 
 
 # ─── Error paths ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **The bug:** step-01b §3 told operators to forward `{skills_output_folder}` and `{forge_data_folder}` directly to `skf-merge-ccc-exclusions.py`, but those values come from `config.yaml` as template strings literally containing `{project-root}`. The result was `**/{project-root}/skills` patterns in `.cocoindex_code/settings.yml` — cocoindex accepted them as literal-segment globs that silently never match, so the SKF infrastructure stayed indexed.
- **Step file:** `step-01b §3` now explicitly states the pre-processing the step must do — substitute `{project-root}` and reduce to the last path segment — with concrete examples for each value.
- **Defense-in-depth:** `skf-merge-ccc-exclusions.py` now rejects values containing `{` or `}` with an actionable warning that points back at step-01b §3, so a future regression in the step file gets caught at the script boundary instead of polluting `settings.yml`.

Fixes #293

## Test plan

- [x] `uv run pytest test/test-skf-merge-ccc-exclusions.py -v` — 40/40 pass, including the new parametric cases (5 `{project-root}`-style values) and the CLI-level reproduction `test_cli_issue293_unresolved_placeholder_in_skills_folder`.
- [x] `npm test` (full suite via pre-commit hook) passed.
- [x] Manual reviewer pass: confirm the warning message in the rejection path names step-01b §3 so a future operator can self-route.