### PR TITLE
feat(skf-update-skill): add SKF_UPDATE_RESULT_JSON envelope + headless_decisions[]

### DIFF
--- a/src/shared/scripts/schemas/skf-update-result-envelope.v1.json
+++ b/src/shared/scripts/schemas/skf-update-result-envelope.v1.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/armelhbobdad/bmad-module-skill-forge/src/shared/scripts/schemas/skf-update-result-envelope.v1.json",
+  "title": "SKF_UPDATE_RESULT_JSON envelope (v1)",
+  "description": "Single-line JSON document emitted by skf-update-skill step 7 (report) when {headless_mode} is true, prefixed with the literal 'SKF_UPDATE_RESULT_JSON: '. Pipelines branch on the envelope's top-level fields without parsing the human-readable report. The `headless_decisions[]` array surfaces every auto-resolved gate so non-interactive runs can be audited post-hoc — previously these were buried in the evidence report as free-form log lines. Schema added in PR #319.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["skf_update"],
+  "properties": {
+    "skf_update": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "skill_name",
+        "version",
+        "previous_version",
+        "update_mode",
+        "files_written",
+        "headless_decisions",
+        "warnings",
+        "error"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "no-changes",
+            "halted-for-workspace-drift",
+            "halted-for-brief-refinement",
+            "halted-for-audit",
+            "halted-for-remediation-path",
+            "halted-for-manual-mismatch",
+            "halted-for-write-failure",
+            "blocked"
+          ],
+          "description": "Single-field outcome for pipeline branching. 'success' when the run completed and wrote the updated artifacts. 'no-changes' when detect-changes found nothing to update. Each 'halted-for-*' value corresponds to a documented halt in the stage prose (workspace-drift from re-extract.md §0.a, brief-refinement from detect-changes.md §1c [U] / §2.2 [B], audit from §2.2 [A], remediation-path from re-extract.md §0a, manual-mismatch from write.md §1, write-failure for any §5b/§6 failure). 'blocked' is the catch-all for halts that don't map to a documented status code."
+        },
+        "skill_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the skill being updated, read from metadata.json at workflow start."
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version written this run. In gap-driven mode this equals previous_version (gap-driven runs do not bump). In normal mode this is either the detected source version or an incremented patch."
+        },
+        "previous_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version read from metadata.json at workflow start, before any write."
+        },
+        "update_mode": {
+          "type": "string",
+          "enum": ["normal", "gap-driven", "degraded"],
+          "description": "Which detect-changes path ran. 'normal' = provenance map present and source-drift detection ran. 'gap-driven' = --from-test-report path. 'degraded' = no provenance baseline (every export looks modified)."
+        },
+        "files_written": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["SKILL.md", "metadata.json", "provenance-map.json", "evidence-report.md", "context-snippet.md", "active-symlink"]
+          },
+          "uniqueItems": true,
+          "description": "Artifacts actually written or updated this run. Empty array when a halt fired before any write completed."
+        },
+        "headless_decisions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["gate", "default_action", "taken_action", "reason"],
+            "properties": {
+              "gate": {
+                "type": "string",
+                "enum": [
+                  "init.update-confirmation",
+                  "detect-changes.promoted-doc-prompt",
+                  "detect-changes.scope-expansion",
+                  "detect-changes.deletion-ratio",
+                  "merge.clean-merge-gate"
+                ],
+                "description": "Identifier for the gate. Matches the labels in stage prose so post-hoc audits can grep both directions."
+              },
+              "default_action": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The action documented as the default for this gate (e.g. 'C' for [C] Continue, 'S' for [S] Skip)."
+              },
+              "taken_action": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The action actually taken. In headless mode this almost always equals default_action — the field exists so future user-overrides via flags (e.g. --orphan-action style) can differ from defaults."
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Human-readable rationale (e.g. 'headless: no user to prompt')."
+              },
+              "evidence": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Optional gate-specific data — for deletion-ratio, the ratio value and counts; for promoted-doc, the candidate path; etc. Pipelines that want the audit trail richer than reason can read this."
+              }
+            }
+          },
+          "description": "One entry per gate that auto-resolved during this run. Empty when no gates fired (no-changes path, or interactive run where the user resolved gates manually). The merge.clean-merge-gate entry never appears with taken_action=continue when the gate halted on conflicts — conflict halts produce a halted-for-* status instead."
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Non-fatal anomalies surfaced during the run. May include workspace_drift_overridden, scope_reconciliation_post entries, qmd indexing failures, etc. Empty when none."
+        },
+        "error": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["phase", "reason"],
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Step or operation that failed (e.g. 'write:active-symlink', 'init:provenance-load')."
+                },
+                "path": {
+                  "type": "string",
+                  "description": "Optional path the failed operation targeted (when applicable)."
+                },
+                "reason": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Human-readable error message."
+                }
+              }
+            }
+          ],
+          "description": "Null on success or no-changes. Object describing the failure when a halt or write error fired. Pipelines branch on error !== null for non-zero exit semantics."
+        }
+      }
+    }
+  }
+}

--- a/src/skf-update-skill/SKILL.md
+++ b/src/skf-update-skill/SKILL.md
@@ -54,7 +54,7 @@ These rules apply to every step in this workflow:
 | **Inputs** | skill_name [required] |
 | **Gates** | step 1: Confirm Gate [C] | step 4: Confirm Gate [C if clean merge, HALT if conflicts] |
 | **Outputs** | Updated SKILL.md, updated provenance-map.json, evidence-report.md |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Each auto-resolved gate appends a `{gate, default_action, taken_action, reason, evidence?}` entry to `headless_decisions[]`, surfaced in step 7's `SKF_UPDATE_RESULT_JSON` envelope so non-interactive runs can be audited post-hoc. Pipeline branches on the envelope's top-level `status` field (`success`, `no-changes`, or one of the documented `halted-for-*` codes). Schema: `src/shared/scripts/schemas/skf-update-result-envelope.v1.json`. |
 
 ## On Activation
 

--- a/src/skf-update-skill/references/detect-changes.md
+++ b/src/skf-update-skill/references/detect-changes.md
@@ -126,7 +126,7 @@ Read the source directory at `{source_root}` and build a current file inventory:
    [U] Update  — halt this run and return to skf-brief-skill to refine scope
    ```
 
-5. **Headless mode (`{headless_mode}` is true):** auto-select `[S] Skip` for every candidate — record `action: "skipped"`, `reason: "headless: no user to prompt"`, `workflow: "skf-update-skill"`. A non-interactive update run must never silently add files to scope.
+5. **Headless mode (`{headless_mode}` is true):** auto-select `[S] Skip` for every candidate — record `action: "skipped"`, `reason: "headless: no user to prompt"`, `workflow: "skf-update-skill"`. A non-interactive update run must never silently add files to scope. **Also append one entry per candidate to in-context `headless_decisions[]`** (surfaced via `SKF_UPDATE_RESULT_JSON` by step 7): `{gate: "detect-changes.promoted-doc-prompt", default_action: "S", taken_action: "S", reason: "headless: no user to prompt", evidence: {path: "<candidate.path>"}}`.
 
 6. **Apply decision:**
 
@@ -229,7 +229,7 @@ Read the source directory at `{source_root}` and build a current file inventory:
    [U] Update  — halt this run and return to skf-brief-skill to refine scope
    ```
 
-4. **Headless mode (`{headless_mode}` is true):** auto-select `[S] Skip` for every candidate — record `action: "skipped"`, `category: "scope-expansion"`, `reason: "headless: no user to prompt"`, `workflow: "skf-update-skill"`. A non-interactive update run must never silently expand scope.
+4. **Headless mode (`{headless_mode}` is true):** auto-select `[S] Skip` for every candidate — record `action: "skipped"`, `category: "scope-expansion"`, `reason: "headless: no user to prompt"`, `workflow: "skf-update-skill"`. A non-interactive update run must never silently expand scope. **Also append one entry per candidate to in-context `headless_decisions[]`** (surfaced via `SKF_UPDATE_RESULT_JSON` by step 7): `{gate: "detect-changes.scope-expansion", default_action: "S", taken_action: "S", reason: "headless: no user to prompt", evidence: {path: "<candidate.path>"}}`.
 
 5. **Apply decision:**
 
@@ -380,7 +380,7 @@ The upstream surface appears to have been substantially replaced. The brief's
 [A] Audit    — halt and run skf-audit-skill to map the new surface, then re-run update-skill
 ```
 
-**Headless mode (`{headless_mode}` is true):** auto-select `[C] Continue`, log a WARN-level entry to the evidence report (`scope_reconciliation_post: {trigger: "deletion-ratio", ratio: X, decision: "headless-continue"}`), and surface the warning in step 7's report. A non-interactive run must not silently halt, but the user must be able to see the signal post-hoc.
+**Headless mode (`{headless_mode}` is true):** auto-select `[C] Continue`, log a WARN-level entry to the evidence report (`scope_reconciliation_post: {trigger: "deletion-ratio", ratio: X, decision: "headless-continue"}`), and surface the warning in step 7's report. A non-interactive run must not silently halt, but the user must be able to see the signal post-hoc. **Also append to in-context `headless_decisions[]`** (surfaced via `SKF_UPDATE_RESULT_JSON` by step 7): `{gate: "detect-changes.deletion-ratio", default_action: "C", taken_action: "C", reason: "headless: deletion-ratio threshold exceeded but no user to halt", evidence: {deletion_ratio: <ratio>, deleted_export_count: <N>, total_provenance_exports: <T>}}`.
 
 **Apply decision:**
 

--- a/src/skf-update-skill/references/init.md
+++ b/src/skf-update-skill/references/init.md
@@ -168,7 +168,7 @@ Display: "**Select:** [C] Continue to Change Detection"
 #### EXECUTION RULES:
 
 - ALWAYS halt and wait for user input after presenting menu
-- **GATE [default: C]** — If `{headless_mode}`: auto-proceed with [C] Continue, log: "headless: auto-continue past update confirmation"
+- **GATE [default: C]** — If `{headless_mode}`: auto-proceed with [C] Continue, log: "headless: auto-continue past update confirmation". **Also append to in-context `headless_decisions[]`** (step 7 surfaces this list in `SKF_UPDATE_RESULT_JSON`): `{gate: "init.update-confirmation", default_action: "C", taken_action: "C", reason: "headless: no user to prompt"}`. The headless_decisions[] array is the structured audit trail for non-interactive runs — see `src/shared/scripts/schemas/skf-update-result-envelope.v1.json` for the entry shape.
 - ONLY proceed to next step when user selects 'C'
 
 ## CRITICAL STEP COMPLETION NOTE

--- a/src/skf-update-skill/references/merge.md
+++ b/src/skf-update-skill/references/merge.md
@@ -207,7 +207,7 @@ Display: "**Merge complete with conflict resolution. Select:** [C] Continue to V
 #### EXECUTION RULES:
 
 - ALWAYS halt and wait for user input after conflict resolution
-- **GATE [default: C if clean merge]** — If `{headless_mode}` and merge is clean (no [MANUAL] conflicts): auto-proceed with [C] Continue, log: "headless: clean merge, auto-continue". If conflicts exist, HALT even in headless mode — conflicts require human judgment.
+- **GATE [default: C if clean merge]** — If `{headless_mode}` and merge is clean (no [MANUAL] conflicts): auto-proceed with [C] Continue, log: "headless: clean merge, auto-continue". **Also append to in-context `headless_decisions[]`** (surfaced via `SKF_UPDATE_RESULT_JSON` by step 7): `{gate: "merge.clean-merge-gate", default_action: "C", taken_action: "C", reason: "headless: clean merge, no conflicts to resolve"}`. If conflicts exist, HALT even in headless mode — conflicts require human judgment, and the headless_decisions[] array does NOT get a continue-on-conflict entry (the workflow status becomes `halted-for-manual-mismatch` instead).
 - ONLY proceed when user selects 'C'
 
 **If clean merge (no conflicts):**

--- a/src/skf-update-skill/references/report.md
+++ b/src/skf-update-skill/references/report.md
@@ -144,6 +144,18 @@ Based on the update results:"
 
 Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_version}/update-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/update-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all modified file paths in `outputs`; include `exports_affected`, `files_modified`, and `validation_status` (passed/warnings/failures) in `summary`.
 
+**Headless envelope (`SKF_UPDATE_RESULT_JSON`):** when `{headless_mode}` is true, ALSO emit a single-line JSON envelope to stdout prefixed with the literal `SKF_UPDATE_RESULT_JSON: `. Schema: `src/shared/scripts/schemas/skf-update-result-envelope.v1.json`. Construct the envelope from in-context state:
+
+```json
+SKF_UPDATE_RESULT_JSON: {"skf_update":{"status":"success|no-changes|halted-for-*|blocked","skill_name":"<name>","version":"<v>","previous_version":"<v>","update_mode":"normal|gap-driven|degraded","files_written":[...],"headless_decisions":[...],"warnings":[...],"error":null|{...}}}
+```
+
+- `headless_decisions[]` — verbatim from the in-context array populated by gates (init.md §confirmation, detect-changes.md §1b/§1c/§2.2, merge.md §gate). Each entry `{gate, default_action, taken_action, reason, evidence?}`. Empty when no gates auto-resolved (e.g. no-changes path skipped detect-changes' gates).
+- `status` — single-field outcome for pipeline branching. `"success"` when the run wrote artifacts and produced no halts; `"no-changes"` when §1 short-circuited; one of the documented `halted-for-*` codes when a halt fired; `"blocked"` as the catch-all.
+- `error` — null on success or no-changes. Object `{phase, path?, reason}` describing the failure when a halt or write error fired. Pipelines branch on `error !== null` for non-zero exit semantics.
+
+The headless envelope is the structured channel; the per-run JSON written above is the audit trail. Both coexist — the envelope is one line on stdout for grep-friendly consumption, the per-run JSON is the full record on disk.
+
 ### 6. Chain to Health Check
 
 ONLY WHEN the change summary has been presented, files-written list displayed, and result contract saved will you then load, read the full file, and execute `{nextStepFile}`. The health-check step is the true terminal step — do not stop here even though the report reads as final.


### PR DESCRIPTION
## Summary

Issue #307 workstream **C1**. Auto-resolutions in headless `skf-update-skill` runs were previously logged as free-form lines buried in the evidence report — pipelines couldn't audit non-interactive runs without parsing markdown. This commit ships a structured `headless_decisions[]` array on a new `SKF_UPDATE_RESULT_JSON` envelope, surfaced in step 7 stdout alongside the human-readable report.

## Changes

**New: `src/shared/scripts/schemas/skf-update-result-envelope.v1.json`**

Single-line JSON envelope schema, modeled on `skf-setup-result-envelope.v1.json`. Top-level fields:

| Field | Purpose |
|---|---|
| `status` | Pipeline branch key: `success`, `no-changes`, one of 7 documented `halted-for-*` codes, or `blocked` |
| `skill_name` / `version` / `previous_version` | Identity + change record |
| `update_mode` | `normal` / `gap-driven` / `degraded` |
| `files_written` | Enum array of artifacts actually updated |
| **`headless_decisions[]`** | **Structured audit trail** — one entry per auto-resolved gate |
| `warnings` | Non-fatal anomalies |
| `error` | Null on success; `{phase, path?, reason}` on failure |

`headless_decisions[]` entry: `{gate, default_action, taken_action, reason, evidence?}`. `gate` is one of 5 enum values matching stage-prose labels so post-hoc audits grep both directions.

**Stage prose updated to record one entry per fired gate:**

| File | Gate | Default | Records |
|---|---|---|---|
| `init.md` | §confirmation | `C` | `init.update-confirmation` |
| `detect-changes.md` | §1b promoted-doc | `S` | one per candidate with `evidence: {path}` |
| `detect-changes.md` | §1c scope-expansion | `S` | one per candidate with `evidence: {path}` |
| `detect-changes.md` | §2.2 deletion-ratio | `C` | full evidence: `{deletion_ratio, deleted_export_count, total_provenance_exports}` |
| `merge.md` | §gate clean-merge | `C` | single entry on clean merge; conflict halts produce `status="halted-for-manual-mismatch"` instead — array does NOT get a continue-on-conflict ghost record |

**`SKILL.md` Invocation Contract:** "Headless" row expanded to document the envelope shape, `headless_decisions[]` mechanism, and schema path.

**`report.md` §5b:** extended with "Headless envelope" sub-section. When `{headless_mode}` is true, step 7 emits the single-line `SKF_UPDATE_RESULT_JSON: {...}` envelope on stdout in addition to the per-run JSON written to disk.

**Deferred:** no emitter helper this PR — prose-driven envelope construction is fine for the initial rollout; a future PR can extract it to `skf-emit-update-result-envelope.py` if a second skill needs the same shape. Schema is shipped now so downstream tooling (CI pipelines, audit dashboards) can lock against it.

## Test plan

- [x] `npm run test:python` — 1076 passed
- [x] `node tools/validate-skills.js` — 0 findings
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 leaks
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green

Tracks: #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)