### PR TITLE
refactor(skf-feature): elevate 5 Feature workflows toward Excellent (foundation pass)

### DIFF
--- a/src/skf-analyze-source/SKILL.md
+++ b/src/skf-analyze-source/SKILL.md
@@ -28,9 +28,7 @@ These rules apply to every step in this workflow:
 - Read each step file completely before taking any action
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
-- Update `stepsCompleted` in output file frontmatter before loading next step
-- If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
-- Always communicate in `{communication_language}`
+- Always communicate in `{communication_language}` (the language for user-facing prose). Written artifact text — the per-unit recommendation `description` and `scope.notes` persisted into `skill-brief.yaml` — is in `{document_output_language}`; per-step rules call this out where it applies. The two values may be the same.
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages
@@ -52,8 +50,31 @@ These rules apply to every step in this workflow:
 |--------|--------|
 | **Inputs** | project_path [required], scope_hint [optional] |
 | **Gates** | step 2: Confirm Gate [C] | step 3: Confirm Gate [C] | step 5: Confirm Gate [C] |
-| **Outputs** | analysis-report.md, skill-brief.yaml files (one per recommended unit) |
+| **Outputs** | analysis-report.md, skill-brief.yaml files (one per recommended unit); final `SKF_ANALYZE_RESULT_JSON` line on stdout when `{headless_mode}` is true |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                  |
+| ---- | -------------------- | ------------------------------------------------------------------------------------------ |
+| 0    | success              | step 7 (terminal — health check completion)                                               |
+| 2    | input-missing        | step 1 §2-3 — required config absent (config.yaml not loadable, project path empty/invalid in headless mode) |
+| 3    | resolution-failure   | step 1 §2 (`forge-tier.yaml` missing at `{sidecar_path}/forge-tier.yaml`); step 1 §3 (project path does not exist or remote URL inaccessible) |
+| 4    | write-failure        | step 1 §6 (analysis report write failed); step 6 §5 (skill-brief.yaml write failed); step 6 §9 (result contract write failed) |
+| 6    | user-cancelled       | any interactive menu in steps 2/3/5/6 (user selected `[X]` Cancel and exit)               |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 6 emits a single-line JSON envelope on **stdout** before chaining to step 7, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_ANALYZE_RESULT_JSON: {"status":"success|error","report_path":"…|null","brief_paths":["…"],"unit_counts":{"confirmed":N,"skipped":N,"maybe":N},"exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"forge-tier-missing"`, `"path-invalid"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above. `brief_paths` is an array of absolute paths to every generated `skill-brief.yaml` (empty array if none were generated). `unit_counts` reports confirmed/skipped/maybe counts from step 5's user decisions.
 
 ## On Activation
 
@@ -62,4 +83,27 @@ These rules apply to every step in this workflow:
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
-3. Load, read the full file, and then execute `references/init.md` to begin the workflow.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the three scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{unitDetectionHeuristicsPath}` ← `workflow.unit_detection_heuristics_path` if non-empty, else `references/unit-detection-heuristics.md`
+   - `{briefSchemaPath}` ← `workflow.brief_schema_path` if non-empty, else `assets/skill-brief-schema.md`
+   - `{analysisReportTemplatePath}` ← `workflow.analysis_report_template_path` if non-empty, else `templates/analysis-report-template.md`
+
+   Stash all three as workflow-context variables. Stage files reference `{unitDetectionHeuristicsPath}` / `{briefSchemaPath}` / `{analysisReportTemplatePath}` directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default; non-empty values let orgs swap in house-style copies without forking the skill.
+
+4. Load, read the full file, and then execute `references/init.md` to begin the workflow.

--- a/src/skf-analyze-source/customize.toml
+++ b/src/skf-analyze-source/customize.toml
@@ -1,0 +1,44 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-analyze-source.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any source-analysis work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (house style, naming conventions, scope guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Recommended skills must align with our agent stack."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/analysis-style.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+unit_detection_heuristics_path = ""
+brief_schema_path = ""
+analysis_report_template_path = ""

--- a/src/skf-analyze-source/references/continue.md
+++ b/src/skf-analyze-source/references/continue.md
@@ -8,6 +8,8 @@ nextStepOptions:
   step 6: 'generate-briefs.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1b: Continue Analysis
 
 ## STEP GOAL:

--- a/src/skf-analyze-source/references/generate-briefs.md
+++ b/src/skf-analyze-source/references/generate-briefs.md
@@ -4,6 +4,8 @@ schemaFile: 'assets/skill-brief-schema.md'
 nextStepFile: 'health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Artifact text in {document_output_language}. -->
+
 # Step 6: Generate Briefs
 
 ## STEP GOAL:
@@ -89,7 +91,7 @@ For each generated brief, check against {schemaFile} validation rules:
 **Validation:** {all passed / N issues found}
 {List any validation issues}
 
-**Ready to write {count} skill-brief.yaml files.** Confirm to proceed? (Y to write / N to abort / M to modify a specific brief)"
+**Ready to write {count} skill-brief.yaml files.** Confirm to proceed? (Y to write all briefs / N to skip writing but continue to report update / M to modify a specific brief / X to cancel and exit the workflow)"
 
 Wait for explicit user confirmation before writing files.
 
@@ -107,9 +109,12 @@ For each confirmed brief:
 - Update the YAML, re-validate, present again
 - Return to confirmation prompt
 
-**IF user aborts (N):**
-- Document abort decision
+**IF user skips writing (N):**
+- Document the skip decision
 - Skip file writing, proceed to report update
+
+**IF user cancels (X):**
+- HARD HALT with exit code 6 (`user-cancelled`). Emit the `SKF_ANALYZE_RESULT_JSON` envelope on stderr with `status: "error"`, `halt_reason: "user-cancelled"`, `brief_paths: []`, and `unit_counts` reflecting the confirmed/skipped/maybe state from step 5
 
 ### 6. Determine Next Workflow Per Unit
 

--- a/src/skf-analyze-source/references/health-check.md
+++ b/src/skf-analyze-source/references/health-check.md
@@ -1,9 +1,11 @@
 ---
 # `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# (`{project-root}/_bmad/skf/` when installed, `src/` during development),
+# NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 7: Workflow Health Check
 

--- a/src/skf-analyze-source/references/identify-units.md
+++ b/src/skf-analyze-source/references/identify-units.md
@@ -4,6 +4,8 @@ outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 heuristicsFile: 'references/unit-detection-heuristics.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Identify Units
 
 ## STEP GOAL:
@@ -120,11 +122,12 @@ lastStep: 'identify-units'
 
 ### 7. Present MENU OPTIONS
 
-Display: "**Select:** [C] Continue to Export Mapping and Integration Detection"
+Display: "**Select:** [C] Continue to Export Mapping and Integration Detection | [X] Cancel and exit"
 
 #### Menu Handling Logic:
 
 - IF C: Save classifications to {outputFile}, update frontmatter, then load, read entire file, then execute {nextStepFile}
+- IF X: HARD HALT with exit code 6 (`user-cancelled`). Emit the `SKF_ANALYZE_RESULT_JSON` envelope on stderr with `status: "error"`, `halt_reason: "user-cancelled"`, and counts/paths reflecting state at cancellation
 - IF Any other: help user, then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-analyze-source/references/init.md
+++ b/src/skf-analyze-source/references/init.md
@@ -5,6 +5,8 @@ outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 templateFile: 'templates/analysis-report-template.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Initialize Analysis
 
 ## STEP GOAL:

--- a/src/skf-analyze-source/references/map-and-detect.md
+++ b/src/skf-analyze-source/references/map-and-detect.md
@@ -4,6 +4,8 @@ outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 heuristicsFile: 'references/unit-detection-heuristics.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Map Exports and Detect Integrations
 
 ## STEP GOAL:

--- a/src/skf-analyze-source/references/recommend.md
+++ b/src/skf-analyze-source/references/recommend.md
@@ -6,6 +6,8 @@ advancedElicitationSkill: '/bmad-advanced-elicitation'
 partyModeSkill: '/bmad-party-mode'
 ---
 
+<!-- Config: communicate in {communication_language}. Artifact text in {document_output_language}. -->
+
 # Step 5: Recommend
 
 ## STEP GOAL:
@@ -153,7 +155,7 @@ stack_skill_candidates: [{updated list with user decisions}]
 
 ### 8. Present MENU OPTIONS
 
-Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [D] Discover Additional Source [C] Continue to Brief Generation"
+Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [D] Discover Additional Source [C] Continue to Brief Generation [X] Cancel and exit"
 
 #### Menu Handling Logic:
 
@@ -161,6 +163,7 @@ Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [D] Disc
 - IF P: Invoke {partyModeSkill}, and when finished redisplay the menu
 - IF D: Accept a new repo path/URL from the user. Run a lightweight scan + classify (subset of steps 02-03) for the new source only. Merge new units into the existing report and update `project_paths[]` in frontmatter. Run export mapping for the new units (same logic as step 04 section 2). Generate recommendation cards for the new units and present them for confirmation. Then redisplay this menu.
 - IF C: Save recommendations to {outputFile}, update frontmatter, then load, read entire file, then execute {nextStepFile}
+- IF X: HARD HALT with exit code 6 (`user-cancelled`). Emit the `SKF_ANALYZE_RESULT_JSON` envelope on stderr with `status: "error"`, `halt_reason: "user-cancelled"`, and counts/paths reflecting state at cancellation
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#8-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-analyze-source/references/scan-project.md
+++ b/src/skf-analyze-source/references/scan-project.md
@@ -4,6 +4,8 @@ outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 heuristicsFile: 'references/unit-detection-heuristics.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Scan Project
 
 ## STEP GOAL:
@@ -136,11 +138,12 @@ lastStep: 'scan-project'
 
 ### 7. Present MENU OPTIONS
 
-Display: "**Select:** [C] Continue to Unit Identification"
+Display: "**Select:** [C] Continue to Unit Identification | [X] Cancel and exit"
 
 #### Menu Handling Logic:
 
 - IF C: Save scan results to {outputFile}, update frontmatter, then load, read entire file, then execute {nextStepFile}
+- IF X: HARD HALT with exit code 6 (`user-cancelled`). Emit the `SKF_ANALYZE_RESULT_JSON` envelope on stderr with `status: "error"`, `halt_reason: "user-cancelled"`, and counts/paths reflecting state at cancellation
 - IF Any other: help user, then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-analyze-source/references/unit-detection-heuristics.md
+++ b/src/skf-analyze-source/references/unit-detection-heuristics.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Unit Detection Heuristics
 
 ## Purpose

--- a/src/skf-audit-skill/SKILL.md
+++ b/src/skf-audit-skill/SKILL.md
@@ -30,7 +30,6 @@ These rules apply to every step in this workflow:
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Update `stepsCompleted` in output file frontmatter before loading next step
-- If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
@@ -50,10 +49,33 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | skill_name [required] |
-| **Gates** | step 1: Confirm Gate [C] |
-| **Outputs** | drift-report-{timestamp}.md with drift_score and nextWorkflow |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Inputs** | `skill_name` [required], `skill_path` [optional override — full path to skill directory; bypasses manifest/symlink resolution], `tier_override` [optional: Quick / Forge / Forge+ / Deep — overrides detected tier], `degraded` [optional bool — pre-confirm degraded-mode opt-in when no provenance map exists], `upstream_drift_choice` [optional: C / S / X — pre-supplied answer for the upstream-drift gate at init.md §5b], `dirty_worktree_choice` [optional: T / A / F — pre-supplied answer for the dirty-worktree sub-gate at init.md §5b], `force` [optional bool — when paired with `dirty_worktree_choice=F` or used for any future destructive-action gate, signals consent to skip the confirmation] |
+| **Gates** | step 1: Manifest-vs-Symlink Gate [N] · Upstream-Drift Gate [C/S/X] · Dirty-Worktree Sub-Gate [T/A/F] · Degraded-Mode Gate [D/X] · Baseline Confirm Gate [C] |
+| **Outputs** | `drift-report-{timestamp}.md` at `{forge_version}/` with `drift_score` and `nextWorkflow` frontmatter; per-run result contract at `{forge_version}/audit-skill-result-{timestamp}.json` plus `-latest.json` copy; final `SKF_AUDIT_RESULT_JSON` line on stdout when `{headless_mode}` is true |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true; pre-supplied inputs (`upstream_drift_choice`, `dirty_worktree_choice`, `degraded`, `tier_override`) consumed at the gates that would otherwise prompt |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                                          |
+| ---- | -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 0    | success              | step 7 (terminal health-check)                                                                                     |
+| 2    | input-missing        | step 1 §1 — no `skill_name` supplied in headless mode (interactive prompt cannot resolve)                          |
+| 3    | resolution-failure   | step 1 §1 (skill not found at resolved path: missing `SKILL.md`); step 1 §2 (`forge-tier.yaml` missing — setup-forge not run); step 1 §5 (source directory from provenance map no longer exists / inaccessible) |
+| 4    | write-failure        | step 1 §6 / step 6 §3 (drift report write failed: read-only mount, disk full, permissions denied)                 |
+| 6    | user-cancelled       | step 1 §1 manifest-vs-symlink gate `[X]` · step 1 §4 degraded-mode gate `[X]` · step 1 §5b upstream-drift gate `[X]` · step 1 §5b dirty-worktree sub-gate `[A]` (and `[A]` headless default) |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 6 emits a single-line JSON envelope on **stdout** before chaining to step 7, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_AUDIT_RESULT_JSON: {"status":"success|error","skill_name":"…","drift_score":"CLEAN|MINOR|SIGNIFICANT|CRITICAL|null","report_path":"…|null","next_workflow":"update-skill|null","audit_ref":"…|null","exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `drift_score` is `null` when the workflow halted before severity classification ran. `next_workflow` is `"update-skill"` when CRITICAL or HIGH findings exist, otherwise `null`. `halt_reason` is one of: `null` (success), `"input-missing"`, `"skill-not-found"`, `"forge-tier-missing"`, `"source-dir-missing"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 
@@ -64,4 +86,26 @@ These rules apply to every step in this workflow:
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
-3. Load, read the full file, and then execute `references/init.md` to begin the workflow.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the two scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{driftReportTemplatePath}` ← `workflow.drift_report_template_path` if non-empty, else `assets/drift-report-template.md`
+   - `{severityRulesPath}` ← `workflow.severity_rules_path` if non-empty, else `references/severity-rules.md`
+
+   Stash both as workflow-context variables. Stage files reference `{driftReportTemplatePath}` / `{severityRulesPath}` directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default; non-empty values let orgs swap in house-style copies (custom drift-report layout, stricter severity thresholds) without forking the skill.
+
+4. Load, read the full file, and then execute `references/init.md` to begin the workflow.

--- a/src/skf-audit-skill/customize.toml
+++ b/src/skf-audit-skill/customize.toml
@@ -1,0 +1,43 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-audit-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any audit work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (house style, severity-threshold policies, audit guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Critical drift requires CODEOWNERS notification."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/audit-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+drift_report_template_path = ""
+severity_rules_path = ""

--- a/src/skf-audit-skill/references/health-check.md
+++ b/src/skf-audit-skill/references/health-check.md
@@ -1,9 +1,11 @@
 ---
 # `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# (`{project-root}/_bmad/skf/` when installed, `{project-root}/src/` during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 7: Workflow Health Check
 

--- a/src/skf-audit-skill/references/init.md
+++ b/src/skf-audit-skill/references/init.md
@@ -4,6 +4,8 @@ outputFile: '{forge_version}/drift-report-{timestamp}.md'
 templateFile: 'assets/drift-report-template.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Initialize Audit
 
 ## STEP GOAL:

--- a/src/skf-audit-skill/references/re-index.md
+++ b/src/skf-audit-skill/references/re-index.md
@@ -3,6 +3,8 @@ nextStepFile: 'structural-diff.md'
 outputFile: '{forge_version}/drift-report-{timestamp}.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Re-Index Source
 
 ## STEP GOAL:

--- a/src/skf-audit-skill/references/report.md
+++ b/src/skf-audit-skill/references/report.md
@@ -3,6 +3,8 @@ outputFile: '{forge_version}/drift-report-{timestamp}.md'
 nextStepFile: 'health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Drift report prose in {document_output_language}. -->
+
 # Step 6: Generate Report
 
 ## STEP GOAL:
@@ -169,6 +171,16 @@ Update {outputFile} frontmatter:
 ### Result Contract
 
 Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_version}/audit-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_version}/audit-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the drift report path in `outputs`; include `drift_count` and `severity` (CLEAN/MINOR/SIGNIFICANT/CRITICAL) in `summary`.
+
+**Stdout envelope (headless only).** When `{headless_mode}` is true, emit a single-line JSON envelope to **stdout** immediately after the on-disk result contract is written, so chaining workflows can consume `drift_score`, `report_path`, and `next_workflow` from a captured stdout line without polling the filesystem. The shape matches the "Result Contract (Headless)" section in SKILL.md verbatim:
+
+```
+SKF_AUDIT_RESULT_JSON: {"status":"success","skill_name":"{skill_name}","drift_score":"{CLEAN|MINOR|SIGNIFICANT|CRITICAL}","report_path":"{outputFile}","next_workflow":"{update-skill|null}","audit_ref":"{audit_ref}","exit_code":0,"halt_reason":null}
+```
+
+Field rules: `next_workflow` is `"update-skill"` when CRITICAL or HIGH findings exist (matches the frontmatter `nextWorkflow` set in §4), otherwise `null`. `audit_ref` carries the resolved value from step 1 §5b (`baseline_ref` when no upstream drift was detected, `latest_tag` or `remote_head` when the operator chose `[C] Checkout-and-audit-against-latest`).
+
+**HALT envelope mirror (headless only).** For every HARD HALT raised in this workflow (skill-not-found at init.md §1, forge-tier missing at §2, source-dir missing at §5, write-failed at §6, user-cancelled at any `[X]` selection), emit the same envelope shape on **stderr** with `status: "error"`, `drift_score: null` (or last known value if classification ran), `report_path: null` if the report write failed, `exit_code` matching the Exit Codes table, and `halt_reason` set to the failure class from the table (`"skill-not-found"`, `"forge-tier-missing"`, `"source-dir-missing"`, `"write-failed"`, `"user-cancelled"`). This is the only signal a wrapping pipeline receives on failure — log it before exiting.
 
 ### 6. Chain to Health Check
 

--- a/src/skf-audit-skill/references/semantic-diff.md
+++ b/src/skf-audit-skill/references/semantic-diff.md
@@ -3,6 +3,8 @@ nextStepFile: 'severity-classify.md'
 outputFile: '{forge_version}/drift-report-{timestamp}.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Semantic Diff
 
 ## STEP GOAL:

--- a/src/skf-audit-skill/references/severity-classify.md
+++ b/src/skf-audit-skill/references/severity-classify.md
@@ -4,6 +4,8 @@ outputFile: '{forge_version}/drift-report-{timestamp}.md'
 severityRulesFile: 'references/severity-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 5: Severity Classification
 
 ## STEP GOAL:

--- a/src/skf-audit-skill/references/severity-rules.md
+++ b/src/skf-audit-skill/references/severity-rules.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Severity Classification Rules
 
 ## Severity Levels

--- a/src/skf-audit-skill/references/structural-diff.md
+++ b/src/skf-audit-skill/references/structural-diff.md
@@ -3,6 +3,8 @@ nextStepFile: 'semantic-diff.md'
 outputFile: '{forge_version}/drift-report-{timestamp}.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Structural Diff
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/SKILL.md
+++ b/src/skf-create-stack-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skf-create-stack-skill
-description: Consolidated project stack skill with integration patterns — code-mode (analyzes manifests) or compose-mode (synthesizes from existing skills + architecture doc). Use when the user requests to "create a stack skill."
+description: Consolidated project stack skill with integration patterns — code-mode (analyzes manifests) or compose-mode (synthesizes from existing skills + architecture doc). Use when the user requests to "create a stack skill", "forge a stack", or "stack this project".
 ---
 
 # Create Stack Skill
@@ -19,7 +19,7 @@ Produces a consolidated stack skill documenting how libraries connect. **Code-mo
 
 ## Role
 
-You are a dependency analyst and integration architect operating in Ferris Architect mode. You bring expertise in dependency analysis, cross-library integration patterns, and compositional architecture, while the user brings their project knowledge and scope preferences.
+You are a dependency analyst and integration architect. You bring expertise in dependency analysis, cross-library integration patterns, and compositional architecture, while the user brings their project knowledge and scope preferences.
 
 ## Workflow Rules
 
@@ -57,6 +57,30 @@ These rules apply to every step in this workflow:
 | **Gates** | step 3: Confirm Gate [C] | step 6: Review Gate [C] |
 | **Outputs** | SKILL.md (stack), context-snippet.md, metadata.json |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                  |
+| ---- | -------------------- | ------------------------------------------------------------------------------------------ |
+| 0    | success              | step 10 (terminal handoff to shared health-check)                                          |
+| 2    | input-missing / input-invalid | step 1 §0 (`config.yaml` missing or malformed); step 2 §2 headless cannot proceed without manifests (S2); step 4 §3 all extractions failed (B7); step 5 §2 feasibility-report `schemaVersion` mismatch; compose-mode-rules `schemaVersion` mismatch |
+| 3    | resolution-failure   | step 1 §1 (`forge-tier.yaml` missing); step 2 §0 compose-mode skill resolution corruption (manifest + symlink both fail); step 2 §0 compose-mode zero qualifying skills (S1/S3) |
+| 4    | write-failure        | step 7 §1 stage-dir / commit-dir failure; step 7 §1 group-dir collision when an existing non-stack skill occupies the target path |
+| 5    | overwrite-cancelled  | step 7 collision when the user declines to replace an existing stack package |
+| 6    | user-cancelled       | any interactive menu in step 3 / step 6 (user selected `[X]` Cancel and exit) |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 9 emits a single-line JSON envelope on **stdout** before chaining to step 10, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_STACK_RESULT_JSON: {"status":"success|error","skill_package":"…|null","skill_name":"…","stack_libraries":["…"],"mode":"code|compose","exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `skill_package` is the absolute path to the committed stack-skill directory (or `null` on error before commit). `skill_name` is the stack skill's published name (e.g. `{project_name}-stack`). `stack_libraries` is the array of library names included in the stack (constituent skill names in compose-mode, dependency names in code-mode). `mode` is `"code"` or `"compose"` per the run's resolved mode. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"forge-tier-missing"`, `"config-missing"`, `"no-manifests"`, `"all-extractions-failed"`, `"schema-version-mismatch"`, `"resolution-failure"`, `"write-failure"`, `"overwrite-cancelled"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 
@@ -69,4 +93,28 @@ These rules apply to every step in this workflow:
    3. **Preferences fallback.** Otherwise, read `headless_mode` from `{sidecar_path}/preferences.yaml` (`true` or `false`).
    4. **Default:** `false`.
 
-3. Load, read the full file, and then execute `references/init.md` to begin the workflow.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the four scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{stackSkillTemplatePath}` ← `workflow.stack_skill_template_path` if non-empty, else `assets/stack-skill-template.md`
+   - `{integrationPatternsPath}` ← `workflow.integration_patterns_path` if non-empty, else `references/integration-patterns.md`
+   - `{manifestPatternsPath}` ← `workflow.manifest_patterns_path` if non-empty, else `references/manifest-patterns.md`
+   - `{composeModeRulesPath}` ← `workflow.compose_mode_rules_path` if non-empty, else `references/compose-mode-rules.md`
+
+   Stash all four as workflow-context variables. Stage files reference `{stackSkillTemplatePath}` / `{integrationPatternsPath}` / `{manifestPatternsPath}` / `{composeModeRulesPath}` directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default; non-empty values let orgs swap in house-style copies without forking the skill.
+
+4. Load, read the full file, and then execute `references/init.md` to begin the workflow.

--- a/src/skf-create-stack-skill/customize.toml
+++ b/src/skf-create-stack-skill/customize.toml
@@ -1,0 +1,45 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-create-stack-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any stack compilation work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (house style, naming conventions, integration-pattern guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Stack skills must cite their constituent libraries."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/stack-style.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+stack_skill_template_path = ""
+integration_patterns_path = ""
+manifest_patterns_path = ""
+compose_mode_rules_path = ""

--- a/src/skf-create-stack-skill/references/compile-stack.md
+++ b/src/skf-create-stack-skill/references/compile-stack.md
@@ -3,6 +3,8 @@ nextStepFile: 'generate-output.md'
 stackSkillTemplate: 'assets/stack-skill-template.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Artifact text in {document_output_language}. -->
+
 # Step 6: Compile Stack Skill
 
 ## STEP GOAL:
@@ -117,7 +119,7 @@ Create the reference index table:
 
 ### 8. Present MENU OPTIONS
 
-Display: **Select:** [C] Continue to Output Generation
+Display: **Select:** [C] Continue to Output Generation | [X] Cancel and exit
 
 #### EXECUTION RULES:
 
@@ -128,5 +130,6 @@ Display: **Select:** [C] Continue to Output Generation
 #### Menu Handling Logic:
 
 - IF C: Store skill_content, then load, read entire file, then execute {nextStepFile}
+- IF X: Invoke the rollback contract (purge any `{forge_data_folder}/{project_name}-stack/{version}/*-tmp` and `*.skf-tmp` staging artifacts under the forge workspace, leave any existing committed stack package untouched), emit the `SKF_STACK_RESULT_JSON` envelope on stderr with `status: "error"`, `halt_reason: "user-cancelled"`, `exit_code: 6`, and exit with code 6
 - IF Any other: Process as feedback, adjust compilation, redisplay preview, then [Redisplay Menu Options](#8-present-menu-options)
 

--- a/src/skf-create-stack-skill/references/compose-mode-rules.md
+++ b/src/skf-create-stack-skill/references/compose-mode-rules.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Compose Mode Rules
 
 Rules for synthesizing a stack skill from pre-generated individual skills and an architecture document, without requiring a codebase.

--- a/src/skf-create-stack-skill/references/detect-integrations.md
+++ b/src/skf-create-stack-skill/references/detect-integrations.md
@@ -4,6 +4,8 @@ integrationPatterns: 'references/integration-patterns.md'
 composeModeRules: 'references/compose-mode-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 5: Detect Integrations
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/references/detect-manifests.md
+++ b/src/skf-create-stack-skill/references/detect-manifests.md
@@ -3,6 +3,8 @@ nextStepFile: 'rank-and-confirm.md'
 manifestPatterns: 'references/manifest-patterns.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Detect Manifests
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/references/generate-output.md
+++ b/src/skf-create-stack-skill/references/generate-output.md
@@ -10,6 +10,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. Artifact text in {document_output_language}. -->
+
 # Step 7: Generate Output Files
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/references/health-check.md
+++ b/src/skf-create-stack-skill/references/health-check.md
@@ -1,9 +1,11 @@
 ---
 # `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
+# (`{project-root}/_bmad/skf/` when installed, `src/` during development), NOT relative
 # to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 10: Workflow Health Check
 

--- a/src/skf-create-stack-skill/references/init.md
+++ b/src/skf-create-stack-skill/references/init.md
@@ -3,6 +3,8 @@ nextStepFile: 'detect-manifests.md'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Initialize
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/references/integration-patterns.md
+++ b/src/skf-create-stack-skill/references/integration-patterns.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Integration Pattern Detection Rules
 
 ## Co-Import Detection

--- a/src/skf-create-stack-skill/references/manifest-patterns.md
+++ b/src/skf-create-stack-skill/references/manifest-patterns.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Manifest Detection Patterns
 
 ## Supported Ecosystems

--- a/src/skf-create-stack-skill/references/parallel-extract.md
+++ b/src/skf-create-stack-skill/references/parallel-extract.md
@@ -2,6 +2,8 @@
 nextStepFile: 'detect-integrations.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Parallel Library Extraction
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/references/rank-and-confirm.md
+++ b/src/skf-create-stack-skill/references/rank-and-confirm.md
@@ -2,6 +2,8 @@
 nextStepFile: 'parallel-extract.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Rank and Confirm Scope
 
 ## STEP GOAL:
@@ -122,7 +124,7 @@ Display final confirmation:
 
 ### 5. Present MENU OPTIONS
 
-Display: **Select:** [C] Continue to Extraction
+Display: **Select:** [C] Continue to Extraction | [X] Cancel and exit
 
 #### EXECUTION RULES:
 
@@ -133,5 +135,6 @@ Display: **Select:** [C] Continue to Extraction
 #### Menu Handling Logic:
 
 - IF C: Store current `confirmed_dependencies` (including any modifications made since initial presentation), then load, read entire file, then execute {nextStepFile}
+- IF X: Invoke the rollback contract (purge any `{forge_data_folder}/{project_name}-stack/{version}/*-tmp` and `*.skf-tmp` staging artifacts under the forge workspace, leave any existing committed stack package untouched), emit the `SKF_STACK_RESULT_JSON` envelope on stderr with `status: "error"`, `halt_reason: "user-cancelled"`, `exit_code: 6`, and exit with code 6
 - IF Any other: Process as scope modification (add/remove skills from `confirmed_dependencies`), update the in-memory `confirmed_dependencies` list accordingly, redisplay the updated skills table, then [Redisplay Menu Options](#5-present-menu-options)
 

--- a/src/skf-create-stack-skill/references/report.md
+++ b/src/skf-create-stack-skill/references/report.md
@@ -8,6 +8,8 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
+<!-- Config: communicate in {communication_language}. Artifact text in {document_output_language}. -->
+
 # Step 9: Stack Skill Report
 
 ## STEP GOAL:

--- a/src/skf-create-stack-skill/references/validate.md
+++ b/src/skf-create-stack-skill/references/validate.md
@@ -3,6 +3,8 @@ nextStepFile: 'report.md'
 stackSkillTemplate: 'assets/stack-skill-template.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Artifact text in {document_output_language}. -->
+
 # Step 8: Validate Output
 
 ## STEP GOAL:

--- a/src/skf-quick-skill/SKILL.md
+++ b/src/skf-quick-skill/SKILL.md
@@ -26,10 +26,8 @@ You are a rapid skill compiler collaborating with a developer. You bring source 
 These rules apply to every step in this workflow:
 
 - Never fabricate content — all data must come from source extraction or user input
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
-- Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}`
+- **Universal cancel-line affordance** — at any interactive prompt the user may type `cancel`, `exit`, `:q`, or select the `[X] Cancel and exit` menu option (where surfaced) to leave cleanly. HARD HALT with **exit code 6 (user-cancelled)** and emit the error result contract per "Result Contract on HARD HALT" with `error.code: "user-cancelled"`. In step 4 §6 the equivalent affordance is `[Q] Quit without writing` — same exit code, same envelope contract.
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 - If `{headless_mode}` is true, emit a single-line JSON progress event to **stderr** at each step's entry and exit so pipeline schedulers can stream live progress instead of post-mortem-parsing the result contract:
   - entry: `{"step":N,"name":"<slug>","status":"start"}`
@@ -55,7 +53,7 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | target (GitHub URL or package name) [required for single-target mode], language_hint [optional], scope_hint [optional] |
-| **Overrides** | `--description`, `--exports`, `--skip-snippet`, `--no-active-pointer`, `--batch <file>`, `--fail-fast` — see On Activation step 3 |
+| **Overrides** | `--description`, `--exports`, `--skip-snippet`, `--no-active-pointer`, `--batch <file>`, `--fail-fast` — see On Activation step 4 |
 | **Gates** | step 1: Input Gate [use args]; step 2: Choice Gate [P] (if match); step 4: Review Gate [C/E/S/Q] |
 | **Outputs** | SKILL.md, context-snippet.md, metadata.json, active pointer, result contract (timestamped + `-latest` copy). Snippet and active pointer can be skipped per overrides. |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
@@ -71,7 +69,7 @@ Every HARD HALT in this workflow exits with a stable, documented code so headles
 | 3    | resolution-failure     | step 1 §2c (prose input), step 1 §3 (registry chain failed) |
 | 4    | write-failure          | step 5 §2 (deliverable write failed)                       |
 | 5    | overwrite-cancelled    | step 5 §1 (user selected [N])                              |
-| 6    | compile-cancelled      | step 4 §6 (user selected [Q])                              |
+| 6    | user-cancelled         | step 1 §1 ([X] Cancel and exit, or cancel-line affordance); step 4 §6 (user selected [Q]) — originally `compile-cancelled`, generalised to cover any interactive gate |
 | 7    | finalize-blocked       | step 6 §1 (active-pointer flip refused — non-link in place) |
 
 Reserved: `validator-missing` may be promoted from advisory log to fatal exit code in a future revision; consumers should not assume code 8+ is unused.
@@ -104,7 +102,7 @@ so consumers that hardcode the `-latest.json` path see a deterministic file even
 | `status`        | string         | always `"error"` for HARD HALTs                                                                             |
 | `exit_code`     | integer        | matches the Exit Codes table                                                                                |
 | `phase`         | string         | step slug where the HALT occurred (e.g. `resolve-target`, `compile`)                                        |
-| `error.code`    | string         | one of: `resolution-failure`, `write-failure`, `overwrite-cancelled`, `compile-cancelled`, `finalize-blocked` |
+| `error.code`    | string         | one of: `resolution-failure`, `write-failure`, `overwrite-cancelled`, `user-cancelled` (formerly `compile-cancelled`), `finalize-blocked` |
 | `error.message` | string         | the user-facing message that was displayed                                                                  |
 | `error.details` | any            | optional — phase-specific context (e.g. the failed file path)                                               |
 | `outputs`       | object         | empty `{}` on early HALTs; partial when files were already written                                          |
@@ -113,13 +111,36 @@ so consumers that hardcode the `-latest.json` path see a deterministic file even
 
 ## On Activation
 
-1. Read `{project-root}/_bmad/skf/config.yaml` and `{forger_root}/preferences.yaml` in parallel (one batched tool-call message — they are independent files), then resolve:
-   - From config: `project_name`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `skills_output_folder`, `forge_data_folder`
+1. Read `{project-root}/_bmad/skf/config.yaml` and `{sidecar_path}/preferences.yaml` in parallel (one batched tool-call message — they are independent files), then resolve:
+   - From config: `project_name`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `skills_output_folder`, `forge_data_folder`, `sidecar_path`
    - From preferences: `headless_mode` (default false)
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in `preferences.yaml`. Default: false.
 
-3. **Parse CLI overrides** — capture optional override flags into the workflow context as `{overrides}`. Each override is opt-in; when omitted, the workflow runs as today.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the three scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{skillTemplatePath}` ← `workflow.skill_template_path` if non-empty, else `assets/skill-template.md`
+   - `{registryResolutionPath}` ← `workflow.registry_resolution_path` if non-empty, else `references/registry-resolution.md`
+   - `{batchOutputPath}` ← `workflow.batch_output_path` if non-empty, else `{skills_output_folder}/_batch/`
+
+   Stash all three as workflow-context variables. Stage files reference `{skillTemplatePath}` / `{registryResolutionPath}` / `{batchOutputPath}` directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default; non-empty values let orgs swap in house-style copies without forking the skill.
+
+4. **Parse CLI overrides** — capture optional override flags into the workflow context as `{overrides}`. Each override is opt-in; when omitted, the workflow runs as today.
 
    | Flag | Effect |
    | --- | --- |
@@ -130,9 +151,9 @@ so consumers that hardcode the `-latest.json` path see a deterministic file even
    | `--batch <file>` | Run the workflow against a list of targets from a text file rather than a single argument. Implies `--headless` (gates cannot be human-driven across N targets). See "Batch Mode" below for input format and summary contract. Single-target overrides above apply globally to every target in the batch. |
    | `--fail-fast` | Only meaningful with `--batch`. Abort the whole batch on the first per-target failure instead of recording the failure in the summary and proceeding to the next target. |
 
-4. **If `--batch` is set**, force `{headless_mode} = true` (log "headless: coerced by --batch" if it was false), read the batch file, and parse the target list per "Batch Mode" below. Continue at step 5; the batch loop documented in "Batch Mode" wraps the step 1 → step 7 pipeline that follows.
+5. **If `--batch` is set**, force `{headless_mode} = true` (log "headless: coerced by --batch" if it was false), read the batch file, and parse the target list per "Batch Mode" below. Continue at step 6; the batch loop documented in "Batch Mode" wraps the step 1 → step 7 pipeline that follows.
 
-5. Load, read the full file, and then execute `references/resolve-target.md` to begin the workflow. (In batch mode, control returns here for each subsequent target after step 7 completes; see "Batch Mode" below.)
+6. Load, read the full file, and then execute `references/resolve-target.md` to begin the workflow. (In batch mode, control returns here for each subsequent target after step 7 completes; see "Batch Mode" below.)
 
 ## Batch Mode
 

--- a/src/skf-quick-skill/customize.toml
+++ b/src/skf-quick-skill/customize.toml
@@ -1,0 +1,44 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-quick-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any compilation work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (house style, naming conventions, compilation guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All skills must cite their upstream source."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/skill-style.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+skill_template_path = ""
+registry_resolution_path = ""
+batch_output_path = ""

--- a/src/skf-quick-skill/references/compile.md
+++ b/src/skf-quick-skill/references/compile.md
@@ -6,9 +6,9 @@ quickMetadataRendererProbeOrder:
   - '{project-root}/src/shared/scripts/skf-render-quick-metadata.py'
 ---
 
-# Step 4: Compile
+<!-- Config: communicate in {communication_language}. Generated SKILL.md text in {document_output_language}. -->
 
-Communicate with the user in `{communication_language}`. Compile generated content (descriptions, usage notes, summaries) in `{document_output_language}`.
+# Step 4: Compile
 
 ## STEP GOAL:
 
@@ -154,7 +154,7 @@ Display: **Select:** [C] Continue to Validation · [E] Edit description · [S] A
 - **IF C** — Load, read entire file, then execute {nextStepFile}.
 - **IF E** — Ask the user for a replacement description ("New description (1–1024 chars):"). Update SKILL.md frontmatter `description` and `metadata.json.description` in the in-memory compiled output, then re-render the §5 preview and redisplay this menu. Do not re-run extraction.
 - **IF S** — Ask the user for an adjusted `scope_hint` ("New scope (e.g. `src/server/`, `packages/core/`):") and optionally a `language_hint`. Update the extraction context with the new hints, then load `quick-extract.md` to re-extract. The new extraction returns to §1 of this step on completion. Discards the prior compiled output.
-- **IF Q** — HARD HALT with **exit code 6 (compile-cancelled)** per the SKILL.md exit-code map: "Compilation cancelled. No files written." Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "compile"`, `error.code: "compile-cancelled"`, `skill_package: null`). Do not proceed to validation; do not write any artifacts.
+- **IF Q** — HARD HALT with **exit code 6 (user-cancelled)** per the SKILL.md exit-code map: "Compilation cancelled. No files written." Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "compile"`, `error.code: "user-cancelled"`, `skill_package: null`). Do not proceed to validation; do not write any artifacts.
 - **IF Any other** — Help the user adjust the compiled output (treated as a free-form revision request), then redisplay the menu.
 
 #### EXECUTION RULES:

--- a/src/skf-quick-skill/references/ecosystem-check.md
+++ b/src/skf-quick-skill/references/ecosystem-check.md
@@ -2,9 +2,9 @@
 nextStepFile: 'quick-extract.md'
 ---
 
-# Step 2: Ecosystem Check
+<!-- Config: communicate in {communication_language}. -->
 
-Communicate with the user in `{communication_language}`.
+# Step 2: Ecosystem Check
 
 ## STEP GOAL:
 

--- a/src/skf-quick-skill/references/finalize.md
+++ b/src/skf-quick-skill/references/finalize.md
@@ -5,9 +5,9 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
 
-# Step 6: Finalize
+<!-- Config: communicate in {communication_language}. Generated SKILL.md text in {document_output_language}. -->
 
-Communicate with the user in `{communication_language}`. Render the user-facing completion summary content in `{document_output_language}`.
+# Step 6: Finalize
 
 ## STEP GOAL:
 

--- a/src/skf-quick-skill/references/health-check.md
+++ b/src/skf-quick-skill/references/health-check.md
@@ -5,9 +5,9 @@
 nextStepFile: 'shared/health-check.md'
 ---
 
-# Step 7: Workflow Health Check
+<!-- Config: communicate in {communication_language}. -->
 
-Communicate with the user in `{communication_language}`.
+# Step 7: Workflow Health Check
 
 ## STEP GOAL:
 

--- a/src/skf-quick-skill/references/quick-extract.md
+++ b/src/skf-quick-skill/references/quick-extract.md
@@ -5,9 +5,9 @@ publicApiExtractorProbeOrder:
   - '{project-root}/src/shared/scripts/skf-extract-public-api.py'
 ---
 
-# Step 3: Quick Extract
+<!-- Config: communicate in {communication_language}. -->
 
-Communicate with the user in `{communication_language}`.
+# Step 3: Quick Extract
 
 ## STEP GOAL:
 

--- a/src/skf-quick-skill/references/registry-resolution.md
+++ b/src/skf-quick-skill/references/registry-resolution.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Registry Resolution Patterns
 
 ## Package-to-Repo Resolution

--- a/src/skf-quick-skill/references/resolve-target.md
+++ b/src/skf-quick-skill/references/resolve-target.md
@@ -6,9 +6,9 @@ packageResolverProbeOrder:
   - '{project-root}/src/shared/scripts/skf-resolve-package.py'
 ---
 
-# Step 1: Resolve Target
+<!-- Config: communicate in {communication_language}. -->
 
-Communicate with the user in `{communication_language}`.
+# Step 1: Resolve Target
 
 ## STEP GOAL:
 
@@ -23,7 +23,7 @@ To accept a GitHub URL or package name from the user, resolve it to a GitHub rep
 
 ### 1. Accept User Input
 
-**Batch mode:** if `--batch` is active (see SKILL.md "Batch Mode"), the current target was already resolved by On Activation step 4 from the next batch line and placed into the workflow context as `target`, with optional `language_hint` and `scope_hint` per-line modifiers. Skip the prompt below — emit `{"batch":<n>,"target":"<target>","status":"start"}` to stderr and proceed directly to §1b with the batch-supplied values.
+**Batch mode:** if `--batch` is active (see SKILL.md "Batch Mode"), the current target was already resolved by On Activation step 5 from the next batch line and placed into the workflow context as `target`, with optional `language_hint` and `scope_hint` per-line modifiers. Skip the prompt below — emit `{"batch":<n>,"target":"<target>","status":"start"}` to stderr and proceed directly to §1b with the batch-supplied values.
 
 **Single-target mode** (default):
 
@@ -37,9 +37,13 @@ Examples: `cocoindex`, `@tanstack/query`, `https://github.com/tursodatabase/limb
 
 **Optional:**
 - **Language hint:** (if the repo is multi-language)
-- **Scope hint:** (specific directories to focus on)"
+- **Scope hint:** (specific directories to focus on)
 
-Wait for user input. **GATE [default: use args]** — If `{headless_mode}` and a target (URL or package name) was provided as argument: use it as the target input and auto-proceed, log: "headless: using provided target". If no target provided in headless mode, HALT with: "headless mode requires a target argument."
+Or type `cancel` / `exit` / `:q` / `[X]` to leave without writing anything."
+
+Wait for user input. **Cancel branch** — if the user types `cancel`, `exit`, `:q`, `[X]`, or selects `[X] Cancel and exit`, display `"Cancelled — no files were written."` and HARD HALT with **exit code 6 (user-cancelled)** per the SKILL.md exit-code map. Before exiting, emit the error result contract per SKILL.md "Result Contract on HARD HALT" (`phase: "resolve-target"`, `error.code: "user-cancelled"`, `skill_package: null`). Cancellation here is non-destructive — no files have been written yet.
+
+**GATE [default: use args]** — If `{headless_mode}` and a target (URL or package name) was provided as argument: use it as the target input and auto-proceed, log: "headless: using provided target". If no target provided in headless mode, HALT with: "headless mode requires a target argument."
 
 ### 1b. Parse Version Targeting
 

--- a/src/skf-quick-skill/references/write-and-validate.md
+++ b/src/skf-quick-skill/references/write-and-validate.md
@@ -8,9 +8,9 @@ outputValidatorProbeOrder:
   - '{project-root}/src/shared/scripts/skf-validate-output.py'
 ---
 
-# Step 5: Write & Validate
+<!-- Config: communicate in {communication_language}. Generated SKILL.md text in {document_output_language}. -->
 
-Communicate with the user in `{communication_language}`. Validation reports are user-facing — render their narrative content in `{document_output_language}`.
+# Step 5: Write & Validate
 
 ## STEP GOAL:
 

--- a/src/skf-test-skill/SKILL.md
+++ b/src/skf-test-skill/SKILL.md
@@ -30,7 +30,6 @@ These rules apply to every step in this workflow:
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Update `stepsCompleted` in output file frontmatter before loading next step
-- If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
@@ -53,8 +52,39 @@ These rules apply to every step in this workflow:
 |--------|--------|
 | **Inputs** | skill_name [required] |
 | **Gates** | step 6: Confirm Gate [C] |
-| **Outputs** | test-report-{skill_name}.md with completeness score and result (PASS/FAIL) |
+| **Outputs** | test-report-{skill_name}.md with completeness score and result (PASS/FAIL); per-run `skf-test-skill-result-{run_id}.json` and `skf-test-skill-result-latest.json` written atomically under `{forge_version}/` |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every terminal state in this workflow exits with a stable code so headless automators can branch on the verdict (and any HARD HALT) without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                  |
+| ---- | -------------------- | ------------------------------------------------------------------------------------------ |
+| 0    | success / PASS       | step 6 §6b — `testResult: 'pass'` (after the result contract is written in §4c)            |
+| 2    | fail / FAIL          | step 6 §6b — `testResult: 'fail'` (after the result contract is written in §4c)            |
+| 3    | inconclusive         | step 6 §6b — `testResult: 'inconclusive'` (distinct from fail so orchestrators can route to manual-review queues) |
+| 4    | pass-with-drift      | step 6 §6b — `testResult: 'pass-with-drift'` (distinct from clean pass — `--allow-workspace-drift` was in effect; orchestrators MUST route to re-test-against-pinned-commit queues and refuse export; never exit 0 under drift override) |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 6 emits a single-line JSON envelope on **stdout** before chaining to step 7, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_TEST_RESULT_JSON: {"status":"success|error","skill_name":"…","verdict":"PASS|FAIL|INCONCLUSIVE|pass-with-drift","score":N,"threshold":N,"report_path":"…|null","next_workflow":"export-skill|update-skill|null","exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path (any of PASS / FAIL / INCONCLUSIVE / pass-with-drift — the workflow completed), `"error"` on any HARD HALT before §4c. `verdict` is the canonical result string. `next_workflow` is `"export-skill"` only when `verdict == "PASS"`; `"update-skill"` for `FAIL` or `pass-with-drift`; `null` for `INCONCLUSIVE` (manual review). `halt_reason` is `null` on the terminal path or one of the workflow-defined halt strings (`"forge-tier-missing"`, `"target-inaccessible"`, `"write-failed"`, `"step-completeness-violation"`, `"report-anchor-missing"`, `"health-check-missing"`, `"atomic-writer-missing"`). `exit_code` matches the table above.
+
+The same payload is persisted to disk by step 6 §4c (atomic write) at two locations under `{forge_version}/`:
+
+| Path                                          | Purpose                                                                    |
+| --------------------------------------------- | -------------------------------------------------------------------------- |
+| `skf-test-skill-result-{run_id}.json`         | Per-run record. `{run_id}` carries UTC timestamp + PID + random suffix.    |
+| `skf-test-skill-result-latest.json`           | Latest copy — stable path for pipeline consumers (copy, not symlink).      |
+
+The on-disk payload is the richer form: it adds `outputs[]` (report-path entries), `summary` (`score`, `threshold`, `result`, `testMode`, `activeCategories[]`, `inconclusiveReasons[]` when present), `runId`, and `healthCheckDispatched`. The stdout envelope is the compact subset documented above.
 
 ## On Activation
 
@@ -64,4 +94,27 @@ These rules apply to every step in this workflow:
 
 2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
 
-3. Load, read the full file, and then execute `references/init.md` to begin the workflow.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the three scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{testReportTemplatePath}` ← `workflow.test_report_template_path` if non-empty, else `templates/test-report-template.md`
+   - `{outputFormatsPath}` ← `workflow.output_formats_path` if non-empty, else `assets/output-section-formats.md`
+   - `{scoringRulesPath}` ← `workflow.scoring_rules_path` if non-empty, else `references/scoring-rules.md`
+
+   Stash all three as workflow-context variables. Stage files reference `{testReportTemplatePath}` / `{outputFormatsPath}` / `{scoringRulesPath}` directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default; non-empty values let orgs swap in house-style copies without forking the skill.
+
+4. Load, read the full file, and then execute `references/init.md` to begin the workflow.

--- a/src/skf-test-skill/customize.toml
+++ b/src/skf-test-skill/customize.toml
@@ -1,0 +1,44 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-test-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any quality-test work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (house style, severity policies, grading guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Test failures of CRITICAL severity block release."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/test-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+test_report_template_path = ""
+output_formats_path = ""
+scoring_rules_path = ""

--- a/src/skf-test-skill/references/coherence-check.md
+++ b/src/skf-test-skill/references/coherence-check.md
@@ -6,6 +6,8 @@ scoringRulesFile: 'references/scoring-rules.md'
 migrationSectionRules: 'references/migration-section-rules.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4: Coherence Check
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/coverage-check.md
+++ b/src/skf-test-skill/references/coverage-check.md
@@ -5,6 +5,8 @@ scoringRulesFile: 'references/scoring-rules.md'
 sourceAccessProtocol: 'references/source-access-protocol.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 3: Coverage Check
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/detect-mode.md
+++ b/src/skf-test-skill/references/detect-mode.md
@@ -3,6 +3,8 @@ nextStepFile: 'coverage-check.md'
 outputFile: '{forge_version}/test-report-{skill_name}-{run_id}.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 2: Detect Mode
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/external-validators.md
+++ b/src/skf-test-skill/references/external-validators.md
@@ -3,6 +3,8 @@ nextStepFile: 'score.md'
 outputFile: '{forge_version}/test-report-{skill_name}-{run_id}.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 4b: External Validators
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/health-check.md
+++ b/src/skf-test-skill/references/health-check.md
@@ -7,6 +7,8 @@ nextStepFileProbeOrder:
   - '{project-root}/src/shared/health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 7: Workflow Health Check
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/init.md
+++ b/src/skf-test-skill/references/init.md
@@ -13,6 +13,8 @@ frontmatterScriptProbeOrder:
 versionPathsKnowledge: 'knowledge/version-paths.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Initialize Test
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/migration-section-rules.md
+++ b/src/skf-test-skill/references/migration-section-rules.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Migration & Deprecation Section Rules (§2b / §5b)
 
 > **Single source of truth.** Both `coherence-check.md` §2b (naive path)

--- a/src/skf-test-skill/references/report.md
+++ b/src/skf-test-skill/references/report.md
@@ -5,8 +5,9 @@ outputFile: '{forge_version}/test-report-{skill_name}-{run_id}.md'
 scoringRulesFile: 'references/scoring-rules.md'
 outputFormatsFile: 'assets/output-section-formats.md'
 # outputContractSchema and healthCheck resolve relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative to
-# this step file. Both paths are probed in order; HALT if neither exists.
+# (`{project-root}/_bmad/skf/` when installed, `{project-root}/src/` during
+# development), NOT relative to this step file. Both paths are probed in
+# order; HALT if neither exists.
 outputContractSchema: 'shared/references/output-contract-schema.md'
 healthCheckProbeOrder:
   - '{project-root}/_bmad/skf/shared/health-check.md'
@@ -15,6 +16,8 @@ atomicWriteProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
+
+<!-- Config: communicate in {communication_language}. Test report prose in {document_output_language}. -->
 
 # Step 6: Gap Report
 
@@ -93,7 +96,7 @@ Count the skills in `{skillsOutputFolder}`: `ls -1d {skillsOutputFolder}/*/ 2>/d
 - If `catalog_size < 2`: **skip §4b.1–§4b.3**. Record an Info-severity note in the Discovery Quality subsection: `discovery — skipped: catalog size N={catalog_size}, requires ≥2 candidates for meaningful routing`. The routing test is vacuous with one candidate (any prompt returns the sole skill); reporting `3/3 PASS` under those conditions inflates the Discovery score and masks genuinely bad description triggers. Proceed to §4b.4 (description optimization) if tessl/skill-check flagged description issues; otherwise skip to §4c.
 - If `catalog_size >= 2`: continue with §4b.1 as written.
 
-Optional escape hatch: the workflow accepts `--discovery-catalog=all` to broaden the candidate pool to `.claude/skills/` or `_bmad/agents/` for single-skill repos where the repo-local catalog is trivially too small. When the flag is set, rebuild `catalog_size` from the broader pool before the precondition check.
+Optional escape hatch: the workflow accepts `--discovery-catalog=all` to broaden the candidate pool to `{project-root}/.claude/skills/` or `{project-root}/_bmad/agents/` for single-skill repos where the repo-local catalog is trivially too small. When the flag is set, rebuild `catalog_size` from the broader pool before the precondition check.
 
 **4b.1 Extract realistic prompts from the skill under test:**
 

--- a/src/skf-test-skill/references/score.md
+++ b/src/skf-test-skill/references/score.md
@@ -6,6 +6,8 @@ sourceAccessProtocol: 'references/source-access-protocol.md'
 scoringScript: 'scripts/compute-score.py'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 5: Score
 
 ## STEP GOAL:

--- a/src/skf-test-skill/references/scoring-rules.md
+++ b/src/skf-test-skill/references/scoring-rules.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Scoring Rules
 
 ## Default Threshold

--- a/src/skf-test-skill/references/source-access-protocol.md
+++ b/src/skf-test-skill/references/source-access-protocol.md
@@ -1,3 +1,5 @@
+<!-- Config: communicate in {communication_language}. -->
+
 # Source Access Protocol
 
 ## Source API Surface Definition

--- a/tools/validate-file-refs.js
+++ b/tools/validate-file-refs.js
@@ -46,7 +46,7 @@ const STRICT = process.argv.includes('--strict');
 const SCAN_EXTENSIONS = new Set(['.yaml', '.yml', '.md', '.xml', '.csv']);
 
 // Skip directories
-const SKIP_DIRS = new Set(['node_modules', '.git']);
+const SKIP_DIRS = new Set(['node_modules', '.git', '.analysis']);
 
 // Pattern: {project-root}/_bmad/ references
 const PROJECT_ROOT_REF = /\{project-root\}\/_bmad\/([^\s'"<>})\]`]+)/g;
@@ -91,8 +91,11 @@ function escapeTableCell(str) {
   return String(str).replaceAll('|', String.raw`\|`);
 }
 
-// Path prefixes/patterns that only exist in installed structure, not in source
-const INSTALL_ONLY_PATHS = ['_config/', '_memory/'];
+// Path prefixes/patterns that only exist in installed structure, not in source.
+// `agents/` is where bmad-method core agents land under `_bmad/`; referenced by
+// some workflows (e.g. test-skill's --discovery-catalog=all escape hatch) but
+// never sourced from this repo.
+const INSTALL_ONLY_PATHS = ['_config/', '_memory/', 'agents/'];
 
 // Files that are generated at install time and don't exist in the source tree
 const INSTALL_GENERATED_FILES = ['config.yaml', 'config.user.yaml', 'VERSION', 'package.json'];


### PR DESCRIPTION
## Summary

Foundation pass mirroring PR #306 for the 5 SKF **Feature workflows** (skf-quick-skill, skf-create-stack-skill, skf-analyze-source, skf-audit-skill, skf-test-skill), bringing them to parity with the Core-elevated peers from PRs #305–#323.

Pre-pass quality scans graded all 5 skills as **Good**; this PR addresses every cross-skill mechanical item identified in those scans:

| Skill | Before | After this PR | After Tightening (follow-up) |
|---|---|---|---|
| skf-quick-skill | Good | Good (foundation parity) | Excellent (target) |
| skf-create-stack-skill | Good | Good (foundation parity) | Excellent (target) |
| skf-analyze-source | Good | Good (foundation parity) | Excellent (target) |
| skf-audit-skill | Good | Good (foundation parity) | Excellent (target) |
| skf-test-skill | Good | Good (foundation parity) | Excellent (target) |

## What changed

### Customization surface (S1 across all 5)

- `customize.toml` shipped per skill: `[workflow]` block with three append-merge arrays (`activation_steps_prepend`, `activation_steps_append`, `persistent_facts`) plus 2–4 asset-path scalars per skill (e.g. `skill_template_path`, `drift_report_template_path`, `scoring_rules_path`).
- `## On Activation` gains a `python3 {project-root}/_bmad/scripts/resolve_customization.py` step computing path-scalar fallback so stage files reference `{<purpose>Path}` directly — no conditional at the call site.

### Headless contract (E1/E2 across the 4 skills that lacked it)

- `## Exit Codes` table added/lifted to SKILL.md for create-stack, analyze-source, audit-skill, test-skill (mirrors skf-brief-skill).
- `## Result Contract (Headless)` block added with single-line envelope prefixes: `SKF_STACK_RESULT_JSON`, `SKF_ANALYZE_RESULT_JSON`, `SKF_AUDIT_RESULT_JSON`, `SKF_TEST_RESULT_JSON`. Mirror-on-stderr for HARD HALTs.

### Language headers (C1 across 50+ reference files)

- Each `references/*.md` gains `<!-- Config: communicate in {communication_language}. -->` after the frontmatter close — survives compaction when SKILL.md is dropped mid-flow.
- Artifact-producing steps get the `Artifact text in {document_output_language}.` variant.

### UX cancel-line (B6 across QS/SS/AN)

`[X] Cancel and exit` wired to exit code 6 on interactive gates:
- skf-quick-skill: `resolve-target.md`
- skf-create-stack-skill: `rank-and-confirm.md`, `compile-stack.md`
- skf-analyze-source: `scan-project.md`, `identify-units.md`, `recommend.md`

### Bug fixes folded in (Broken items, all 1-line)

- skf-quick-skill SKILL.md: `{forger_root}` was an undefined variable (no module declares it), silently breaking headless detection via `preferences.yaml`. Replaced with `{sidecar_path}`.
- Bare `_bmad/skf/` references in `health-check.md` frontmatter comments now correctly prefixed with `{project-root}/` (4 skills).
- skf-test-skill `references/report.md`: bare `_bmad/agents/` and `.claude/skills/` in the `--discovery-catalog=all` prose now prefixed.

### Workflow Rules tightened (A5/A6/A7)

- Dropped defensive "main-thread fallback" bullets covered by per-step fallback wording (AN, AS, TS).
- Dropped LLM-native procedural rules ("read each step file completely", "follow the mandatory sequence exactly") from QS Workflow Rules.

### Skill-specific polish

- skf-create-stack-skill: description trigger expanded to 3 quoted phrases; "Ferris Architect mode" persona clause dropped; Invocation Contract gains Exit codes row.
- skf-audit-skill: Invocation Contract Inputs row enumerates the optional inputs the workflow actually consumes (`skill_path`, `tier_override`, `degraded`, `upstream_drift_choice`, `dirty_worktree_choice`, `force`) rather than just `skill_name`.

### Validator updates (directly motivated by surfaces added in this PR)

- `tools/validate-file-refs.js`: skip `.analysis/` analysis dirs (gitignored runtime state); add `agents/` to `INSTALL_ONLY_PATHS` so the test-skill `--discovery-catalog=all` reference to `{project-root}/_bmad/agents/` resolves cleanly.

## Deferred (substantive items — separate Tightening PR + tracking issue)

- 4 Broken items needing design judgment: SS cross-dir `./references/{library}.md` template bug, QS ecosystem-check exit-envelopes, AN orphaned "Pattern N" references, AN nonexistent `knowledge/tool-resolution.md`
- Reference-file boilerplate cleanup in test-skill (~150-line delete across 7 step files)
- Low-severity sweep across all 5 skills (slug-list dedup, no-op directives, etc.)

## Deferred (tracking issue — out of elevation scope)

- New shared scripts: `scan-manifests.py`, `pair-intersect.py`, `compare-file-hashes.py`, `scan-skill-md-structure.py`, `disqualify-candidates.py`, `enumerate-skills.py`, `load-provenance.py`
- compute-score.py unit tests + argparse migration
- Decision-Log Workspace resume protocols for stack/audit
- New optional headless modes (`--no-discovery`, `--no-health-check`, `--tier=`)
- Carving Batch Mode out of skf-quick-skill SKILL.md
- Subagent fan-out for AN map-and-detect per-unit
- `{document_output_language}` second-pass threading where deferred

## Test plan

- [x] `node tools/validate-skills.js` — 0 findings (15 skills scanned)
- [x] `node tools/validate-file-refs.js --strict` — 0 broken refs, 0 abs-path leaks (189 files / 124 refs)
- [x] `node test/test-installation-components.js` — 179 passed
- [x] `node test/test-workflow-state.js` — 38 passed
- [x] `node test/test-cli-integration.js` — 83 passed
- [x] `node test/test-knowledge-base.js` — 95 passed
- [x] `npm run test:python` — 1076 passed
- [x] `npm run lint`, `lint:md`, `format:check` — all clean
- [x] pre-commit hook full suite — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)