### PR TITLE
feat(shared): extract SHA-256 hashing helpers from update-skill detect-changes

### DIFF
--- a/src/shared/scripts/skf-hash-content.py
+++ b/src/shared/scripts/skf-hash-content.py
@@ -1,0 +1,284 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SKF Hash Content — SHA-256 hashing helpers for skill workflows.
+
+Two patterns recur across the update-skill workflow's stage prose:
+
+  1. **Single-file hash** — detect-changes.md §1b, when a candidate file is
+     promoted into `brief.scope.include`, the LLM is asked to "compute SHA-256
+     content hash of candidate.path" and emit a record
+     `{path, heuristic, size_bytes, line_count, content_hash}` for
+     `promoted_docs_new[]`. Deterministic file-read + hashlib.sha256.
+
+  2. **Bulk-compare against provenance** — detect-changes.md §Category D,
+     where the LLM is asked to "for each file_entry: compute current SHA-256
+     content hash, compare against stored hash" and classify entries as
+     MODIFIED_FILE / DELETED_FILE / (UNCHANGED). Same hashing primitive,
+     iterated, plus a stat-and-compare. NEW_FILE detection is intentionally
+     out of scope here — that lives in `skf-detect-scripts-assets.py`.
+
+Subcommands:
+  hash <path> [--include-path]
+      Emit JSON {"content_hash": "sha256:...", "size_bytes": N, "line_count": L}
+      for a single file. With --include-path, the record also includes
+      "path": <as given>, so batch callers can collect records by streaming
+      multiple invocations.
+
+  compare <source-root> --provenance-map <path>
+      Read `file_entries[]` from a provenance-map JSON and classify each row
+      against the current source tree. Emits
+        {
+          "comparisons": [
+            {"source_file": "...", "classification": "UNCHANGED|MODIFIED_FILE|DELETED_FILE",
+             "stored_hash": "sha256:...", "current_hash": "sha256:..."|null,
+             "current_size_bytes": N|null}, ...
+          ],
+          "stats": {"total": N, "unchanged": U, "modified": M, "deleted": D}
+        }
+      The provenance file must contain `file_entries` as a top-level array
+      OR be the array itself (handles both schemas).
+
+Hash format: `sha256:` prefix on a hex digest. Matches the convention used
+by skf-detect-scripts-assets.py and the existing prose ("SHA-256 content
+hash" — agnostic about prefix, but the prefix is the SKF convention to make
+hashes self-describing for future algorithm migrations).
+
+CLI examples:
+  uv run skf-hash-content.py hash docs/AGENTS.md
+  uv run skf-hash-content.py hash docs/AGENTS.md --include-path
+  uv run skf-hash-content.py compare /path/to/source \\
+      --provenance-map /path/to/provenance-map.json
+
+Exit codes:
+  0  — operation succeeded (including: file in compare missing on disk;
+       its classification is DELETED_FILE, not an error)
+  1  — user error (bad path, malformed JSON, missing required field)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+# --------------------------------------------------------------------------
+# Hashing primitives
+# --------------------------------------------------------------------------
+
+
+def sha256_of_file(path: Path) -> str:
+    """SHA-256 of file content, with sha256: prefix."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def count_lines(path: Path) -> int:
+    """Count newlines in file content; 0 if unreadable."""
+    n = 0
+    try:
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                n += chunk.count(b"\n")
+    except OSError:
+        return 0
+    return n
+
+
+def hash_record(path: Path, *, include_path: bool = False) -> dict:
+    """Build a single-file record: content_hash + size_bytes + line_count."""
+    rec: dict = {
+        "content_hash": sha256_of_file(path),
+        "size_bytes": path.stat().st_size,
+        "line_count": count_lines(path),
+    }
+    if include_path:
+        rec = {"path": str(path), **rec}
+    return rec
+
+
+# --------------------------------------------------------------------------
+# Provenance comparison
+# --------------------------------------------------------------------------
+
+
+UNCHANGED = "UNCHANGED"
+MODIFIED_FILE = "MODIFIED_FILE"
+DELETED_FILE = "DELETED_FILE"
+
+
+def load_file_entries(provenance_path: Path) -> list[dict]:
+    """Extract the file_entries list from a provenance file.
+
+    Accepts two shapes:
+      - top-level object with a `file_entries` key (canonical)
+      - top-level array of entries (already-extracted)
+
+    Returns a copy of the list. Raises ValueError on malformed JSON or
+    missing key.
+    """
+    try:
+        data = json.loads(provenance_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"failed to read provenance file {provenance_path}: {exc}") from exc
+
+    if isinstance(data, list):
+        return list(data)
+    if isinstance(data, dict):
+        entries = data.get("file_entries")
+        if entries is None:
+            raise ValueError(
+                f"provenance file {provenance_path} has no `file_entries` field"
+            )
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"`file_entries` in {provenance_path} is not an array"
+            )
+        return list(entries)
+    raise ValueError(
+        f"provenance file {provenance_path} must be an object or array; "
+        f"got {type(data).__name__}"
+    )
+
+
+def classify_entry(source_root: Path, entry: dict) -> dict:
+    """Classify a single file_entry against the current source tree."""
+    source_file = entry.get("source_file")
+    stored_hash = entry.get("content_hash")
+    if not isinstance(source_file, str):
+        raise ValueError(f"file_entry missing required `source_file`: {entry!r}")
+
+    current = (source_root / source_file).resolve()
+    # guard against ../.. escapes — resolved path must stay inside source_root
+    try:
+        current.relative_to(source_root.resolve())
+    except ValueError:
+        return {
+            "source_file": source_file,
+            "classification": DELETED_FILE,
+            "stored_hash": stored_hash,
+            "current_hash": None,
+            "current_size_bytes": None,
+        }
+
+    if not current.is_file():
+        return {
+            "source_file": source_file,
+            "classification": DELETED_FILE,
+            "stored_hash": stored_hash,
+            "current_hash": None,
+            "current_size_bytes": None,
+        }
+
+    current_hash = sha256_of_file(current)
+    if current_hash == stored_hash:
+        classification = UNCHANGED
+    else:
+        classification = MODIFIED_FILE
+    return {
+        "source_file": source_file,
+        "classification": classification,
+        "stored_hash": stored_hash,
+        "current_hash": current_hash,
+        "current_size_bytes": current.stat().st_size,
+    }
+
+
+def compare(source_root: Path, provenance_path: Path) -> dict:
+    entries = load_file_entries(provenance_path)
+    comparisons = [classify_entry(source_root, entry) for entry in entries]
+    counts = {UNCHANGED: 0, MODIFIED_FILE: 0, DELETED_FILE: 0}
+    for c in comparisons:
+        counts[c["classification"]] += 1
+    return {
+        "comparisons": comparisons,
+        "stats": {
+            "total": len(comparisons),
+            "unchanged": counts[UNCHANGED],
+            "modified": counts[MODIFIED_FILE],
+            "deleted": counts[DELETED_FILE],
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _cmd_hash(args: argparse.Namespace) -> int:
+    path = Path(args.path)
+    if not path.is_file():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 1
+    rec = hash_record(path, include_path=args.include_path)
+    json.dump(rec, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    source_root = Path(args.source_root)
+    provenance = Path(args.provenance_map)
+    if not source_root.is_dir():
+        print(f"error: source root not a directory: {source_root}", file=sys.stderr)
+        return 1
+    if not provenance.is_file():
+        print(f"error: provenance map not found: {provenance}", file=sys.stderr)
+        return 1
+    try:
+        result = compare(source_root, provenance)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skf-hash-content",
+        description="SHA-256 hashing helpers: single-file record or bulk-compare against provenance.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_hash = sub.add_parser("hash", help="emit hash record for a single file")
+    p_hash.add_argument("path", help="path to the file")
+    p_hash.add_argument(
+        "--include-path",
+        action="store_true",
+        help="include the path string in the emitted record",
+    )
+    p_hash.set_defaults(func=_cmd_hash)
+
+    p_cmp = sub.add_parser(
+        "compare",
+        help="classify provenance file_entries[] against current source tree",
+    )
+    p_cmp.add_argument("source_root", help="path to the source tree root")
+    p_cmp.add_argument(
+        "--provenance-map",
+        required=True,
+        help="path to provenance-map.json (object with file_entries[] or bare array)",
+    )
+    p_cmp.set_defaults(func=_cmd_compare)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/skf-update-skill/references/detect-changes.md
+++ b/src/skf-update-skill/references/detect-changes.md
@@ -1,6 +1,14 @@
 ---
 nextStepFile: 're-extract.md'
 noChangeReportFile: 'report.md'
+# Resolve `{hashContentHelper}` to the first existing path; HALT if neither
+# candidate exists — §1b and §Category D rely on the helper for deterministic
+# SHA-256 hashing (file-read + size + line-count) and provenance comparison
+# (UNCHANGED / MODIFIED_FILE / DELETED_FILE classification). Falling back to
+# prose-driven hashing would lose hash stability across runs.
+hashContentProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-hash-content.py'
+  - '{project-root}/src/shared/scripts/skf-hash-content.py'
 ---
 
 <!-- Config: communicate in {communication_language}. -->
@@ -110,7 +118,7 @@ Read the source directory at `{source_root}` and build a current file inventory:
      1. Append `candidate.path` to `brief.scope.include` as a literal glob.
      2. Append a `brief.scope.amendments[]` entry: `action: "promoted"`, `path: candidate.path`, `reason: {user-provided or auto: "discovered post-creation — matched heuristic {basename}"}`, `heuristic: {basename}`, `date: {today ISO}`, `workflow: "skf-update-skill"`.
      3. **Write the amended brief back to disk immediately** at `{forge_data_folder}/{skill_name}/skill-brief.yaml`. Preserve all other fields.
-     4. **Compute SHA-256 content hash** of `candidate.path` and add an entry to the in-context `promoted_docs_new[]` list: `{path, heuristic, size_bytes, line_count, content_hash}`. This list is consumed by §4 merge Priority 7 to write new `file_entries[]` rows — promoted docs do NOT go through §3 code re-extraction, which would produce ghost entries on non-code files.
+     4. **Hash the candidate** via `uv run {hashContentHelper} hash {candidate.path}` — emits `{content_hash, size_bytes, line_count}` as JSON. Combine with the existing context fields and append to the in-context `promoted_docs_new[]` list: `{path, heuristic, size_bytes, line_count, content_hash}`. This list is consumed by §4 merge Priority 7 to write new `file_entries[]` rows — promoted docs do NOT go through §3 code re-extraction, which would produce ghost entries on non-code files.
      5. Display: `"Promoted {path} — brief amended, scheduled as new file_entries row for file_type doc."`
 
    - **[S] Skip:**
@@ -245,12 +253,35 @@ Launch subprocesses in parallel that compare source state against provenance map
 - If content similarity > 80%: classify as RENAMED instead of deleted+added. **Similarity mechanism by tier:** Quick: compare file size ratio (within 20%) and export name overlap (>70% of exports match by name). Forge and above: use ast-grep to compare export signatures between the deleted and added files. Forge+/Deep: use CCC semantic similarity when available
 
 **Category D — Script/asset file changes:**
-- Compare `file_entries` from provenance-map.json against current source files
-- For each file_entry: compute current SHA-256 content hash, compare against stored hash
-- Files with changed hashes → MODIFIED_FILE
-- Files in provenance but missing from source → DELETED_FILE
-- Files in source matching detection patterns (scripts/, bin/, assets/, templates/) but not in provenance → NEW_FILE
-- Files in `scripts/[MANUAL]/` or `assets/[MANUAL]/` → SKIP (user-authored, preserved)
+
+Run the bulk comparison once via:
+
+```bash
+uv run {hashContentHelper} compare <source-root> \
+    --provenance-map <provenance-map-path>
+```
+
+The helper emits:
+
+```json
+{
+  "comparisons": [
+    {"source_file": "...", "classification": "UNCHANGED|MODIFIED_FILE|DELETED_FILE",
+     "stored_hash": "sha256:...", "current_hash": "sha256:..."|null,
+     "current_size_bytes": N|null}, ...
+  ],
+  "stats": {"total": N, "unchanged": U, "modified": M, "deleted": D}
+}
+```
+
+Translate the helper's output into the change manifest:
+- `MODIFIED_FILE` rows → add to manifest as MODIFIED_FILE
+- `DELETED_FILE` rows → add to manifest as DELETED_FILE
+- `UNCHANGED` rows → omit from the manifest (no action needed)
+
+The helper does NOT detect NEW_FILE — its job is provenance comparison only. Detect new files via `skf-detect-scripts-assets.py` from create-skill step 3 §4c against the current source tree, then subtract the paths already present in `provenance.file_entries[].source_file`. Remaining files matching detection patterns (`scripts/`, `bin/`, `assets/`, `templates/`) and NOT under `scripts/[MANUAL]/` or `assets/[MANUAL]/` are NEW_FILE.
+
+Files in `scripts/[MANUAL]/` or `assets/[MANUAL]/` → SKIP (user-authored, preserved).
 
 Aggregate all subprocess results into a unified change manifest.
 

--- a/test/test-skf-hash-content.py
+++ b/test/test-skf-hash-content.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Tests for skf-hash-content.py.
+
+Covers:
+  - hash: content_hash + size_bytes + line_count; --include-path flag
+  - compare: UNCHANGED / MODIFIED_FILE / DELETED_FILE classification
+  - provenance shapes: top-level object with file_entries[]; bare array
+  - guard against ../.. escapes from source-root
+  - error paths: missing file, malformed JSON, missing file_entries key
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT_PATH = REPO_ROOT / "src" / "shared" / "scripts" / "skf-hash-content.py"
+
+spec = importlib.util.spec_from_file_location("skf_hash_content", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mod)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _expected_hash(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------
+# hash subcommand
+# --------------------------------------------------------------------------
+
+
+class TestHash:
+    def test_basic_record(self, tmp_path: Path) -> None:
+        content = "hello world\nsecond line\n"
+        path = _write(tmp_path / "f.txt", content)
+        rec = mod.hash_record(path)
+        assert rec == {
+            "content_hash": _expected_hash(content.encode()),
+            "size_bytes": len(content),
+            "line_count": 2,
+        }
+
+    def test_include_path(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "x.txt", "x\n")
+        rec = mod.hash_record(path, include_path=True)
+        assert rec["path"] == str(path)
+        assert "content_hash" in rec
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "empty.txt", "")
+        rec = mod.hash_record(path)
+        assert rec["content_hash"] == _expected_hash(b"")
+        assert rec["size_bytes"] == 0
+        assert rec["line_count"] == 0
+
+    def test_binary_content(self, tmp_path: Path) -> None:
+        # bytes that aren't valid UTF-8 — hash should still work
+        path = tmp_path / "blob.bin"
+        path.write_bytes(b"\x00\x01\xff\xfe\n")
+        rec = mod.hash_record(path)
+        assert rec["content_hash"] == _expected_hash(b"\x00\x01\xff\xfe\n")
+        assert rec["line_count"] == 1
+
+    def test_no_trailing_newline_line_count(self, tmp_path: Path) -> None:
+        # line_count counts newlines, not "lines that have content"
+        path = _write(tmp_path / "f.txt", "one\ntwo")  # 1 newline, 2 lines of text
+        rec = mod.hash_record(path)
+        assert rec["line_count"] == 1
+
+
+# --------------------------------------------------------------------------
+# load_file_entries
+# --------------------------------------------------------------------------
+
+
+class TestLoadFileEntries:
+    def test_object_with_file_entries(self, tmp_path: Path) -> None:
+        prov = _write(
+            tmp_path / "prov.json",
+            json.dumps({
+                "file_entries": [
+                    {"source_file": "scripts/a.sh", "content_hash": "sha256:abc"},
+                    {"source_file": "assets/b.json", "content_hash": "sha256:def"},
+                ]
+            }),
+        )
+        entries = mod.load_file_entries(prov)
+        assert len(entries) == 2
+        assert entries[0]["source_file"] == "scripts/a.sh"
+
+    def test_bare_array(self, tmp_path: Path) -> None:
+        prov = _write(
+            tmp_path / "prov.json",
+            json.dumps([{"source_file": "x.md", "content_hash": "sha256:z"}]),
+        )
+        entries = mod.load_file_entries(prov)
+        assert entries == [{"source_file": "x.md", "content_hash": "sha256:z"}]
+
+    def test_malformed_json_raises(self, tmp_path: Path) -> None:
+        prov = _write(tmp_path / "prov.json", "{not json")
+        import pytest
+
+        with pytest.raises(ValueError, match="failed to read"):
+            mod.load_file_entries(prov)
+
+    def test_object_missing_file_entries_raises(self, tmp_path: Path) -> None:
+        prov = _write(tmp_path / "prov.json", "{}")
+        import pytest
+
+        with pytest.raises(ValueError, match="no `file_entries`"):
+            mod.load_file_entries(prov)
+
+    def test_file_entries_not_array_raises(self, tmp_path: Path) -> None:
+        prov = _write(tmp_path / "prov.json", '{"file_entries": "not an array"}')
+        import pytest
+
+        with pytest.raises(ValueError, match="not an array"):
+            mod.load_file_entries(prov)
+
+    def test_top_level_scalar_raises(self, tmp_path: Path) -> None:
+        prov = _write(tmp_path / "prov.json", "42")
+        import pytest
+
+        with pytest.raises(ValueError, match="must be an object or array"):
+            mod.load_file_entries(prov)
+
+
+# --------------------------------------------------------------------------
+# classify_entry / compare
+# --------------------------------------------------------------------------
+
+
+class TestClassifyEntry:
+    def test_unchanged(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        f = _write(source / "scripts" / "a.sh", "echo hi\n")
+        stored = _expected_hash(b"echo hi\n")
+        result = mod.classify_entry(
+            source, {"source_file": "scripts/a.sh", "content_hash": stored}
+        )
+        assert result["classification"] == "UNCHANGED"
+        assert result["current_hash"] == stored
+
+    def test_modified(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        _write(source / "scripts" / "a.sh", "echo new content\n")
+        result = mod.classify_entry(
+            source,
+            {"source_file": "scripts/a.sh", "content_hash": "sha256:oldhash"},
+        )
+        assert result["classification"] == "MODIFIED_FILE"
+        assert result["stored_hash"] == "sha256:oldhash"
+        assert result["current_hash"] != "sha256:oldhash"
+
+    def test_deleted(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        source.mkdir()
+        result = mod.classify_entry(
+            source,
+            {"source_file": "scripts/gone.sh", "content_hash": "sha256:was-here"},
+        )
+        assert result["classification"] == "DELETED_FILE"
+        assert result["current_hash"] is None
+        assert result["current_size_bytes"] is None
+
+    def test_path_escape_treated_as_deleted(self, tmp_path: Path) -> None:
+        # source_file with ../.. attempting to escape source-root → DELETED
+        source = tmp_path / "src"
+        source.mkdir()
+        # write a real file outside the source-root
+        _write(tmp_path / "outside.txt", "outside\n")
+        result = mod.classify_entry(
+            source,
+            {"source_file": "../outside.txt", "content_hash": "sha256:x"},
+        )
+        assert result["classification"] == "DELETED_FILE"
+
+    def test_missing_source_file_field_raises(self, tmp_path: Path) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="source_file"):
+            mod.classify_entry(tmp_path, {"content_hash": "sha256:x"})
+
+
+class TestCompare:
+    def test_mixed_classifications(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        _write(source / "a.sh", "unchanged content\n")
+        _write(source / "b.sh", "modified content\n")
+        # c.sh missing → DELETED
+        prov = _write(
+            tmp_path / "prov.json",
+            json.dumps({
+                "file_entries": [
+                    {"source_file": "a.sh", "content_hash": _expected_hash(b"unchanged content\n")},
+                    {"source_file": "b.sh", "content_hash": "sha256:stale"},
+                    {"source_file": "c.sh", "content_hash": "sha256:was-here"},
+                ]
+            }),
+        )
+        result = mod.compare(source, prov)
+        assert result["stats"] == {"total": 3, "unchanged": 1, "modified": 1, "deleted": 1}
+        # check ordering preserved
+        classifications = [c["classification"] for c in result["comparisons"]]
+        assert classifications == ["UNCHANGED", "MODIFIED_FILE", "DELETED_FILE"]
+
+    def test_empty_provenance(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        source.mkdir()
+        prov = _write(tmp_path / "prov.json", '{"file_entries": []}')
+        result = mod.compare(source, prov)
+        assert result == {
+            "comparisons": [],
+            "stats": {"total": 0, "unchanged": 0, "modified": 0, "deleted": 0},
+        }
+
+
+# --------------------------------------------------------------------------
+# CLI integration
+# --------------------------------------------------------------------------
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestCli:
+    def test_hash_emits_json(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "x.txt", "hello\n")
+        result = _run_cli("hash", str(path))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["content_hash"] == _expected_hash(b"hello\n")
+        assert payload["size_bytes"] == 6
+        assert payload["line_count"] == 1
+        # without --include-path, the field is absent
+        assert "path" not in payload
+
+    def test_hash_include_path(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "x.txt", "x\n")
+        result = _run_cli("hash", str(path), "--include-path")
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert payload["path"] == str(path)
+
+    def test_hash_missing_file_exits_1(self, tmp_path: Path) -> None:
+        result = _run_cli("hash", str(tmp_path / "missing.txt"))
+        assert result.returncode == 1
+        assert "file not found" in result.stderr
+
+    def test_compare_emits_json(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        _write(source / "a.sh", "x\n")
+        prov = _write(
+            tmp_path / "prov.json",
+            json.dumps({
+                "file_entries": [
+                    {"source_file": "a.sh", "content_hash": _expected_hash(b"x\n")}
+                ]
+            }),
+        )
+        result = _run_cli("compare", str(source), "--provenance-map", str(prov))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["stats"]["unchanged"] == 1
+
+    def test_compare_bad_source_exits_1(self, tmp_path: Path) -> None:
+        prov = _write(tmp_path / "prov.json", '{"file_entries": []}')
+        result = _run_cli(
+            "compare", str(tmp_path / "missing"), "--provenance-map", str(prov)
+        )
+        assert result.returncode == 1
+        assert "source root" in result.stderr
+
+    def test_compare_bad_provenance_exits_1(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        source.mkdir()
+        result = _run_cli(
+            "compare", str(source), "--provenance-map", str(tmp_path / "missing.json")
+        )
+        assert result.returncode == 1
+        assert "provenance map" in result.stderr
+
+    def test_compare_malformed_provenance_exits_1(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        source.mkdir()
+        prov = _write(tmp_path / "prov.json", "{not json")
+        result = _run_cli("compare", str(source), "--provenance-map", str(prov))
+        assert result.returncode == 1
+        assert "failed to read" in result.stderr


### PR DESCRIPTION
## Summary

Issue #307 workstream **A4**. Two distinct hashing patterns recurred across `update-skill/references/detect-changes.md` as prose:

- **§1b promoted-doc case** — "compute SHA-256 content hash of `candidate.path`" and emit a `{path, heuristic, size_bytes, line_count, content_hash}` record. Single-file primitive.
- **§Category D file-drift case** — "for each file_entry: compute current SHA-256 content hash, compare against stored hash" — bulk iteration over `provenance.file_entries[]` producing `MODIFIED_FILE` / `DELETED_FILE` classifications.

Both asked the LLM to re-derive the same `hashlib` + `os.stat` + newline-count code per run. The new helper bakes both patterns in.

## Changes

**New: `src/shared/scripts/skf-hash-content.py`** — PEP 723, stdlib only
- `hash <path> [--include-path]` → `{content_hash, size_bytes, line_count}` (path field optional for batch contexts)
- `compare <source-root> --provenance-map <file>` → classifies each `file_entries[]` row as `UNCHANGED` / `MODIFIED_FILE` / `DELETED_FILE` against the current source tree. Accepts both the canonical `{file_entries: [...]}` object shape AND a bare array shape for flexibility
- **Path-escape guard:** `source_file` values that resolve outside `source_root` via `../..` are treated as `DELETED` rather than reaching outside the tree
- **NEW_FILE detection intentionally not in scope** — that's `skf-detect-scripts-assets.py` (PR #309)'s job. Compare's contract is pure provenance-iteration

**New: `test/test-skf-hash-content.py`** — 25 tests
- hash: basic record, --include-path, empty file, binary content, line-count semantics
- load_file_entries: object/array shapes, malformed JSON, missing key, key-not-array, top-level scalar
- classify_entry: unchanged/modified/deleted, path-escape → deleted, missing field → raises
- compare: mixed classifications with stats, empty provenance
- CLI integration for both subcommands + every error path

**Wired: `src/skf-update-skill/references/detect-changes.md`**
- Frontmatter gains `hashContentProbeOrder` (installed module path first, src/ dev-checkout fallback)
- §1b prose collapses to one bash call emitting the three computed fields; the LLM still owns building the full record (path + heuristic from context)
- §Category D's per-file-entry iteration prose collapses to one bulk-compare invocation. Classification-translation step documented explicitly so §3 / §4 don't need to re-classify
- NEW_FILE detection prose now points at `skf-detect-scripts-assets.py` rather than restating directory heuristics — single source of truth across the two helpers

## Test plan

- [x] `python3 -m pytest test/test-skf-hash-content.py` — 25/25 pass in 0.75s
- [x] `node tools/validate-skills.js` — 0 findings
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 leaks
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green

Tracks: #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)