### PR TITLE
refactor(skf-core): post-elevation tightening pass across all 3 Core skills

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -87,6 +87,7 @@ These rules apply to every step in this workflow:
 | **Gates** | step 1: Input Gate [use args] | step 3: Confirm Gate [C] | step 4: Confirm Gate [C] |
 | **Outputs** | `skill-brief.yaml` at `{forge_data_folder}/{skill-name}/skill-brief.yaml`; final `SKF_BRIEF_RESULT_JSON` line on stdout when `{headless_mode}` is true |
 | **Headless** | All gates auto-resolve with heuristic-driven or default action when `{headless_mode}` is true; pre-supplied inputs consumed at the gates that would otherwise prompt; absent `source_authority` and `scope_type` are resolved by signal-driven detection (see `references/headless-args.md`); existing briefs are preserved unless `--force` was supplied (HALT with `overwrite-cancelled` otherwise) |
+| **Transient-failure retry** | This workflow does **not** auto-retry network or subprocess failures. A failed `gh` fetch (analyze-target.md §1, portfolio-similarity-check.md), QMD probe, or extraction script is logged and surfaced in the final result envelope as a warning, but the workflow continues with whatever signal it has. Headless pipelines that want retry semantics should wrap the invocation at their orchestrator level (e.g. CI re-runner on non-zero exit). Rationale: brief-skill is read-mostly with one terminal write (the YAML at step 5); a partial-signal retry has more failure modes than just re-running the whole workflow, which is cheap. |
 | **Exit codes** | See "Exit Codes" below |
 
 ## Exit Codes

--- a/src/skf-brief-skill/customize.toml
+++ b/src/skf-brief-skill/customize.toml
@@ -30,7 +30,9 @@ activation_steps_append = []
 #     "file:{project-root}/docs/brief-style.md" (globs supported; file
 #     contents are loaded and treated as facts).
 
-persistent_facts = []
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
 
 # --- Optional asset overrides ---
 #

--- a/src/skf-brief-skill/references/analyze-target.md
+++ b/src/skf-brief-skill/references/analyze-target.md
@@ -81,7 +81,7 @@ This looks like a monorepo ({manifest_kind}) with these workspaces:
   1. {workspaces[0].name} ({workspaces[0].path})
   2. {workspaces[1].name} ({workspaces[1].path})
   ...
-Which one should the skill cover? Pick a number, type 'all' to scope at the repo root, or 'list' to keep listing more.
+Which one should the skill cover? Pick a number, or type 'all' to scope at the repo root.
 ```
 
 Interactive: wait for the user choice. On a numbered choice, store `monorepo_workspace: {path}` and rebase §2-§4b against that path. On `'all'`, leave `monorepo_workspace` unset and proceed at the repo root with a note in the analysis summary that scope is unfiltered.

--- a/src/skf-create-skill/customize.toml
+++ b/src/skf-create-skill/customize.toml
@@ -30,4 +30,6 @@ activation_steps_append = []
 #     "file:{project-root}/docs/create-policy.md" (globs supported; file
 #     contents are loaded and treated as facts).
 
-persistent_facts = []
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]

--- a/src/skf-create-skill/references/sub/fetch-temporal.md
+++ b/src/skf-create-skill/references/sub/fetch-temporal.md
@@ -112,15 +112,17 @@ Per-call rationale:
    # Sequential per-tag loop. Iterate the JSON tag array verbatim so a
    # crash mid-loop leaves a partial-but-well-formed releases.md on disk.
    echo "# Releases (partial if interrupted)" > {staging}/releases.md
+   ERR_FILE="{staging}/.gh-release-err"  # per-run stderr capture inside staging
    jq -r '.[].tagName' {staging}/.release-tags.json | while IFS= read -r tag; do
      if gh release view "$tag" -R {owner}/{repo} \
-          --json tagName,name,publishedAt,body 2>/tmp/.gh-err; then
+          --json tagName,name,publishedAt,body 2>"$ERR_FILE"; then
        jq -r '...' >> {staging}/releases.md  # one ## {tag} block per release
      else
-       echo "## $tag — fetch failed: $(cat /tmp/.gh-err)" \
+       echo "## $tag — fetch failed: $(cat "$ERR_FILE")" \
          >> {staging}/releases.md
      fi
    done
+   rm -f "$ERR_FILE"
    ```
 
    Failed individual fetches get a one-line placeholder; the loop continues with remaining tags. If a rate limit (HTTP 429) is hit, stop the release loop, keep the partial `releases.md` file in place (do NOT delete it), and log: "Release fetch stopped at tag {N}/{total} due to rate limiting — partial releases.md retained."

--- a/src/skf-update-skill/customize.toml
+++ b/src/skf-update-skill/customize.toml
@@ -30,7 +30,9 @@ activation_steps_append = []
 #     "file:{project-root}/docs/update-policy.md" (globs supported; file
 #     contents are loaded and treated as facts).
 
-persistent_facts = []
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
 
 # --- Optional gate thresholds ---
 #

--- a/src/skf-update-skill/references/init.md
+++ b/src/skf-update-skill/references/init.md
@@ -177,7 +177,7 @@ Load {manualSectionRulesFile} to understand [MANUAL] detection patterns.
 
 "**Source path from provenance map is invalid:** `{source_root}`
 
-Please provide the current source code path:
+Provide the current source code path:
 **Path:** {user provides path}"
 
 ### 7. Present Baseline Summary

--- a/src/skf-update-skill/references/manual-section-rules.md
+++ b/src/skf-update-skill/references/manual-section-rules.md
@@ -1,3 +1,7 @@
+---
+type: static-reference
+---
+
 # [MANUAL] Section Rules
 
 ## Detection Pattern

--- a/src/skf-update-skill/references/merge-conflict-rules.md
+++ b/src/skf-update-skill/references/merge-conflict-rules.md
@@ -1,3 +1,7 @@
+---
+type: static-reference
+---
+
 # Merge Conflict Rules
 
 ## Change Categories

--- a/src/skf-update-skill/references/remote-source-resolution.md
+++ b/src/skf-update-skill/references/remote-source-resolution.md
@@ -1,3 +1,7 @@
+---
+type: static-reference
+---
+
 # Remote Source Resolution (Forge/Deep Tier)
 
 If `source_root` is a local path: proceed with the tier-appropriate strategy as normal.

--- a/src/skf-update-skill/references/report.md
+++ b/src/skf-update-skill/references/report.md
@@ -93,8 +93,18 @@ The headless envelope carries `status: "dry-run"`, `files_written: []`, the `hea
 |--------|-------|
 | **Skill** | {skill_name} ({single/stack}) |
 | **Forge Tier** | {tier} |
-| **Mode** | {normal/degraded} |
+| **Mode** | {update_mode}{mode_fallback_note} |
 | **Duration** | {step count} steps |
+
+**`{update_mode}`** is one of `normal`, `gap-driven`, or `degraded` (mirrors the `update_mode` field of `SKF_UPDATE_RESULT_JSON`).
+
+**`{mode_fallback_note}`** surfaces weak-signal fallbacks the workflow took silently and would otherwise be buried in the evidence report. Render it inline after the mode value when any of these conditions fire; render the empty string when none did:
+
+- `--from-test-report` was passed but the test report was missing at the expected path, so step 1 fell back to `normal` mode → ` (gap-driven requested; test report missing — fell back to normal)`
+- `re-extract.md §0.a` skipped the workspace-drift guard because `source_root` is not a git working tree (or HEAD was unreadable) → ` (workspace-drift check skipped: {skip_reason})` where `{skip_reason}` is the helper's `skip_reason` field (`not-a-git-tree` or `HEAD unreadable`)
+- Both fallbacks fired: concatenate both parenthetical notes with `; ` between them
+
+These signals also appear in `warnings[]` on the headless envelope; the Mode row makes them visible to interactive users who scan the report without parsing the envelope.
 
 ### Changes Applied
 


### PR DESCRIPTION
## Summary

Post-elevation quality re-scan (2026-05-15) confirmed all three Core skills at **Excellent**:

| Skill | Before #307 | After #307 + #322 |
|---|---|---|
| skf-brief-skill | Excellent | Excellent |
| skf-create-skill | **Good** | **Excellent** ⬆️ (target reached) |
| skf-update-skill | Excellent | Excellent |

Zero broken findings across all three. This PR closes the remaining actionable low-severity items in a single commit.

## What this fixes

### Real fixes

| # | Item | Where |
|---|---|---|
| 1 | `/tmp/.gh-err` absolute-path leak from PR #318's per-release stderr capture | `fetch-temporal.md:117,120` — replaced with `{staging}/.gh-release-err` (Windows-friendly, concurrent-run-friendly, cleaned up after the loop) |
| 2 | Dangling `'list'` option in monorepo prompt (advertised but never handled) | `analyze-target.md:84` — removed |
| 3 | "Please provide…" → "Provide…" direct-imperative tightening | `update-skill init.md:180` |

### Quality-of-life additions

| # | Item | Where |
|---|---|---|
| 4 | `persistent_facts` seeded with `file:{project-root}/**/project-context.md` (bmad convention; canonical example: `bmad-agent-pm/customize.toml`) | All 3 `customize.toml` files |
| 5 | Banner weak-signal surfacing in update-skill report | `report.md §2` Mode row gains fallback notes for test-report-missing and workspace-drift-skipped — already in `warnings[]` on the envelope; this makes them visible to interactive users |
| 6 | Transient-failure retry semantics explicit | `brief-skill SKILL.md` Invocation Contract — explicit "this workflow does NOT auto-retry; orchestrator wraps with retry" |
| 7 | `type: static-reference` frontmatter on 3 update-skill reference docs | `manual-section-rules.md`, `merge-conflict-rules.md`, `remote-source-resolution.md` — lets scanners distinguish stage files from lazy-loaded references |

## Deferred (low-value or substantial work)

Tracked for future workstreams, deliberately not in this PR:

- **Marker-syntax override** (`[markers]` block in update-skill customize.toml). Adding the surface without wiring the many `[MANUAL]` references in stage prose would be inert — same pattern D1 just fixed in brief-skill. Defer until a wiring workstream lands both halves together.
- **Re-forge UX guardrails** (silent overwrite, rename orphan) in create-skill — substantial behavior changes that need design conversation, not blind addition.
- **Second-wave script delegation** (5 helpers identified in the create-skill scan). Real opportunity but lower-value than the 9 already-extracted ones.
- **`[workflow.gate_defaults]`** for per-gate headless overrides — needs concrete gate enumeration first.
- **Split `skill-sections.md` + `compile-assembly-rules.md`** into standard vs component-library variants. Real structural work, not a one-PR tightening item.
- **Path-standards false-positives** (parent-dir frontmatter refs in `sub/`, `~/.skf/` in explanatory prose, `_bmad/skf/` in a frontmatter comment). All correctly flagged by the scanner but they're legitimate patterns, not defects.

## Test plan

- [x] `npm run test:python` — 1076 passed
- [x] `node tools/validate-skills.js` — 0 findings
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 leaks
- [x] `node test/test-installation-components.js` — pass
- [x] `node test/test-workflow-state.js` — pass
- [x] pre-commit hook full suite — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)