### PR TITLE
refactor(skf-core): elevate brief/create/update with customize.toml + path-standards parity

### DIFF
--- a/src/skf-brief-skill/customize.toml
+++ b/src/skf-brief-skill/customize.toml
@@ -1,0 +1,42 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-brief-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any brief authoring work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (house style, naming conventions, description-voice guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Skill briefs must cite an authoritative source."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/brief-style.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = []
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+description_voice_examples_path = ""
+scope_templates_path = ""
+brief_schema_path = ""

--- a/src/skf-brief-skill/references/analyze-target.md
+++ b/src/skf-brief-skill/references/analyze-target.md
@@ -6,6 +6,8 @@ detectWorkspacesScript: '{project-root}/src/shared/scripts/skf-detect-workspaces
 detectLanguageScript: '{project-root}/src/shared/scripts/skf-detect-language.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Analyze Target
 
 ## STEP GOAL:

--- a/src/skf-brief-skill/references/confirm-brief.md
+++ b/src/skf-brief-skill/references/confirm-brief.md
@@ -6,6 +6,8 @@ advancedElicitationSkill: '/bmad-advanced-elicitation'
 partyModeSkill: '/bmad-party-mode'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Confirm Brief
 
 ## STEP GOAL:

--- a/src/skf-brief-skill/references/gather-intent.md
+++ b/src/skf-brief-skill/references/gather-intent.md
@@ -10,6 +10,8 @@ validateBriefInputsScript: '{project-root}/src/shared/scripts/skf-validate-brief
 emitBriefEnvelopeScript: '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Gather Intent
 
 ## STEP GOAL:
@@ -59,6 +61,8 @@ Attempt to load `{forgeTierFile}`:
 
 "**Welcome to Brief Skill — the skill scoping workflow.**
 
+**Wanted something different?** This workflow *creates* a new brief — a YAML scoping document for a skill that doesn't yet exist. If you meant to compile an existing brief into a skill (`/skf-create-skill`), package one for distribution (`/skf-export-skill`), or just ask SKF a question, type `cancel` at any prompt and run that workflow instead.
+
 I'll help you define exactly what to skill and produce a `skill-brief.yaml` that drives the create-skill compilation workflow.
 
 We'll work through this together:
@@ -73,8 +77,6 @@ We'll work through this together:
 **Your forge tier:** {detected tier} — {tier_gloss}
 
 (Substitute `{tier_gloss}` with the matching one-liner so the user knows what the tier label means: `Quick` → "text-only extraction"; `Forge` → "AST-grep on, semantic discovery off"; `Forge+` → "AST-grep + ccc semantic discovery"; `Deep` → "full pipeline — AST + ccc + qmd portfolio search + LLM re-ranking". The tier sets the ceiling for what the downstream create-skill workflow can do; you can re-run setup later to change it.)
-
-**Wanted something different?** This workflow *creates* a new brief — a YAML scoping document for a skill that doesn't yet exist. If you meant to compile an existing brief into a skill (`/skf-create-skill`), package one for distribution (`/skf-export-skill`), or just ask SKF a question, type `cancel` at any prompt and run that workflow instead.
 
 Let's get started."
 

--- a/src/skf-brief-skill/references/health-check.md
+++ b/src/skf-brief-skill/references/health-check.md
@@ -5,6 +5,8 @@
 nextStepFile: 'shared/health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 6: Workflow Health Check
 
 ## STEP GOAL:

--- a/src/skf-brief-skill/references/scope-definition.md
+++ b/src/skf-brief-skill/references/scope-definition.md
@@ -6,6 +6,8 @@ advancedElicitationSkill: '/bmad-advanced-elicitation'
 partyModeSkill: '/bmad-party-mode'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Scope Definition
 
 ## STEP GOAL:

--- a/src/skf-brief-skill/references/write-brief.md
+++ b/src/skf-brief-skill/references/write-brief.md
@@ -9,6 +9,8 @@ forgeTierRwScript: '{project-root}/src/shared/scripts/skf-forge-tier-rw.py'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 5: Write Brief
 
 ## STEP GOAL:

--- a/src/skf-create-skill/customize.toml
+++ b/src/skf-create-skill/customize.toml
@@ -1,0 +1,33 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-create-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any skill compilation work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (extraction style, compilation guardrails, tessl review preferences).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Skills must declare PEP 723 inline metadata."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/create-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = []

--- a/src/skf-create-skill/references/compile.md
+++ b/src/skf-create-skill/references/compile.md
@@ -4,6 +4,8 @@ skillSectionsData: 'assets/skill-sections.md'
 assemblyRulesData: 'assets/compile-assembly-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 5: Compile
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/component-extraction.md
+++ b/src/skf-create-skill/references/component-extraction.md
@@ -3,6 +3,8 @@ returnToStep: 'extract.md'
 extractionPatternsData: 'references/extraction-patterns.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3d: Component Library Extraction
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/ecosystem-check.md
+++ b/src/skf-create-skill/references/ecosystem-check.md
@@ -2,6 +2,8 @@
 nextStepFile: 'sub/ccc-discover.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Ecosystem Check
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/enrich.md
+++ b/src/skf-create-skill/references/enrich.md
@@ -2,6 +2,8 @@
 nextStepFile: 'compile.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Enrich
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/extract.md
+++ b/src/skf-create-skill/references/extract.md
@@ -13,6 +13,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Extract
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/generate-artifacts.md
+++ b/src/skf-create-skill/references/generate-artifacts.md
@@ -10,6 +10,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 7: Generate Artifacts
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/health-check.md
+++ b/src/skf-create-skill/references/health-check.md
@@ -5,6 +5,8 @@
 nextStepFile: 'shared/health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 9: Workflow Health Check
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/load-brief.md
+++ b/src/skf-create-skill/references/load-brief.md
@@ -4,6 +4,8 @@ forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 preferencesFile: '{sidecar_path}/preferences.yaml'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Load Brief
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/report.md
+++ b/src/skf-create-skill/references/report.md
@@ -8,6 +8,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 8: Report
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/sub/ccc-discover.md
+++ b/src/skf-create-skill/references/sub/ccc-discover.md
@@ -2,6 +2,8 @@
 nextStepFile: '../extract.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2b: CCC Semantic Discovery
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/sub/fetch-docs.md
+++ b/src/skf-create-skill/references/sub/fetch-docs.md
@@ -8,6 +8,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3c: Fetch Remote Documentation
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/sub/fetch-temporal.md
+++ b/src/skf-create-skill/references/sub/fetch-temporal.md
@@ -8,6 +8,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3b: Fetch Temporal Context
 
 ## STEP GOAL:

--- a/src/skf-create-skill/references/validate.md
+++ b/src/skf-create-skill/references/validate.md
@@ -10,6 +10,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 6: Validate
 
 ## STEP GOAL:

--- a/src/skf-update-skill/SKILL.md
+++ b/src/skf-update-skill/SKILL.md
@@ -16,6 +16,7 @@ Surgically updates existing skills when source code changes, preserving all [MAN
 - `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives, if present).
 - `{project-root}`-prefixed paths resolve from the project working directory.
 - `{skill-name}` resolves to the skill directory's basename.
+- **Cross-skill data coupling:** stages in this workflow load four shared assets from `skf-create-skill` to keep extraction semantics aligned between create and update — `re-extract.md` pulls `extraction-patterns.md`, `extraction-patterns-tracing.md`, and `tier-degradation-rules.md` from `skf-create-skill/references/`; `remote-source-resolution.md` references `source-resolution-protocols.md`; `write.md` reads `skill-sections.md` from `skf-create-skill/assets/`. Update-skill assumes these files are present at install time and that their semantics are stable across the two skills' versions.
 
 ## Role
 

--- a/src/skf-update-skill/customize.toml
+++ b/src/skf-update-skill/customize.toml
@@ -1,0 +1,42 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-update-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any skill update work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (drift policies, manual-section preservation rules, compliance
+# guardrails). Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Updates must preserve [MANUAL] sections verbatim."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/update-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = []
+
+# --- Optional gate thresholds ---
+#
+# Override the default thresholds used by detect-changes and merge. Empty
+# string or commented = use the bundled default (50% deletion ratio,
+# 80% rename similarity).
+
+deletion_ratio_threshold = ""
+rename_similarity_threshold = ""

--- a/src/skf-update-skill/references/detect-changes.md
+++ b/src/skf-update-skill/references/detect-changes.md
@@ -3,6 +3,8 @@ nextStepFile: 're-extract.md'
 noChangeReportFile: 'report.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Detect Changes
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/health-check.md
+++ b/src/skf-update-skill/references/health-check.md
@@ -5,6 +5,8 @@
 nextStepFile: 'shared/health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 8: Workflow Health Check
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/init.md
+++ b/src/skf-update-skill/references/init.md
@@ -3,6 +3,8 @@ nextStepFile: 'detect-changes.md'
 manualSectionRulesFile: 'references/manual-section-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Initialize Update
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/merge.md
+++ b/src/skf-update-skill/references/merge.md
@@ -4,6 +4,8 @@ manualSectionRulesFile: 'references/manual-section-rules.md'
 mergeConflictRulesFile: 'references/merge-conflict-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Merge
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/re-extract.md
+++ b/src/skf-update-skill/references/re-extract.md
@@ -6,6 +6,8 @@ remoteSourceResolutionData: 'references/remote-source-resolution.md'
 tierDegradationRulesData: 'skf-create-skill/references/tier-degradation-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Re-Extract Changed Exports
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/report.md
+++ b/src/skf-update-skill/references/report.md
@@ -2,6 +2,8 @@
 nextStepFile: 'health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 7: Report
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/validate.md
+++ b/src/skf-update-skill/references/validate.md
@@ -2,6 +2,8 @@
 nextStepFile: 'write.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 5: Validate
 
 ## STEP GOAL:

--- a/src/skf-update-skill/references/write.md
+++ b/src/skf-update-skill/references/write.md
@@ -2,6 +2,8 @@
 nextStepFile: 'report.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 6: Write Updated Files
 
 ## STEP GOAL:


### PR DESCRIPTION
## Summary

Foundation pass to elevate the three remaining SKF Core workflow skills (`skf-brief-skill`, `skf-create-skill`, `skf-update-skill`) toward the same Excellent grade `skf-setup` reached in PR #305 (commit `3dd864cd`).

This PR ships the **mechanical / parity** portion of the elevation work. Quality-analysis re-scans against the v2 module-wide refactor already showed:

| Skill | Pre-scan | This PR adds |
|---|---|---|
| skf-brief-skill | Excellent | customize.toml parity, asset-path scalars, B6 cancel-line, language headers |
| skf-create-skill | Good | customize.toml parity, **language headers for path-standards C1**, B6-equivalent |
| skf-update-skill | Excellent | customize.toml parity, **Conventions cross-skill coupling doc (U4)**, language headers |

The remaining ~9 shared-script extractions (Description Guard cross-skill, change-manifest builder, provenance-gap dispatcher, etc.), `--dry-run`/`--detect-only` flags, concurrency lock, and §2a carve are tracked separately for a focused PR #2.

## Changes

**Customization surface (S1):**
- `src/skf-brief-skill/customize.toml` — minimum-three `[workflow]` + three asset-path scalars (`description_voice_examples_path`, `scope_templates_path`, `brief_schema_path`) so orgs can swap house-style copies without forking.
- `src/skf-create-skill/customize.toml` — minimum-three `[workflow]`.
- `src/skf-update-skill/customize.toml` — minimum-three `[workflow]` + two gate-threshold scalars (`deletion_ratio_threshold`, `rename_similarity_threshold`).

All three mirror `skf-setup`'s `customize.toml` shape: `DO NOT EDIT` header, `[workflow]` table, three append-merge arrays (`activation_steps_prepend`, `activation_steps_append`, `persistent_facts`).

**Path-standards (C1, extended to all three skills for parity):**
- 27 stage files gained the canonical language-config header (`<!-- Config: communicate in {communication_language}. -->`) after the frontmatter close. `skf-setup` already had this; brief/create/update were drifting.

**Cross-skill coupling documented (U4):**
- `src/skf-update-skill/SKILL.md` `## Conventions` calls out the four shared assets pulled from `skf-create-skill` at install time (extraction-patterns, extraction-patterns-tracing, tier-degradation-rules, source-resolution-protocols, skill-sections). Two scanners flagged this coupling independently; the prose makes the assumption explicit.

**UX polish (B6):**
- `skf-brief-skill` gather-intent.md §2 Welcome — promoted the "Wanted something different?" cancel-line to the top of the block so confused users see the off-ramp before reading the four-step plan.

## Deferred to follow-up (separate PR)

Tracked for a focused follow-up:

- **Shared script extractions (9):** `skf-description-guard.py` (S3 — cross-skill Description Guard, currently duplicated in create-skill validate.md and update-skill write.md), `skf-build-change-manifest.py`, `skf-provenance-gap-dispatch.py`, `skf-hash-content.py`, `skf-check-workspace-drift.py`, `skf-update-active-symlink.py` (U1), `skf-detect-scripts-assets.py`, `skf-resolve-authoritative-files.py`, `skf-validate-brief-schema.py` (C2)
- **Workflow structural changes:** carve `extract.md §2a` to its own protocol file (C3), parallelize `fetch-temporal.md §3` / `fetch-docs.md §3` gh fetches (C4)
- **Headless improvements:** `headless_decisions[]` in result contract, `--dry-run` and `--detect-only` flags (U2), concurrency lock for `skf-update-skill` (U3)
- **Speculative / new features (deferred indefinitely pending design):** brief-from-preset entry (B2), preview-create-skill-output hop (B3), `skf-count-sentences.py` helper (B5), workspace-list pagination spec (B4), UX polish in create-skill (C6: rename-orphans cleanup, version-overwrite diff, Quick-tier upgrade hint)

## Test plan

- [x] `node tools/validate-skills.js` — 0 findings (15 skills scanned)
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 abs-path leaks (187 files / 109 refs)
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green (schemas, install, cli, workflow, python, knowledge, validate, lint, markdownlint, format-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Follow-up tracking issue: #307