### PR TITLE
feat(shared): extract scripts/assets detection from create-skill step 3 §4c

### DIFF
--- a/src/shared/scripts/skf-detect-scripts-assets.py
+++ b/src/shared/scripts/skf-detect-scripts-assets.py
@@ -1,0 +1,609 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SKF Detect Scripts & Assets — file-level artifact detection for skill compilation.
+
+Scans a source tree and identifies script and asset files per the detection
+heuristics documented in
+`src/skf-create-skill/references/extraction-patterns-tracing.md` (Script/Asset
+Extraction Patterns section). The output feeds `scripts_inventory[]` and
+`assets_inventory[]` in the create-skill workflow's extraction inventory
+(see step 3 §4c).
+
+This script replaces ~13 lines of prose plus implicit "compute SHA-256, read
+shebang, find header comments" operations that would otherwise be re-derived
+by the LLM on every run.
+
+Subcommand: a single `detect` subcommand keeps room for future extensions
+(e.g., `detect-entry-points` that only parses package.json/Cargo.toml).
+
+CLI:
+  uv run skf-detect-scripts-assets.py detect <source-root> \\
+      [--scripts-intent detect|none] \\
+      [--assets-intent detect|none] \\
+      [--scope-include "pattern1,pattern2,..."] \\
+      [--max-lines 500]
+
+Detection rules — scripts:
+  Directory convention: scripts/, bin/, tools/, cli/
+  Shebang signals: #!/bin/bash, #!/usr/bin/env python|node|bash|sh, etc.
+  Entry point declarations: package.json `bin`, pyproject.toml [project.scripts]
+  CLI argument-parser imports are detected for the LLM-judgment tier only —
+  this script flags the directory/shebang/entry-point cases that are fully
+  deterministic.
+
+Detection rules — assets:
+  Directory convention: assets/, templates/, schemas/, configs/, examples/
+  Pattern matches: *.schema.json (contains "$schema"), *.example,
+    *.template.*, *.sample, openapi.json, *.graphql, swagger.yaml
+
+Exclusions:
+  Binary extensions: .so, .dll, .jar, .wasm, .exe, .dylib, .a, .o, .pyc,
+    .class, .png, .jpg, .jpeg, .gif, .ico, .pdf, .zip, .tar, .gz, .tgz
+  Generated paths: dist/, build/, .webpack/, node_modules/, __pycache__/,
+    target/ (Rust), .next/, .nuxt/, out/, coverage/
+
+Size flag:
+  Files >max-lines (default 500) get size_flag="oversized" but are still
+  included — the caller decides whether to bundle them.
+
+Output JSON (stdout):
+  {
+    "scripts_inventory": [ {name, source_file, purpose, language,
+                            content_hash, confidence, lines, size_flag}, ... ],
+    "assets_inventory":  [ {name, source_file, purpose, type, content_hash,
+                            confidence, lines, size_flag}, ... ],
+    "scripts_skipped": false,
+    "assets_skipped":  false,
+    "stats": { "scripts_found": N, "assets_found": M, "files_scanned": K }
+  }
+
+Confidence is always "T1-low" — file existence verified, content not
+AST-analyzed. Matches the spec at extraction-patterns-tracing.md §Provenance.
+
+Exit codes:
+  0  — detection succeeded (including --scripts-intent=none --assets-intent=none)
+  1  — user error (bad source root, malformed args)
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+# --------------------------------------------------------------------------
+# Constants — detection rules (single source of truth)
+# --------------------------------------------------------------------------
+
+
+SCRIPT_DIRS = {"scripts", "bin", "tools", "cli"}
+ASSET_DIRS = {"assets", "templates", "schemas", "configs", "examples"}
+
+SHEBANG_LANGS = {
+    "bash": "bash",
+    "sh": "shell",
+    "zsh": "zsh",
+    "python": "python",
+    "python2": "python",
+    "python3": "python",
+    "node": "javascript",
+    "deno": "typescript",
+    "ruby": "ruby",
+    "perl": "perl",
+}
+
+EXTENSION_LANGS = {
+    ".sh": "shell",
+    ".bash": "bash",
+    ".zsh": "zsh",
+    ".py": "python",
+    ".js": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".rb": "ruby",
+    ".pl": "perl",
+    ".go": "go",
+    ".rs": "rust",
+}
+
+BINARY_EXTS = {
+    ".so", ".dll", ".jar", ".wasm", ".exe", ".dylib", ".a", ".o",
+    ".pyc", ".class", ".png", ".jpg", ".jpeg", ".gif", ".ico",
+    ".pdf", ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z",
+    ".woff", ".woff2", ".ttf", ".otf", ".eot",
+}
+
+# Path-segment names that mark generated/vendored output trees.
+EXCLUDED_DIR_NAMES = {
+    "node_modules", "__pycache__", "dist", "build", ".webpack",
+    "target", ".next", ".nuxt", "out", "coverage", ".git",
+    ".venv", "venv", ".tox", ".mypy_cache", ".pytest_cache",
+    ".ruff_cache", ".gradle", ".idea", ".vscode",
+}
+
+ASSET_TYPE_SCHEMA = "schema"
+ASSET_TYPE_TEMPLATE = "template"
+ASSET_TYPE_CONFIG = "config"
+ASSET_TYPE_EXAMPLE = "example"
+
+CONFIDENCE = "T1-low"
+
+
+# --------------------------------------------------------------------------
+# Walk + filter
+# --------------------------------------------------------------------------
+
+
+def iter_files(source_root: Path) -> Iterable[Path]:
+    """Yield every file under source_root, skipping excluded directory trees.
+
+    Done as a manual walk so we can prune EXCLUDED_DIR_NAMES at any depth
+    without scanning their contents (Path.rglob can't prune efficiently).
+    """
+    stack: list[Path] = [source_root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except (PermissionError, FileNotFoundError):
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                if entry.name in EXCLUDED_DIR_NAMES:
+                    continue
+                stack.append(entry)
+            elif entry.is_file():
+                yield entry
+
+
+def is_binary_path(path: Path) -> bool:
+    return path.suffix.lower() in BINARY_EXTS
+
+
+def relative_segments(path: Path, root: Path) -> tuple[str, ...]:
+    """Return path parts relative to root, dropping the filename."""
+    rel = path.relative_to(root)
+    return rel.parts[:-1]
+
+
+def in_directory(path: Path, root: Path, dir_names: set[str]) -> bool:
+    """True if any segment of path's relative dir is in dir_names."""
+    return any(seg in dir_names for seg in relative_segments(path, root))
+
+
+def matches_scope(path: Path, root: Path, scope_patterns: list[str]) -> bool:
+    """Match `path` against scope-include glob patterns relative to root."""
+    if not scope_patterns:
+        return True
+    rel = str(path.relative_to(root))
+    return any(fnmatch.fnmatch(rel, pattern) for pattern in scope_patterns)
+
+
+# --------------------------------------------------------------------------
+# Read helpers
+# --------------------------------------------------------------------------
+
+
+def read_text_safe(path: Path, *, max_bytes: int | None = None) -> str | None:
+    """Read text from `path` as UTF-8, returning None on decode failure
+    (treated as binary). Caller can pass max_bytes to bound reads of large
+    files."""
+    try:
+        if max_bytes is None:
+            return path.read_text(encoding="utf-8")
+        with path.open("rb") as fh:
+            blob = fh.read(max_bytes)
+        return blob.decode("utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+
+
+def sha256_of_file(path: Path) -> str:
+    """Compute SHA-256 of file content; emits with `sha256:` prefix."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def count_lines(path: Path) -> int:
+    """Count newlines in the file; returns 0 if file is unreadable."""
+    n = 0
+    try:
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                n += chunk.count(b"\n")
+    except OSError:
+        return 0
+    return n
+
+
+# --------------------------------------------------------------------------
+# Script detection
+# --------------------------------------------------------------------------
+
+
+_SHEBANG_RE = re.compile(rb"^#!.*?(\b(?:" + "|".join(SHEBANG_LANGS).encode() + rb")\b)")
+
+
+def detect_shebang_language(path: Path) -> str | None:
+    """Return language name if the file starts with a recognized shebang."""
+    try:
+        with path.open("rb") as fh:
+            first = fh.readline(256)
+    except OSError:
+        return None
+    if not first.startswith(b"#!"):
+        return None
+    match = _SHEBANG_RE.match(first)
+    if not match:
+        return None
+    interp = match.group(1).decode()
+    return SHEBANG_LANGS.get(interp)
+
+
+def detect_language(path: Path, *, shebang_lang: str | None) -> str:
+    """Determine the script's language for the inventory record."""
+    if shebang_lang:
+        return shebang_lang
+    ext_lang = EXTENSION_LANGS.get(path.suffix.lower())
+    if ext_lang:
+        return ext_lang
+    return "unknown"
+
+
+def entry_point_script_paths(source_root: Path) -> set[Path]:
+    """Parse package.json `bin` and pyproject.toml [project.scripts] to find
+    explicit entry-point scripts. Returns absolute paths that exist on disk.
+
+    Other manifest formats (Cargo.toml [[bin]]) are handled by directory
+    convention (`src/bin/` etc.) rather than parsing — adding a Cargo parser
+    is future work and not in this script's scope per the deterministic-only
+    extraction rule.
+    """
+    found: set[Path] = set()
+    found.update(_parse_package_json_bin(source_root))
+    found.update(_parse_pyproject_scripts(source_root))
+    return found
+
+
+def _parse_package_json_bin(source_root: Path) -> Iterable[Path]:
+    pkg = source_root / "package.json"
+    if not pkg.is_file():
+        return ()
+    text = read_text_safe(pkg, max_bytes=512 * 1024)
+    if text is None:
+        return ()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return ()
+    bin_field = data.get("bin")
+    if isinstance(bin_field, str):
+        candidates = [bin_field]
+    elif isinstance(bin_field, dict):
+        candidates = [v for v in bin_field.values() if isinstance(v, str)]
+    else:
+        return ()
+    out: list[Path] = []
+    for cand in candidates:
+        # bin paths are relative to package.json
+        p = (source_root / cand).resolve()
+        if p.is_file():
+            out.append(p)
+    return out
+
+
+def _parse_pyproject_scripts(source_root: Path) -> Iterable[Path]:
+    """Pyproject [project.scripts] points at a dotted module path, not a file
+    path — we can't deterministically map `mypkg.cli:main` to a script file
+    without invoking the package's installer. We instead surface the existence
+    of any [project.scripts] entry as a hint by treating any file under
+    `<source_root>/<top-level>/__main__.py` or files matching the cli module
+    in standard layouts. To avoid speculative mapping, this function returns
+    an empty set today; the directory-convention path picks up most cases
+    (script-like files in scripts/ or bin/). Future work: parse setuptools
+    package layout to resolve.
+    """
+    _ = source_root
+    return ()
+
+
+def is_script(path: Path, source_root: Path, *, entry_points: set[Path]) -> tuple[bool, str | None]:
+    """Decide whether `path` is a script. Returns (is_script, shebang_lang)."""
+    if path.resolve() in entry_points:
+        return True, detect_shebang_language(path)
+    if in_directory(path, source_root, SCRIPT_DIRS):
+        return True, detect_shebang_language(path)
+    shebang_lang = detect_shebang_language(path)
+    if shebang_lang is not None:
+        return True, shebang_lang
+    return False, None
+
+
+# --------------------------------------------------------------------------
+# Asset detection
+# --------------------------------------------------------------------------
+
+
+_ASSET_FILENAME_TYPE: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r".*\.schema\.json$", re.IGNORECASE), ASSET_TYPE_SCHEMA),
+    (re.compile(r"^openapi\.(json|ya?ml)$", re.IGNORECASE), ASSET_TYPE_SCHEMA),
+    (re.compile(r"^swagger\.(json|ya?ml)$", re.IGNORECASE), ASSET_TYPE_SCHEMA),
+    (re.compile(r".*\.graphql$", re.IGNORECASE), ASSET_TYPE_SCHEMA),
+    (re.compile(r".*\.template\..+$", re.IGNORECASE), ASSET_TYPE_TEMPLATE),
+    (re.compile(r".*\.(example|sample)(\..+)?$", re.IGNORECASE), ASSET_TYPE_EXAMPLE),
+]
+
+
+def asset_type(path: Path, source_root: Path) -> str | None:
+    """Return the asset type for `path` or None if it doesn't match asset rules."""
+    # Pattern-based detection (works regardless of containing directory)
+    for pattern, atype in _ASSET_FILENAME_TYPE:
+        if pattern.match(path.name):
+            return atype
+
+    if in_directory(path, source_root, ASSET_DIRS):
+        segments = set(relative_segments(path, source_root))
+        if "templates" in segments:
+            return ASSET_TYPE_TEMPLATE
+        if "schemas" in segments:
+            # JSON schema content check
+            if path.suffix.lower() == ".json":
+                text = read_text_safe(path, max_bytes=64 * 1024)
+                if text and '"$schema"' in text:
+                    return ASSET_TYPE_SCHEMA
+            return ASSET_TYPE_SCHEMA
+        if "configs" in segments:
+            return ASSET_TYPE_CONFIG
+        if "examples" in segments:
+            return ASSET_TYPE_EXAMPLE
+        # assets/ — type unknown, default to config (safer than template)
+        return ASSET_TYPE_CONFIG
+    return None
+
+
+# --------------------------------------------------------------------------
+# Purpose extraction
+# --------------------------------------------------------------------------
+
+
+_HEADER_COMMENT_RE = re.compile(
+    r"^\s*(?:#|//|/\*|\*)\s*(.{3,})$"
+)
+
+
+def extract_purpose(path: Path, *, asset_type_hint: str | None) -> str:
+    """Pull a one-line purpose summary from the file's leading content.
+
+    Heuristics (first match wins):
+      - JSON schema: read top-level `title` or `description` field
+      - Files with header comments: first comment line after any shebang
+      - Otherwise: fall back to the filename (per spec)
+    """
+    if asset_type_hint == ASSET_TYPE_SCHEMA and path.suffix.lower() == ".json":
+        text = read_text_safe(path, max_bytes=64 * 1024)
+        if text:
+            try:
+                data = json.loads(text)
+                for key in ("title", "description"):
+                    val = data.get(key) if isinstance(data, dict) else None
+                    if isinstance(val, str) and val.strip():
+                        return val.strip()
+            except json.JSONDecodeError:
+                pass
+
+    text = read_text_safe(path, max_bytes=4 * 1024)
+    if text:
+        for i, line in enumerate(text.splitlines()[:10]):
+            if i == 0 and line.startswith("#!"):
+                continue
+            if not line.strip():
+                continue
+            match = _HEADER_COMMENT_RE.match(line)
+            if match:
+                purpose = match.group(1).strip().rstrip("*/").strip()
+                if purpose:
+                    return purpose
+
+    return path.name
+
+
+# --------------------------------------------------------------------------
+# Build records
+# --------------------------------------------------------------------------
+
+
+def build_script_record(
+    path: Path, source_root: Path, *, shebang_lang: str | None, max_lines: int
+) -> dict:
+    rel = str(path.relative_to(source_root))
+    lines = count_lines(path)
+    return {
+        "name": path.name,
+        "source_file": rel,
+        "purpose": extract_purpose(path, asset_type_hint=None),
+        "language": detect_language(path, shebang_lang=shebang_lang),
+        "content_hash": sha256_of_file(path),
+        "confidence": CONFIDENCE,
+        "lines": lines,
+        "size_flag": "oversized" if lines > max_lines else None,
+    }
+
+
+def build_asset_record(
+    path: Path, source_root: Path, *, atype: str, max_lines: int
+) -> dict:
+    rel = str(path.relative_to(source_root))
+    lines = count_lines(path)
+    return {
+        "name": path.name,
+        "source_file": rel,
+        "purpose": extract_purpose(path, asset_type_hint=atype),
+        "type": atype,
+        "content_hash": sha256_of_file(path),
+        "confidence": CONFIDENCE,
+        "lines": lines,
+        "size_flag": "oversized" if lines > max_lines else None,
+    }
+
+
+# --------------------------------------------------------------------------
+# Main detection
+# --------------------------------------------------------------------------
+
+
+def detect(
+    source_root: Path,
+    *,
+    scripts_intent: str = "detect",
+    assets_intent: str = "detect",
+    scope_patterns: list[str] | None = None,
+    max_lines: int = 500,
+) -> dict:
+    scope_patterns = scope_patterns or []
+    scripts_skipped = scripts_intent == "none"
+    assets_skipped = assets_intent == "none"
+
+    scripts_inventory: list[dict] = []
+    assets_inventory: list[dict] = []
+    files_scanned = 0
+
+    entry_points = (
+        entry_point_script_paths(source_root) if not scripts_skipped else set()
+    )
+
+    if not scripts_skipped or not assets_skipped:
+        for path in iter_files(source_root):
+            files_scanned += 1
+            if is_binary_path(path):
+                continue
+            if not matches_scope(path, source_root, scope_patterns):
+                continue
+
+            if not scripts_skipped:
+                is_scr, shebang_lang = is_script(
+                    path, source_root, entry_points=entry_points
+                )
+                if is_scr:
+                    scripts_inventory.append(
+                        build_script_record(
+                            path, source_root,
+                            shebang_lang=shebang_lang, max_lines=max_lines,
+                        )
+                    )
+                    continue  # a script can't also be an asset
+
+            if not assets_skipped:
+                atype = asset_type(path, source_root)
+                if atype is not None:
+                    assets_inventory.append(
+                        build_asset_record(
+                            path, source_root, atype=atype, max_lines=max_lines,
+                        )
+                    )
+
+    # Deterministic ordering for stable diffs / cacheability
+    scripts_inventory.sort(key=lambda r: r["source_file"])
+    assets_inventory.sort(key=lambda r: r["source_file"])
+
+    return {
+        "scripts_inventory": scripts_inventory,
+        "assets_inventory": assets_inventory,
+        "scripts_skipped": scripts_skipped,
+        "assets_skipped": assets_skipped,
+        "stats": {
+            "scripts_found": len(scripts_inventory),
+            "assets_found": len(assets_inventory),
+            "files_scanned": files_scanned,
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _cmd_detect(args: argparse.Namespace) -> int:
+    source_root = Path(args.source_root).resolve()
+    if not source_root.is_dir():
+        print(f"error: source root not a directory: {source_root}", file=sys.stderr)
+        return 1
+    scope_patterns = (
+        [s.strip() for s in args.scope_include.split(",") if s.strip()]
+        if args.scope_include
+        else []
+    )
+    if args.scripts_intent not in ("detect", "none"):
+        print(f"error: --scripts-intent must be detect|none", file=sys.stderr)
+        return 1
+    if args.assets_intent not in ("detect", "none"):
+        print(f"error: --assets-intent must be detect|none", file=sys.stderr)
+        return 1
+
+    result = detect(
+        source_root,
+        scripts_intent=args.scripts_intent,
+        assets_intent=args.assets_intent,
+        scope_patterns=scope_patterns,
+        max_lines=args.max_lines,
+    )
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skf-detect-scripts-assets",
+        description="Detect script and asset files in a source tree per SKF extraction rules.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("detect", help="scan a source tree and emit inventory JSON")
+    p.add_argument("source_root", help="path to the source tree root")
+    p.add_argument(
+        "--scripts-intent",
+        default="detect",
+        help="detect|none (default: detect)",
+    )
+    p.add_argument(
+        "--assets-intent",
+        default="detect",
+        help="detect|none (default: detect)",
+    )
+    p.add_argument(
+        "--scope-include",
+        default=None,
+        help="comma-separated glob patterns to limit detection (relative to source-root)",
+    )
+    p.add_argument(
+        "--max-lines",
+        type=int,
+        default=500,
+        help="files above this line count get size_flag='oversized' (default: 500)",
+    )
+    p.set_defaults(func=_cmd_detect)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/skf-create-skill/references/extract.md
+++ b/src/skf-create-skill/references/extract.md
@@ -11,6 +11,13 @@ sourceResolutionData: 'references/source-resolution-protocols.md'
 atomicWriteProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
+# Resolve `{detectScriptsAssetsHelper}` to the first existing path; HALT if
+# neither candidate exists. §4c relies on the helper for deterministic
+# script/asset detection (file walk, SHA-256 hashing, header-comment purpose
+# extraction); falling back to prose-driven detection would lose hash stability.
+detectScriptsAssetsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-detect-scripts-assets.py'
+  - '{project-root}/src/shared/scripts/skf-detect-scripts-assets.py'
 ---
 
 <!-- Config: communicate in {communication_language}. -->
@@ -297,15 +304,29 @@ Use the entry point as the authoritative source for `metadata.json`'s `exports[]
 
 **Default resolution:** If `scripts_intent` is absent from the brief, treat as `"detect"` (auto-detection). If `assets_intent` is absent, treat as `"detect"`. Only an explicit `"none"` value disables detection.
 
-**If `scripts_intent` is `"none"` AND `assets_intent` is `"none"`:** Skip this section entirely. **If only one is `"none"`:** Skip that category only, proceed with the other.
+Invoke the deterministic detector — it implements the heuristics from `{extractionPatternsTracingData}` (directory conventions, shebang signals, `package.json` `bin` entry-points, asset filename patterns, binary-extension exclusion, generated-path pruning) so this stage doesn't re-derive them per-run:
 
-After export extraction, scan the source for scripts and assets using the detection patterns in `{extractionPatternsTracingData}`:
+```bash
+uv run {detectScriptsAssetsHelper} detect <source-root> \
+    --scripts-intent <scripts_intent> \
+    --assets-intent <assets_intent> \
+    [--scope-include "<glob1>,<glob2>,..."] \
+    [--max-lines 500]
+```
 
-1. Scan source tree for directories/files matching detection heuristics (scripts/, bin/, tools/, cli/ for scripts; assets/, templates/, schemas/, configs/, examples/ for assets)
-2. For each candidate: verify existence, check size (flag >500 lines), exclude binaries, compute SHA-256 hash
-3. Extract purpose from header comments, shebang, README references, or schema fields. Record: file_path, purpose, source_path, language/type, content_hash, confidence (T1-low)
+The helper emits JSON on stdout:
 
-Add results to `scripts_inventory[]` and `assets_inventory[]` alongside the existing export inventory.
+```json
+{
+  "scripts_inventory": [ {name, source_file, purpose, language, content_hash, confidence, lines, size_flag}, ... ],
+  "assets_inventory":  [ {name, source_file, purpose, type,     content_hash, confidence, lines, size_flag}, ... ],
+  "scripts_skipped": <bool>,
+  "assets_skipped":  <bool>,
+  "stats": { "scripts_found": N, "assets_found": M, "files_scanned": K }
+}
+```
+
+Merge `scripts_inventory[]` and `assets_inventory[]` into the running extraction inventory verbatim — entries already carry `confidence: "T1-low"` and `content_hash` (sha256:...). Records with `size_flag: "oversized"` should be surfaced in §6 (Extraction Summary) so the user can confirm before bundling. If both `scripts_skipped` and `assets_skipped` are true, the helper performs no walk and §4c is effectively a no-op.
 
 ### 5. Build Extraction Inventory
 

--- a/test/test-skf-detect-scripts-assets.py
+++ b/test/test-skf-detect-scripts-assets.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Tests for skf-detect-scripts-assets.py.
+
+Covers detection rules from src/skf-create-skill/references/extraction-patterns-tracing.md:
+  - Script directory convention (scripts/, bin/, tools/, cli/)
+  - Shebang signals (#!/bin/bash, #!/usr/bin/env python|node|...)
+  - Entry point declarations (package.json `bin`)
+  - Asset directory convention + filename patterns (*.schema.json, *.template.*, ...)
+  - Binary exclusion + generated-path pruning
+  - Size flagging + scope filtering
+  - Intent gates (scripts_intent=none, assets_intent=none)
+  - Purpose extraction (header comment, schema title, filename fallback)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT_PATH = REPO_ROOT / "src" / "shared" / "scripts" / "skf-detect-scripts-assets.py"
+
+spec = importlib.util.spec_from_file_location("skf_detect_scripts_assets", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mod)
+
+
+# --------------------------------------------------------------------------
+# Fixture helpers
+# --------------------------------------------------------------------------
+
+
+def write_file(path: Path, content: str = "", *, executable: bool = False) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    if executable:
+        path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return path
+
+
+# --------------------------------------------------------------------------
+# Script directory convention
+# --------------------------------------------------------------------------
+
+
+class TestScriptDirectoryConvention:
+    def test_file_in_scripts_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "deploy.sh", "echo hello\n")
+        result = mod.detect(tmp_path)
+        assert len(result["scripts_inventory"]) == 1
+        rec = result["scripts_inventory"][0]
+        assert rec["source_file"] == "scripts/deploy.sh"
+        assert rec["language"] == "shell"
+        assert rec["confidence"] == "T1-low"
+        assert rec["content_hash"].startswith("sha256:")
+
+    def test_file_in_bin_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "bin" / "tool.py", "import sys\n")
+        result = mod.detect(tmp_path)
+        assert any(r["name"] == "tool.py" for r in result["scripts_inventory"])
+
+    def test_file_in_tools_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "tools" / "lint.js", "console.log('x')\n")
+        result = mod.detect(tmp_path)
+        assert any(r["name"] == "lint.js" for r in result["scripts_inventory"])
+
+    def test_nested_script_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "pkg" / "scripts" / "build.sh", "")
+        result = mod.detect(tmp_path)
+        assert any(r["name"] == "build.sh" for r in result["scripts_inventory"])
+
+
+# --------------------------------------------------------------------------
+# Shebang signals
+# --------------------------------------------------------------------------
+
+
+class TestShebangSignals:
+    def test_bash_shebang(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "deploy", "#!/bin/bash\necho hi\n")
+        result = mod.detect(tmp_path)
+        rec = result["scripts_inventory"][0]
+        assert rec["language"] == "bash"
+
+    def test_env_python_shebang(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "tool", "#!/usr/bin/env python3\nimport sys\n")
+        result = mod.detect(tmp_path)
+        rec = result["scripts_inventory"][0]
+        assert rec["language"] == "python"
+
+    def test_env_node_shebang(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "cli", "#!/usr/bin/env node\nconsole.log()\n")
+        result = mod.detect(tmp_path)
+        rec = result["scripts_inventory"][0]
+        assert rec["language"] == "javascript"
+
+    def test_no_shebang_no_dir_not_detected(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "lib.py", "def foo(): pass\n")
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"] == []
+
+
+# --------------------------------------------------------------------------
+# Entry-point declarations (package.json bin)
+# --------------------------------------------------------------------------
+
+
+class TestPackageJsonBin:
+    def test_bin_string(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "package.json",
+            '{"name": "mytool", "bin": "src/cli.js"}',
+        )
+        write_file(tmp_path / "src" / "cli.js", "// cli entry\n")
+        result = mod.detect(tmp_path)
+        # cli.js is in src/, not scripts/, so it's detected via entry-point only
+        assert any(r["source_file"] == "src/cli.js" for r in result["scripts_inventory"])
+
+    def test_bin_object(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "package.json",
+            '{"name": "x", "bin": {"foo": "lib/foo.js", "bar": "lib/bar.js"}}',
+        )
+        write_file(tmp_path / "lib" / "foo.js", "")
+        write_file(tmp_path / "lib" / "bar.js", "")
+        result = mod.detect(tmp_path)
+        names = {r["name"] for r in result["scripts_inventory"]}
+        assert names == {"foo.js", "bar.js"}
+
+    def test_bin_missing_file_ignored(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "package.json",
+            '{"name": "x", "bin": "missing.js"}',
+        )
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"] == []
+
+    def test_malformed_package_json_no_crash(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "package.json", "{not json")
+        write_file(tmp_path / "scripts" / "ok.sh", "")
+        result = mod.detect(tmp_path)
+        # malformed package.json doesn't kill scanning
+        assert any(r["name"] == "ok.sh" for r in result["scripts_inventory"])
+
+
+# --------------------------------------------------------------------------
+# Asset detection
+# --------------------------------------------------------------------------
+
+
+class TestAssetDetection:
+    def test_schema_json_in_schemas_dir(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "schemas" / "config.schema.json",
+            '{"$schema": "http://json-schema.org/draft-07/schema#", "title": "Config"}',
+        )
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "schema"
+        assert rec["purpose"] == "Config"
+
+    def test_schema_json_outside_schemas_dir(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "pkg" / "user.schema.json",
+            '{"$schema": "x"}',
+        )
+        result = mod.detect(tmp_path)
+        # pattern-based detection catches *.schema.json anywhere
+        assert len(result["assets_inventory"]) == 1
+        assert result["assets_inventory"][0]["type"] == "schema"
+
+    def test_template_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "templates" / "report.md.template", "# {{title}}\n")
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "template"
+
+    def test_configs_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "configs" / "production.yaml", "key: value\n")
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "config"
+
+    def test_examples_dir(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "examples" / "basic.md", "# Example\n")
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "example"
+
+    def test_openapi_json(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "openapi.json", '{"openapi": "3.0.0"}')
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "schema"
+
+    def test_graphql_file(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "api.graphql", "type Query { hello: String }\n")
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "schema"
+
+    def test_sample_extension(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "config.sample", "# sample\n")
+        result = mod.detect(tmp_path)
+        rec = result["assets_inventory"][0]
+        assert rec["type"] == "example"
+
+
+# --------------------------------------------------------------------------
+# Exclusions
+# --------------------------------------------------------------------------
+
+
+class TestExclusions:
+    def test_binary_extension_excluded(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "tool.exe", "")
+        write_file(tmp_path / "lib" / "blob.so", "")
+        write_file(tmp_path / "assets" / "icon.png", "")
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"] == []
+        assert result["assets_inventory"] == []
+
+    def test_node_modules_pruned(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "node_modules" / "lib" / "scripts" / "x.sh", "")
+        write_file(tmp_path / "scripts" / "deploy.sh", "")
+        result = mod.detect(tmp_path)
+        names = [r["name"] for r in result["scripts_inventory"]]
+        assert names == ["deploy.sh"]
+
+    def test_dist_pruned(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "dist" / "scripts" / "bundle.js", "")
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"] == []
+
+    def test_pycache_pruned(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "__pycache__" / "x.cpython-310.pyc", "")
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"] == []
+
+    def test_git_pruned(self, tmp_path: Path) -> None:
+        write_file(tmp_path / ".git" / "hooks" / "pre-commit", "#!/bin/sh\n")
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"] == []
+
+
+# --------------------------------------------------------------------------
+# Size flagging
+# --------------------------------------------------------------------------
+
+
+class TestSizeFlag:
+    def test_under_threshold_no_flag(self, tmp_path: Path) -> None:
+        content = "echo line\n" * 100
+        write_file(tmp_path / "scripts" / "small.sh", content)
+        result = mod.detect(tmp_path)
+        rec = result["scripts_inventory"][0]
+        assert rec["lines"] == 100
+        assert rec["size_flag"] is None
+
+    def test_over_threshold_flagged(self, tmp_path: Path) -> None:
+        content = "echo line\n" * 600
+        write_file(tmp_path / "scripts" / "big.sh", content)
+        result = mod.detect(tmp_path, max_lines=500)
+        rec = result["scripts_inventory"][0]
+        assert rec["lines"] == 600
+        assert rec["size_flag"] == "oversized"
+
+
+# --------------------------------------------------------------------------
+# Scope filtering
+# --------------------------------------------------------------------------
+
+
+class TestScope:
+    def test_scope_include_filter(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "include-me.sh", "")
+        write_file(tmp_path / "tools" / "exclude-me.sh", "")
+        result = mod.detect(tmp_path, scope_patterns=["scripts/*"])
+        names = {r["name"] for r in result["scripts_inventory"]}
+        assert names == {"include-me.sh"}
+
+    def test_empty_scope_includes_everything(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "a.sh", "")
+        write_file(tmp_path / "tools" / "b.sh", "")
+        result = mod.detect(tmp_path, scope_patterns=[])
+        names = {r["name"] for r in result["scripts_inventory"]}
+        assert names == {"a.sh", "b.sh"}
+
+
+# --------------------------------------------------------------------------
+# Intent gates
+# --------------------------------------------------------------------------
+
+
+class TestIntentGates:
+    def test_scripts_intent_none(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "x.sh", "")
+        write_file(tmp_path / "assets" / "y.yaml", "")
+        result = mod.detect(tmp_path, scripts_intent="none")
+        assert result["scripts_skipped"] is True
+        assert result["scripts_inventory"] == []
+        # assets still detected
+        assert len(result["assets_inventory"]) == 1
+
+    def test_assets_intent_none(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "x.sh", "")
+        write_file(tmp_path / "assets" / "y.yaml", "")
+        result = mod.detect(tmp_path, assets_intent="none")
+        assert result["assets_skipped"] is True
+        assert result["assets_inventory"] == []
+        assert len(result["scripts_inventory"]) == 1
+
+    def test_both_none_no_walk(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "x.sh", "")
+        result = mod.detect(tmp_path, scripts_intent="none", assets_intent="none")
+        assert result["stats"]["files_scanned"] == 0
+        assert result["scripts_skipped"] is True
+        assert result["assets_skipped"] is True
+
+
+# --------------------------------------------------------------------------
+# Purpose extraction
+# --------------------------------------------------------------------------
+
+
+class TestPurpose:
+    def test_purpose_from_header_comment_bash(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "scripts" / "deploy.sh",
+            "#!/bin/bash\n# Deploy the app to staging\nset -e\n",
+        )
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"][0]["purpose"] == "Deploy the app to staging"
+
+    def test_purpose_from_header_comment_python(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "scripts" / "tool.py",
+            "#!/usr/bin/env python\n# Tool that processes things\nimport sys\n",
+        )
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"][0]["purpose"] == "Tool that processes things"
+
+    def test_purpose_from_header_comment_js(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "scripts" / "build.js",
+            "// Build the project\nconst x = 1\n",
+        )
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"][0]["purpose"] == "Build the project"
+
+    def test_purpose_from_schema_title(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "user.schema.json",
+            '{"$schema": "x", "title": "User Profile", "description": "ignored"}',
+        )
+        result = mod.detect(tmp_path)
+        assert result["assets_inventory"][0]["purpose"] == "User Profile"
+
+    def test_purpose_from_schema_description_fallback(self, tmp_path: Path) -> None:
+        write_file(
+            tmp_path / "x.schema.json",
+            '{"$schema": "x", "description": "A schema with no title"}',
+        )
+        result = mod.detect(tmp_path)
+        assert result["assets_inventory"][0]["purpose"] == "A schema with no title"
+
+    def test_purpose_falls_back_to_filename(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "no-comments.sh", "echo x\n")
+        result = mod.detect(tmp_path)
+        assert result["scripts_inventory"][0]["purpose"] == "no-comments.sh"
+
+
+# --------------------------------------------------------------------------
+# Determinism & ordering
+# --------------------------------------------------------------------------
+
+
+class TestOrdering:
+    def test_scripts_sorted_by_source_file(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "zzz.sh", "")
+        write_file(tmp_path / "scripts" / "aaa.sh", "")
+        write_file(tmp_path / "bin" / "mmm.sh", "")
+        result = mod.detect(tmp_path)
+        paths = [r["source_file"] for r in result["scripts_inventory"]]
+        assert paths == sorted(paths)
+
+    def test_hash_stable_across_runs(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "x.sh", "echo hi\n")
+        r1 = mod.detect(tmp_path)
+        r2 = mod.detect(tmp_path)
+        assert r1 == r2
+
+
+# --------------------------------------------------------------------------
+# CLI integration
+# --------------------------------------------------------------------------
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestCli:
+    def test_detect_emits_json(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "x.sh", "")
+        result = _run_cli("detect", str(tmp_path))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert "scripts_inventory" in payload
+        assert "assets_inventory" in payload
+        assert "stats" in payload
+
+    def test_bad_source_root_exits_1(self, tmp_path: Path) -> None:
+        result = _run_cli("detect", str(tmp_path / "missing"))
+        assert result.returncode == 1
+        assert "not a directory" in result.stderr
+
+    def test_bad_intent_exits_1(self, tmp_path: Path) -> None:
+        result = _run_cli(
+            "detect", str(tmp_path), "--scripts-intent", "bogus"
+        )
+        assert result.returncode == 1
+
+    def test_scope_include_passes_through(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "a.sh", "")
+        write_file(tmp_path / "tools" / "b.sh", "")
+        result = _run_cli(
+            "detect", str(tmp_path), "--scope-include", "scripts/*"
+        )
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        names = {r["name"] for r in payload["scripts_inventory"]}
+        assert names == {"a.sh"}
+
+    def test_max_lines_passes_through(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "scripts" / "x.sh", "echo\n" * 50)
+        result = _run_cli(
+            "detect", str(tmp_path), "--max-lines", "10"
+        )
+        payload = json.loads(result.stdout)
+        assert payload["scripts_inventory"][0]["size_flag"] == "oversized"


### PR DESCRIPTION
## Summary

Issue #307 workstream **A7** — the second-most-impactful create-skill extraction. `extract.md §4c` previously asked the LLM to scan the source tree, match directory and filename heuristics, exclude binaries, prune generated paths, compute SHA-256 hashes, and extract purposes from header comments — all on every run. ~13 lines of prose specifying file-walk, hashing, and parser semantics that had to be re-derived per-invocation. The new helper makes it one bash call with stable hashes across runs.

## Changes

**New: `src/shared/scripts/skf-detect-scripts-assets.py`** — PEP 723, stdlib only
- `detect <source-root>` subcommand with `--scripts-intent`, `--assets-intent`, `--scope-include`, `--max-lines` flags
- Manual tree walk with directory pruning (no `Path.rglob` — can't prune efficiently). Skips `node_modules`, `__pycache__`, `dist`, `build`, `.git`, `target`, `.next`, `coverage`, `.venv`, `.mypy_cache`, `.pytest_cache`, etc.
- **Script detection:** directory convention (`scripts/`, `bin/`, `tools/`, `cli/`), shebang (bash/sh/zsh/python/node/deno/ruby/perl), explicit entry points (`package.json` `bin` as string or object)
- **Asset detection:** `*.schema.json` anywhere, `openapi.{json,yaml}`, `swagger.{json,yaml}`, `*.graphql`, `*.template.*`, `*.sample`, `*.example.*` — plus directory convention (`assets/`, `templates/`, `schemas/`, `configs/`, `examples/`) with type inferred from directory
- **Purpose extraction:** JSON-schema `title`/`description` for schemas, first header comment after any shebang for scripts, filename fallback per spec
- **Binary exclusion:** `.so`, `.dll`, `.jar`, `.wasm`, `.exe`, images, archives, fonts, `.pyc`, `.class`
- **Size flagging:** files > `--max-lines` (default 500) get `size_flag="oversized"` but are still inventoried
- **Deterministic output:** inventories sorted by `source_file` so diffs and caching are stable

**New: `test/test-skf-detect-scripts-assets.py`** — 45 tests
- Script directory convention (scripts/bin/tools, nested)
- Shebang signals (bash, env python, env node, no shebang → not detected)
- `package.json` bin (string, object, missing-file ignored, malformed JSON doesn't kill scan)
- Asset detection (schema in/out of schemas/, templates/, configs/, examples/, openapi.json, *.graphql, *.sample)
- Exclusions (binary ext, node_modules/dist/__pycache__/.git pruned)
- Size flagging, scope filtering, intent gates (`scripts=none`, `assets=none`, both=none → no walk)
- Purpose extraction (bash/python/JS header comments, schema title, schema description fallback, filename fallback)
- Determinism (sorted output, hash stable across runs)
- CLI integration (JSON output, bad root → exit 1, bad intent → exit 1, scope-include + max-lines pass-through)

**Wired: `src/skf-create-skill/references/extract.md`**
- Frontmatter gains `detectScriptsAssetsProbeOrder` (installed module path first, src/ dev-checkout fallback — same shape as `atomicWriteProbeOrder`)
- §4c's 4-step prose ("scan tree", "verify + hash", "extract purpose", "add to inventory") collapses to a single helper invocation + output-merge contract
- `extractionPatternsTracingData` remains authoritative for LLM-judgment signals (CLI-parser imports, CI/CD references) that §5 inventory polish still uses

## Test plan

- [x] `python3 -m pytest test/test-skf-detect-scripts-assets.py` — 45/45 pass in 0.3s
- [x] `node tools/validate-skills.js` — 0 findings
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 leaks
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green

Tracks: #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)