### PR TITLE
feat(skf-brief-skill): wire customize.toml path scalars (closes #307 D1)

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -43,7 +43,30 @@ These rules apply to every step in this workflow:
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
-3. Load, read the full file, and execute `references/gather-intent.md`.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the three scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{descriptionVoiceExamplesPath}` ← `workflow.description_voice_examples_path` if non-empty, else `assets/description-voice-examples.md`
+   - `{scopeTemplatesPath}` ← `workflow.scope_templates_path` if non-empty, else `assets/scope-templates.md`
+   - `{briefSchemaPath}` ← `workflow.brief_schema_path` if non-empty, else `assets/skill-brief-schema.md`
+
+   Stash all three as workflow-context variables. Stage files reference `{descriptionVoiceExamplesPath}` / `{scopeTemplatesPath}` / `{briefSchemaPath}` directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default; non-empty values let orgs swap in house-style copies without forking the skill.
+
+4. Load, read the full file, and execute `references/gather-intent.md`.
 
 ## Stages
 

--- a/src/skf-brief-skill/references/confirm-brief.md
+++ b/src/skf-brief-skill/references/confirm-brief.md
@@ -26,7 +26,7 @@ To present the complete skill brief in human-readable format, highlighting all f
 
 ### 1. Assemble Complete Brief
 
-Use the values already accepted in steps 01-03 directly — do not re-load `{briefSchemaFile}` here. The 18 fields below are all in conversation; the schema is only consulted in §4 if an inline adjustment needs a specific field's validation rule cited.
+Use the values already accepted in steps 01-03 directly — do not re-load `{briefSchemaPath}` here. The 18 fields below are all in conversation; the schema is only consulted in §4 if an inline adjustment needs a specific field's validation rule cited.
 
 Compile all gathered data from steps 01-03 into the complete brief:
 
@@ -140,7 +140,7 @@ You can:
 ### 4. Handle Inline Adjustments
 
 If the user requests changes to specific fields (name, description, version, etc.):
-- If the adjustment requires explaining a field's validation rule or allowed values, load `{briefSchemaFile}` now (otherwise skip the read — the common path does not need it)
+- If the adjustment requires explaining a field's validation rule or allowed values, load `{briefSchemaPath}` now (otherwise skip the read — the common path does not need it)
 - Make the adjustment
 - Re-present the updated brief
 - Return to the menu

--- a/src/skf-brief-skill/references/gather-intent.md
+++ b/src/skf-brief-skill/references/gather-intent.md
@@ -178,7 +178,7 @@ If the command produces any output, skip this rail silently — repeat users don
 
 "**Want to see a few example descriptions first?** [Y/N] (Helpful if this is your first time — I'll show the voices we use so you have an anchor for what 'good intent' produces.)"
 
-On `[Y]`: load `{descriptionVoiceExamplesFile}` and present the five examples verbatim with a one-line preface (`"Each example shows a different voice — yours doesn't have to match any specific one."`). On `[N]` or empty: proceed silently.
+On `[Y]`: load `{descriptionVoiceExamplesPath}` and present the five examples verbatim with a one-line preface (`"Each example shows a different voice — yours doesn't have to match any specific one."`). On `[N]` or empty: proceed silently.
 
 "**What's your intent for this skill?**
 
@@ -266,7 +266,7 @@ The schema's `description` field is 1-3 sentences and surfaces in skill registri
 
 Compose a candidate 1-3 sentence description from the gathered material. **Write like a human library maintainer would** — what does an agent get from this skill, and when should it route here? Two facts must come through (what the skill is, when to use it); everything else is voice. Resist filling in the same skeleton every time.
 
-Load `{descriptionVoiceExamplesFile}` for the five voice examples (range of acceptable leads, structures, and trigger phrasings) and the "do not template-stamp" guidance, then compose in that spirit. The asset documents what "in that spirit" means; the gathered material to draw on is the target repo, the user's intent, the version if set, and any scope hints.
+Load `{descriptionVoiceExamplesPath}` for the five voice examples (range of acceptable leads, structures, and trigger phrasings) and the "do not template-stamp" guidance, then compose in that spirit. The asset documents what "in that spirit" means; the gathered material to draw on is the target repo, the user's intent, the version if set, and any scope hints.
 
 Present:
 
@@ -286,9 +286,9 @@ On `tighten` or a fresh edit: re-prompt for the description. On `accept` or any 
 
 Store the accepted text as the brief's `description` field. The same field is re-presented in step 4 §3 for a final review pass — refinements there flow back to this value.
 
-**Headless:** if the `intent` argument was supplied, load `{descriptionVoiceExamplesFile}` and run the same synthesis against it (in `{document_output_language}`), then store the result. If `intent` was not supplied, fall back in priority order:
+**Headless:** if the `intent` argument was supplied, load `{descriptionVoiceExamplesPath}` and run the same synthesis against it (in `{document_output_language}`), then store the result. If `intent` was not supplied, fall back in priority order:
 
-1. **GitHub repo description** — when `target_repo` is a GitHub URL, fetch `gh api repos/{owner}/{repo} --jq .description` (5-second timeout). If a non-empty description comes back, load `{descriptionVoiceExamplesFile}` and synthesize using the GitHub description as the seed in place of `intent`. Write the synthesized description in `{document_output_language}` regardless of the seed's language (the seed may be in any language; the output's language is dictated by the workflow's document-output configuration). Log `"info: description seeded from GitHub repo description"`. (The full `gh api repos` response is fetched again in step 2 §1; this lightweight `--jq .description` call only retrieves the one field.)
+1. **GitHub repo description** — when `target_repo` is a GitHub URL, fetch `gh api repos/{owner}/{repo} --jq .description` (5-second timeout). If a non-empty description comes back, load `{descriptionVoiceExamplesPath}` and synthesize using the GitHub description as the seed in place of `intent`. Write the synthesized description in `{document_output_language}` regardless of the seed's language (the seed may be in any language; the output's language is dictated by the workflow's document-output configuration). Log `"info: description seeded from GitHub repo description"`. (The full `gh api repos` response is fetched again in step 2 §1; this lightweight `--jq .description` call only retrieves the one field.)
 2. **Generic stub** — when no GitHub description is available (local-path target, GitHub repo with empty description, or `gh api` fails): derive from `target_repo` + `skill_name` (`"Use the {skill_name} skill to work with code or content from {target_repo}."`) — the generic fallback does not need the asset — and log `"warn: description synthesized without intent or repo description — narrow registry text."`
 
 ### 8. Present MENU OPTIONS

--- a/src/skf-brief-skill/references/scope-definition.md
+++ b/src/skf-brief-skill/references/scope-definition.md
@@ -80,7 +80,7 @@ HEAD-check the URLs in parallel — issue all N `curl -sI --max-time 5 {url}` ca
 
 ### 2c. Offer Scope Templates
 
-Load `{scopeTemplatesFile}` for the scope type options ([F], [M], [P], [C], [R]) and their descriptions.
+Load `{scopeTemplatesPath}` for the scope type options ([F], [M], [P], [C], [R]) and their descriptions.
 
 **Recommend a scope type — don't present the five options as equal weight.** SKILL.md states this workflow "steers toward the smaller, sharper version when scope is unclear" — surface that opinion at decision time. Use the analysis from step 2 and the user's intent from step 1 to pick the best-fit recommendation, then present the menu with that option marked as the suggested default.
 
@@ -112,7 +112,7 @@ Present:
 
 How broadly should this skill cover the library?
 
-{full menu from `{scopeTemplatesFile}` with the recommended letter marked, e.g. '[F] Full Library', '[M] Specific Modules', '[P] Public API Only ← recommended', '[C] Component Library', '[R] Reference App'}
+{full menu from `{scopeTemplatesPath}` with the recommended letter marked, e.g. '[F] Full Library', '[M] Specific Modules', '[P] Public API Only ← recommended', '[C] Component Library', '[R] Reference App'}
 
 Press Enter to accept the recommendation, or pick a different letter."
 
@@ -120,7 +120,7 @@ Wait for user selection. Empty input or just Enter accepts the recommendation; a
 
 ### 3. Define Boundaries Based on Selection
 
-Using the boundary definitions from `{scopeTemplatesFile}`, present the appropriate flow for the user's selected scope type ([F], [M], [P], [C], or [R]). Follow each type's prompts and wait for user input at each phase before proceeding.
+Using the boundary definitions from `{scopeTemplatesPath}`, present the appropriate flow for the user's selected scope type ([F], [M], [P], [C], or [R]). Follow each type's prompts and wait for user input at each phase before proceeding.
 
 ### 4. Handle Language Override
 

--- a/src/skf-brief-skill/references/write-brief.md
+++ b/src/skf-brief-skill/references/write-brief.md
@@ -32,7 +32,7 @@ To generate the complete skill-brief.yaml from the approved brief data and write
 
 ### 1. Reference the Schema (LLM context only)
 
-`{briefSchemaFile}` and `{versionResolutionFile}` document the brief contract for human readers. The deterministic enforcement of that contract lives in `{writeSkillBriefScript}` and its JSON Schema artifact at `src/shared/scripts/schemas/skill-brief.v1.json`. Load `{briefSchemaFile}` only if you need to explain a specific field to the user during inline adjustments — otherwise skip the read; the script is the source of truth.
+`{briefSchemaPath}` and `{versionResolutionFile}` document the brief contract for human readers. The deterministic enforcement of that contract lives in `{writeSkillBriefScript}` and its JSON Schema artifact at `src/shared/scripts/schemas/skill-brief.v1.json`. Load `{briefSchemaPath}` only if you need to explain a specific field to the user during inline adjustments — otherwise skip the read; the script is the source of truth.
 
 ### 2. Resolve Output Path
 


### PR DESCRIPTION
## Summary

Issue #307 workstream **D1**, the final item in the elevation track. PR #306 shipped three asset-path scalars in `customize.toml` as part of the "elevate to Excellent" parity work:

```toml
description_voice_examples_path = ""
scope_templates_path = ""
brief_schema_path = ""
```

The `customize.toml` documented them as "Empty string = use the bundled default" but **the stage prompts never consumed them** — the surface was present but inert. Orgs setting any of these scalars to a custom path would see no effect at runtime. This PR closes the gap.

## Changes

**`src/skf-brief-skill/SKILL.md`** — new **Step 3 "Resolve workflow customization"** in On Activation:

- Runs `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
- Falls back to direct `customize.toml` read if the resolver is missing
- **Applies the fallback at activation, not at usage sites** — stage files reference one variable each without conditional logic:

| Resolved variable | Source | Fallback |
|---|---|---|
| `{descriptionVoiceExamplesPath}` | `workflow.description_voice_examples_path` | `assets/description-voice-examples.md` |
| `{scopeTemplatesPath}` | `workflow.scope_templates_path` | `assets/scope-templates.md` |
| `{briefSchemaPath}` | `workflow.brief_schema_path` | `assets/skill-brief-schema.md` |

**Stage files updated** (9 usage sites total):

| File | Changes |
|---|---|
| `gather-intent.md` | 4× `{descriptionVoiceExamplesFile}` → `{Path}` |
| `scope-definition.md` | 3× `{scopeTemplatesFile}` → `{Path}` |
| `confirm-brief.md` | 1× `{briefSchemaFile}` → `{Path}` |
| `write-brief.md` | 1× `{briefSchemaFile}` → `{Path}` |

Frontmatter pointers (`descriptionVoiceExamplesFile`, etc.) stay in place as **documented defaults** — readers see them and understand where the bundled asset lives. The body now uses the resolved `Path` variable, so empty-string overrides fall through cleanly to the bundled default and non-empty values let orgs swap in house-style copies without forking the skill.

## Validator gotcha worth noting

Initial draft of the new step wrote the team-override path as `` `{project-root}/_bmad/custom/{skill-name}.toml` ``. `validate-file-refs.js` parses `{project-root}/_bmad/` references with the regex `\{project-root\}\/_bmad\/([^\s'"<>})\]`]+)` — that regex stops at the inner `}` of `{skill-name}`, capturing `custom/{skill-name` and flagging it as broken. Rewrote the prose to describe both override paths as bullet items under `{project-root}` rather than as a single token, sidestepping the validator's inability to handle nested placeholders. (Improving the validator to recognize `{skill-name}` is out of scope for this PR.)

## Scope note

This does NOT fix the same gap in `skf-setup`, `skf-create-skill`, or `skf-update-skill` — their `[workflow]` customization surfaces are also inert today (none runs the resolver in On Activation). The arrays declared in those `customize.toml` files (`activation_steps_prepend` / `_append` / `persistent_facts`) have no consumer. Wiring those is a separate workstream beyond #307; D1's stated scope is brief-skill specifically.

## Issue #307 status after this PR

| ID | Workstream | Status |
|---|---|---|
| A1–A9 | All 9 script extractions | ✅ merged |
| B1 | Carve §2a to own file | ✅ merged |
| B2 | Parallelize fetches | ✅ merged |
| C1 | headless_decisions[] envelope | ✅ merged |
| C2 | --dry-run + --detect-only flags | ✅ merged |
| C3 | Concurrency lock | ✅ merged |
| **D1** | brief-skill scalar wiring | **🟡 this PR** |

**Closes #307** once merged.

## Test plan

- [x] `npm run test:python` — 1076 passed
- [x] `node tools/validate-skills.js` — 0 findings
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 leaks
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)