### PR TITLE
feat(skf-update-skill): add --dry-run and --detect-only inspection modes

### DIFF
--- a/src/shared/scripts/schemas/skf-update-result-envelope.v1.json
+++ b/src/shared/scripts/schemas/skf-update-result-envelope.v1.json
@@ -27,6 +27,8 @@
           "enum": [
             "success",
             "no-changes",
+            "detect-only",
+            "dry-run",
             "halted-for-workspace-drift",
             "halted-for-brief-refinement",
             "halted-for-audit",
@@ -35,7 +37,7 @@
             "halted-for-write-failure",
             "blocked"
           ],
-          "description": "Single-field outcome for pipeline branching. 'success' when the run completed and wrote the updated artifacts. 'no-changes' when detect-changes found nothing to update. Each 'halted-for-*' value corresponds to a documented halt in the stage prose (workspace-drift from re-extract.md §0.a, brief-refinement from detect-changes.md §1c [U] / §2.2 [B], audit from §2.2 [A], remediation-path from re-extract.md §0a, manual-mismatch from write.md §1, write-failure for any §5b/§6 failure). 'blocked' is the catch-all for halts that don't map to a documented status code."
+          "description": "Single-field outcome for pipeline branching. 'success' when the run completed and wrote the updated artifacts. 'no-changes' when detect-changes found nothing to update. 'detect-only' when the workflow was invoked with --detect-only and exited after step 2 without modifying any artifact. 'dry-run' when the workflow was invoked with --dry-run and exited after step 3 (re-extract) without merging or writing — the envelope describes what merge+write WOULD have done. Each 'halted-for-*' value corresponds to a documented halt in the stage prose (workspace-drift from re-extract.md §0.a, brief-refinement from detect-changes.md §1c [U] / §2.2 [B], audit from §2.2 [A], remediation-path from re-extract.md §0a, manual-mismatch from write.md §1, write-failure for any §5b/§6 failure). 'blocked' is the catch-all for halts that don't map to a documented status code. NOTE: detect-only and dry-run are successful exits — pipelines treating non-success as failure must include them in the success set."
         },
         "skill_name": {
           "type": "string",

--- a/src/skf-update-skill/SKILL.md
+++ b/src/skf-update-skill/SKILL.md
@@ -52,9 +52,10 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | skill_name [required] |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--from-test-report` (gap-driven mode); `--allow-workspace-drift` (gap-driven only — bypass §0.a pinning guard); `--detect-only` (run detect-changes only, exit before re-extract; envelope `status="detect-only"`); `--dry-run` (run detect-changes + re-extract, exit before merge/write; envelope `status="dry-run"` describes what would change). If both `--detect-only` and `--dry-run` are passed, `--detect-only` wins. |
 | **Gates** | step 1: Confirm Gate [C] | step 4: Confirm Gate [C if clean merge, HALT if conflicts] |
-| **Outputs** | Updated SKILL.md, updated provenance-map.json, evidence-report.md |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Each auto-resolved gate appends a `{gate, default_action, taken_action, reason, evidence?}` entry to `headless_decisions[]`, surfaced in step 7's `SKF_UPDATE_RESULT_JSON` envelope so non-interactive runs can be audited post-hoc. Pipeline branches on the envelope's top-level `status` field (`success`, `no-changes`, or one of the documented `halted-for-*` codes). Schema: `src/shared/scripts/schemas/skf-update-result-envelope.v1.json`. |
+| **Outputs** | Updated SKILL.md, updated provenance-map.json, evidence-report.md (none when `--detect-only` or `--dry-run` is set — those modes are read-only inspection paths) |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Each auto-resolved gate appends a `{gate, default_action, taken_action, reason, evidence?}` entry to `headless_decisions[]`, surfaced in step 7's `SKF_UPDATE_RESULT_JSON` envelope so non-interactive runs can be audited post-hoc. Pipeline branches on the envelope's top-level `status` field (`success`, `no-changes`, `detect-only`, `dry-run`, or one of the documented `halted-for-*` codes). The first four are successful exits — pipelines treating non-success as failure must include them in the success set. Schema: `src/shared/scripts/schemas/skf-update-result-envelope.v1.json`. |
 
 ## On Activation
 

--- a/src/skf-update-skill/references/detect-changes.md
+++ b/src/skf-update-skill/references/detect-changes.md
@@ -469,15 +469,20 @@ Display: "**Proceeding to re-extraction...**"
 
 #### Menu Handling Logic:
 
-- After change manifest is built, immediately load, read entire file, then execute {nextStepFile}
-- **EXCEPTION:** If no changes detected (section 4), load {noChangeReportFile} instead
+- **If `detect_only_mode` is true:** display "**Detect-only mode — skipping re-extract/merge/validate/write.** Loading report..." and load `{noChangeReportFile}` (report.md). The report handles the detect-only envelope. Do NOT load `{nextStepFile}`.
+- Else, after change manifest is built, immediately load, read entire file, then execute `{nextStepFile}`.
+- **EXCEPTION:** If no changes detected (section 4), load `{noChangeReportFile}` instead.
 
 #### EXECUTION RULES:
 
 - This is an auto-proceed step with no user choices
-- Proceed directly to next step after change detection completes
+- Proceed directly to next step after change detection completes (or to report when `detect_only_mode` is true)
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN the change manifest is fully built will you load {nextStepFile} to begin re-extraction. If no changes detected, skip to {noChangeReportFile}.
+ONLY WHEN the change manifest is fully built will you load the next file:
+
+- `detect_only_mode == true` → load `{noChangeReportFile}` (report.md). Report emits status `detect-only`.
+- No changes detected → load `{noChangeReportFile}` (report.md). Report emits status `no-changes`.
+- Otherwise → load `{nextStepFile}` (re-extract.md) to begin re-extraction.
 

--- a/src/skf-update-skill/references/init.md
+++ b/src/skf-update-skill/references/init.md
@@ -29,6 +29,8 @@ Provide either:
 - A full path to the skill folder
 - A skill name with `--from-test-report` to use the test report's gap findings instead of source drift detection
 - `--allow-workspace-drift` (gap-driven mode only) to intentionally bypass the step 3 §0.a guard that halts when the local workspace HEAD does not match `metadata.source_commit`. Only use this if you know the spot-checks should read the current workspace instead of the pinned tree — step 6 will NOT automatically re-pin
+- `--detect-only` to run detect-changes only and exit; emits the change manifest with no further work and no writes
+- `--dry-run` to run detect-changes + re-extract and exit before merge/write; emits what WOULD change without modifying any artifact
 
 **Skill:** {user provides path or name}"
 
@@ -45,6 +47,12 @@ Resolve the path to an absolute skill folder location.
 Search for the test report at `{forge_data_folder}/{skill_name}/{active_version}/test-report-{skill_name}.md` (i.e., `{forge_version}/test-report-{skill_name}.md`). If not found at the versioned path, fall back to `{forge_data_folder}/{skill_name}/test-report-{skill_name}.md`. If found, set `test_report_path` in context and `update_mode: gap-driven`. If not found at either path, warn and continue with normal source drift mode.
 
 **If `--allow-workspace-drift` was provided:** set `allow_workspace_drift: true` in workflow context. This flag is consumed by step 3 §0.a's pre-flight drift guard (gap-driven mode only) and has no effect in normal source-drift mode.
+
+**If `--detect-only` was provided:** set `detect_only_mode: true` in workflow context. After step 2 (detect-changes) completes, jump directly to step 7 (report) — skip re-extract, merge, validate, and write. The report emits the change manifest and a `SKF_UPDATE_RESULT_JSON` envelope with `status: "detect-only"`. **Compatibility:** `--detect-only` short-circuits before §0.a runs, so `--allow-workspace-drift` is silently ignored in detect-only mode (warn the user once at flag-parse time: "`--allow-workspace-drift` has no effect with `--detect-only` — workspace drift guard runs in step 3 §0.a, which is skipped").
+
+**If `--dry-run` was provided:** set `dry_run_mode: true` in workflow context. After step 3 (re-extract) completes, jump directly to step 7 (report) — skip merge, validate, and write. The report emits what would change with `status: "dry-run"` in the envelope. No artifact on disk is modified — `--dry-run` is the "show me what an update would do without committing" mode.
+
+**If BOTH `--detect-only` AND `--dry-run` were provided:** `--detect-only` wins (it's the more restrictive). Warn the user once: "`--detect-only` supersedes `--dry-run`; re-extract is skipped." Set `detect_only_mode: true`, ignore `dry_run_mode`.
 
 ### 2. Validate Required Artifacts
 

--- a/src/skf-update-skill/references/re-extract.md
+++ b/src/skf-update-skill/references/re-extract.md
@@ -334,12 +334,14 @@ Extraction Results:
 
 ### 6. Present MENU OPTIONS
 
-Display: "**Proceeding to merge...**"
-
-- After extraction results are compiled, immediately load, read entire file, then execute {nextStepFile}
-- This is an auto-proceed step with no user choices
+- **If `dry_run_mode` is true:** display "**Dry-run mode — skipping merge/validate/write.** Loading report..." and load `report.md` (NOT `{nextStepFile}`). The report emits the dry-run envelope describing what merge+write WOULD have done.
+- Else, display "**Proceeding to merge...**" and after extraction results are compiled, immediately load, read entire file, then execute `{nextStepFile}`.
+- This is an auto-proceed step with no user choices.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN all changed files have been extracted and results compiled will you load {nextStepFile} to begin the merge operation.
+ONLY WHEN all changed files have been extracted and results compiled will you load the next file:
+
+- `dry_run_mode == true` → load `report.md`. Report emits status `dry-run`. No artifact is modified on disk by this run.
+- Otherwise → load `{nextStepFile}` (merge.md) to begin the merge operation.
 

--- a/src/skf-update-skill/references/report.md
+++ b/src/skf-update-skill/references/report.md
@@ -37,6 +37,50 @@ Source code matches provenance map exactly. The skill `{skill_name}` is current 
 
 → Load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 
+### 1a. Handle Detect-Only Mode
+
+**If `detect_only_mode` is true (routed here from detect-changes.md §6):**
+
+"**Update Skill Report: {skill_name} — Detect-Only Mode**
+
+**Status:** Detect-only (no writes)
+
+The change manifest below describes what would be updated. No artifact was modified — re-run without `--detect-only` to apply.
+
+{render the change manifest summary table from detect-changes.md §5, plus the per-file detail section}
+
+**Recommendation:** Review the manifest; if it matches expectations, re-run `skf-update-skill` without `--detect-only` to perform the actual update."
+
+The headless envelope (`SKF_UPDATE_RESULT_JSON`) carries `status: "detect-only"`, `files_written: []`, and any `headless_decisions[]` recorded by detect-changes' §1b / §1c / §2.2 gates. `version` and `previous_version` are both equal to the on-disk version (detect-only does not bump). `update_mode` reflects the run's mode (`normal` or `gap-driven` or `degraded`) so consumers know which detection path produced the manifest.
+
+→ Load, read the full file, and execute `{nextStepFile}` (health-check) — even detect-only runs through the terminal health-check step.
+
+### 1b. Handle Dry-Run Mode
+
+**If `dry_run_mode` is true (routed here from re-extract.md §6):**
+
+"**Update Skill Report: {skill_name} — Dry-Run Mode**
+
+**Status:** Dry-run (no writes)
+
+The change manifest below shows what was detected; re-extraction ran to compute the planned merge but neither merge nor write executed. No artifact was modified.
+
+{render the change manifest summary AND the re-extraction summary — what merge+validate+write WOULD have done}
+
+**Planned writes (skipped):**
+- SKILL.md re-merge with re-extracted exports
+- metadata.json version bump (or hold for gap-driven)
+- provenance-map.json update with re-extraction results
+- evidence-report.md
+- context-snippet.md (only if a staleness trigger fired)
+- active-symlink flip (only if version changed)
+
+**Recommendation:** Review the manifest and re-extraction summary; if both match expectations, re-run `skf-update-skill` without `--dry-run` to perform the actual update."
+
+The headless envelope carries `status: "dry-run"`, `files_written: []`, the `headless_decisions[]` recorded so far (everything before merge), and `update_mode` from the run.
+
+→ Load, read the full file, and execute `{nextStepFile}` (health-check).
+
 ### 2. Present Change Summary
 
 "**Update Skill Report: {skill_name}**


### PR DESCRIPTION
## Summary

Issue #307 workstream **C2**. `skf-update-skill` previously had no way to ask "what would this update do without actually doing it." Pipelines that wanted to gate manual review on the planned changes had to run a real update and parse the report after the fact — too late to abort.

Two new flags, both **read-only with zero artifact modification**:

| Flag | Stops after | Envelope `status` | Use case |
|---|---|---|---|
| `--detect-only` | step 2 (detect-changes) | `"detect-only"` | "Did anything change?" — fastest answer, no extraction work |
| `--dry-run` | step 3 (re-extract) | `"dry-run"` | "What WOULD this update do?" — describes the planned merge in detail |

When both flags are passed, `--detect-only` wins (warning surfaced at flag-parse time). Both flags are compatible with `--headless` and `--from-test-report`. `--allow-workspace-drift` is silently ignored under `--detect-only` (the §0.a guard runs in step 3, which is skipped).

## Changes

**`src/skf-update-skill/references/init.md §1`** — help text extended with the two new flags; three new parsing blocks after the existing `--from-test-report` / `--allow-workspace-drift` parsing handle the new flags, document early-exit semantics, and call out compatibility interactions.

**`src/skf-update-skill/references/detect-changes.md §6`** — Menu Handling Logic gains a `detect_only_mode` branch that loads `report.md` instead of `{nextStepFile}`. CRITICAL STEP COMPLETION NOTE rewritten as a 3-row dispatch table covering `detect_only` / `no-changes` / normal paths.

**`src/skf-update-skill/references/re-extract.md §6`** — same pattern at the post-re-extract exit. `dry_run_mode` loads `report.md` instead of `merge.md`.

**`src/skf-update-skill/references/report.md`** — two new sub-sections **§1a (detect-only)** and **§1b (dry-run)** before the existing §2. Each renders the appropriate "what would change" view (manifest summary table for detect-only; manifest + re-extraction summary + planned-writes list for dry-run) and notes which envelope `status` to emit. Health-check chains the same as full runs — even inspection modes complete the workflow's terminal step.

**`src/shared/scripts/schemas/skf-update-result-envelope.v1.json`** — status enum gains `"detect-only"` and `"dry-run"`. Description expanded to call out that **these are SUCCESSFUL exits** — pipelines treating non-`success` as failure must include them in the success set alongside `success`/`no-changes`. Same note added to the SKILL.md Headless row.

**`src/skf-update-skill/SKILL.md` Invocation Contract** — new **Flags** row enumerates all five flags. Outputs row notes that `--detect-only` and `--dry-run` produce no artifact writes.

## Test plan

- [x] `npm run test:python` — 1076 passed
- [x] `node tools/validate-skills.js` — 0 findings
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 leaks
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green

Tracks: #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)