### PR TITLE
refactor(skf): elevate Architecture / Utility / Management workflows (foundation)

### DIFF
--- a/src/skf-drop-skill/SKILL.md
+++ b/src/skf-drop-skill/SKILL.md
@@ -32,6 +32,7 @@ These rules apply to every step in this workflow:
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`
+- At any interactive prompt, the inputs `cancel`, `exit`, `[X]`, `q`, or `:q` exit cleanly with exit code 6 (`halt_reason: "user-cancelled"`)
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages
@@ -48,9 +49,34 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | skill_name [required], mode (deprecate/purge) [required], version (all/specific) [required] |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates) |
 | **Gates** | step 1: Input Gate [use args], Confirm Gate [Y] |
-| **Outputs** | Updated manifest, rebuilt context files, (purge: deleted directories) |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Outputs** | Updated manifest, rebuilt context files, (purge: deleted directories), `drop-skill-result-{timestamp}.json` and `drop-skill-result-latest.json` |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. When `forbid_purge_in_headless` is `"true"` in `customize.toml` AND `drop_mode = "purge"`, On-Activation §4 HALTs with exit code 6 (`halt_reason: "headless-purge-forbidden"`) before any work begins. |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                    |
+| ---- | -------------------- | -------------------------------------------------------------------------------------------- |
+| 0    | success              | step 4 (terminal)                                                                           |
+| 2    | input-missing / input-invalid | step 1 §4 (headless missing `skill_name` arg) → `input-missing`; non-existent skill / unparseable version → `input-invalid` |
+| 3    | resolution-failure   | step 1 §2 (manifest is malformed JSON); step 1 §3 (no skills found anywhere)               |
+| 4    | write-failure        | On-Activation §3 pre-flight write probe (skills_output_folder unwritable); step 2 §2 (manifest write); step 2 §3 (context-file rewrite); step 2 §4 (directory delete) |
+| 5    | state-conflict       | step 1 §7 (active-version-guard refuses to drop the active version while non-deprecated peers remain) |
+| 6    | user-cancelled       | step 1 §10 confirmation gate `[N]`; any prompt that accepted `cancel`/`exit`/`:q`; On-Activation §4 (`headless-purge-forbidden`) |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 3 emits a single-line JSON envelope on **stdout** before chaining to step 4, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_DROP_SKILL_RESULT_JSON: {"status":"success|error","skill":"…|null","drop_mode":"…|null","versions_affected":[],"files_deleted":[],"manifest_updated":false,"exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"manifest-corrupt"`, `"nothing-to-drop"`, `"active-version-guard-refused"`, `"headless-purge-forbidden"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"delete-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 
@@ -60,6 +86,44 @@ These rules apply to every step in this workflow:
    - `snippet_skill_root_override` (optional string) — when set, the context-file rebuild in step 2 preserves any snippet `root:` prefix that matches the override instead of rewriting it to the target IDE's skill root. See `skf-export-skill/assets/managed-section-format.md` for full semantics.
    - Generate and store `timestamp` as `YYYYMMDD-HHmmss` format. This value is fixed for the entire workflow run.
 
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in `{sidecar_path}/preferences.yaml`. Default: false.
 
-3. Load, read the full file, and then execute `references/select.md` to begin the workflow.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each scalar.
+
+   Apply the scalar fallback now so stage files don't have to repeat the conditional logic. For each of the four scalars, if the merged value is empty or absent, the bundled default applies:
+
+   - `{defaultMode}` ← `workflow.default_mode` (empty = always prompt; `"deprecate"` or `"purge"` = skip §8 Ask Mode)
+   - `{forbidPurgeInHeadless}` ← `workflow.forbid_purge_in_headless` (empty or non-`"true"` = no guard)
+   - `{unknownIdeDefaultContextFile}` ← `workflow.unknown_ide_default_context_file` if non-empty, else `AGENTS.md`
+   - `{unknownIdeDefaultSkillRoot}` ← `workflow.unknown_ide_default_skill_root` if non-empty, else `.agents/skills/`
+
+   Stash all four as workflow-context variables. Stage files reference them directly — no conditional at the usage site.
+
+4. **Pre-flight write probe + headless-purge guard.**
+
+   First, verify `{skills_output_folder}` is writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces at step 2's manifest write — by then the user has already gone through every selection prompt:
+
+   ```bash
+   mkdir -p "{skills_output_folder}" && \
+     printf 'probe' > "{skills_output_folder}/.skf-write-probe" && \
+     rm "{skills_output_folder}/.skf-write-probe"
+   ```
+
+   On any non-zero exit: HALT (exit code 4, `halt_reason: "write-failed"`). In headless mode, emit the error envelope per **Result Contract (Headless)** with `skill: null` and `drop_mode: null` (neither is resolved yet at activation time).
+
+   Second, enforce the headless-purge guard. If `{headless_mode}` is true AND `{forbidPurgeInHeadless}` is `"true"` AND the parsed `mode` arg is `"purge"`: HALT with exit code 6 and `halt_reason: "headless-purge-forbidden"`, emit the error envelope, and exit immediately. The operator must re-run with `mode=deprecate` or set `forbid_purge_in_headless = ""` (or omit the override entirely) to proceed.
+
+5. Load, read the full file, and then execute `references/select.md` to begin the workflow.

--- a/src/skf-drop-skill/customize.toml
+++ b/src/skf-drop-skill/customize.toml
@@ -1,0 +1,57 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-drop-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (audit-log emit,
+# ticket-reference enforcement) that must precede any destructive work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (drop-policy reminders, retention guardrails, audit-trail rules).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Purges of skills tagged `compliance` require ticket reference."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/drop-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional safety + default scalars ---
+#
+# Default drop mode. Empty string = always prompt the user at §8 Ask Mode.
+# Set to "deprecate" or "purge" to skip the prompt — the headless
+# auto-decision log records the override source.
+
+default_mode = ""
+
+# Hard-block hard-purge in headless mode. When set to "true", a headless
+# invocation with `mode=purge` HALTs at activation with exit code 6
+# (`halt_reason: "headless-purge-forbidden"`) instead of silently deleting
+# files. Operators must either re-run with `mode=deprecate` or unset this
+# flag for that run. Empty string = no guard (default).
+
+forbid_purge_in_headless = ""
+
+# Fallback IDE → context-file mapping for unknown IDEs in `config.yaml.ides`.
+# Empty string = use bundled defaults (AGENTS.md / .agents/skills/).
+
+unknown_ide_default_context_file = ""
+unknown_ide_default_skill_root = ""

--- a/src/skf-drop-skill/references/execute.md
+++ b/src/skf-drop-skill/references/execute.md
@@ -2,7 +2,25 @@
 nextStepFile: 'report.md'
 versionPathsKnowledge: 'knowledge/version-paths.md'
 managedSectionLogic: 'skf-export-skill/assets/managed-section-format.md'
+# Resolve `{manifestOpsHelper}` by probing `{manifestOpsProbeOrder}` in
+# order (installed SKF module path first, src/ dev-checkout fallback);
+# first existing path wins. §2 calls it for atomic manifest deprecate /
+# remove with v1→v2 migration handled internally — letting the LLM hand-
+# roll JSON manipulation risks key-order drift, indent regressions, and
+# write-atomicity bugs. HALT if neither candidate exists.
+manifestOpsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-manifest-ops.py'
+  - '{project-root}/src/shared/scripts/skf-manifest-ops.py'
+# Resolve `{rebuildManagedSectionsHelper}` similarly. §3 calls it (replace
+# action) for the surgical between-marker rewrite — the LLM still computes
+# the new managed section text, but the file mutation is deterministic
+# (atomic temp-file + rename, marker preservation, post-write verify).
+rebuildManagedSectionsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-rebuild-managed-sections.py'
+  - '{project-root}/src/shared/scripts/skf-rebuild-managed-sections.py'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 2: Execute Drop
 
@@ -33,32 +51,33 @@ Also read `{managedSectionLogic}` for the format template, the four-case logic, 
 
 **If `target_in_manifest == true`:**
 
-Load `{skills_output_folder}/.export-manifest.json`.
+**Resolve `{manifestOpsHelper}`** from `{manifestOpsProbeOrder}`; first existing path wins. HALT (exit code 4, `halt_reason: "manifest-write-failed"`) if no candidate exists — atomic manifest mutation must go through the helper.
 
 **If `is_skill_level == false` (version-level drop):**
 
-For each version in `target_versions`:
+For each version in `target_versions`, invoke:
 
-1. Navigate to `exports.{target_skill}.versions.{version}`
-2. Set `status = "deprecated"`
-3. Leave `ides`, `last_exported`, and all other fields unchanged
+```bash
+python3 {manifestOpsHelper} {skills_output_folder} deprecate {target_skill} {version}
+```
 
-Do NOT change `active_version` on the skill entry in this pass — if the dropped version was the active one (only reachable when it was the sole non-deprecated version per the step 1 guard), the active_version field will still point at it, but every consumer excludes deprecated versions from exports.
+The helper sets `exports.{target_skill}.versions.{version}.status = "deprecated"` and writes the manifest atomically. It does NOT change `active_version` on the skill entry — if the dropped version was the active one (only reachable when it was the sole non-deprecated version per the step 1 guard), the field still points at it, but every consumer excludes deprecated versions from exports.
 
 **If `is_skill_level == true` (skill-level drop):**
 
-1. Delete the `exports.{target_skill}` key entirely from the manifest
-2. Leave all other skill entries untouched
+```bash
+python3 {manifestOpsHelper} {skills_output_folder} remove {target_skill}
+```
 
-**Write the updated manifest back to `{skills_output_folder}/.export-manifest.json`.**
+The helper deletes the `exports.{target_skill}` key entirely; other entries are untouched.
 
 Set context flag `manifest_updated = true`.
 
-**On error (read/parse/write failure):**
+**On error (helper non-zero exit):**
 
 - Do not proceed to section 3
-- Report: "**Manifest update failed:** {error}. No files were deleted and platform context files were not rebuilt. The manifest is in its pre-drop state — rerun the workflow once the underlying issue is resolved."
-- Store `manifest_updated = false` and jump to section 6
+- Report: "**Manifest update failed:** {captured stderr}. No files were deleted and platform context files were not rebuilt. The manifest is in its pre-drop state — rerun the workflow once the underlying issue is resolved."
+- Store `manifest_updated = false` and jump to section 6. In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with `halt_reason: "manifest-write-failed"` and exit code 4.
 
 ### 3. Rebuild Context Files
 
@@ -117,17 +136,15 @@ For each entry in `target_context_files`:
 
    If the filtered skill index is empty (e.g., the dropped skill was the only one), still emit the header with `0 skills|0 stack` and no skill entries. This keeps the managed section syntactically valid.
 
-8. **Surgical replacement — Case 3 (Regenerate) only:**
-   - Locate the `<!-- SKF:BEGIN` line — preserve everything before it
-   - Locate the `<!-- SKF:END -->` line — preserve everything after it
-   - Replace everything between the markers (inclusive) with the new managed section
-   - Write the file back
+8. **Surgical replacement — atomic, deterministic.** Resolve `{rebuildManagedSectionsHelper}` from `{rebuildManagedSectionsProbeOrder}`; first existing path wins. Then invoke:
 
-9. **Verify:**
-   - Re-read the written file
-   - Confirm both markers are present
-   - Confirm `{target_skill}` (at the dropped version, or at all versions if skill-level) no longer appears between the markers
-   - Confirm content outside the markers is byte-identical to what was preserved
+   ```bash
+   python3 {rebuildManagedSectionsHelper} {context_file} replace --content "{new_managed_section_text}"
+   ```
+
+   The helper handles marker location, between-marker swap, atomic temp-file + rename, and post-write verification (markers preserved, content outside markers byte-identical). It exits non-zero on any failure with a clear `stderr` reason.
+
+9. **Verify (deferred to helper).** The `replace` action above performs verification internally. Treat any non-zero exit code as a per-file failure (next bullet). If the helper is missing entirely (no probe candidate exists), HALT (exit code 4, `halt_reason: "context-rebuild-failed"`) — the rewrite cannot proceed without the atomic helper.
 
 10. **On per-file failure:** record the error against that context file and continue to the next entry. Do not halt — other context files should still be rebuilt.
 

--- a/src/skf-drop-skill/references/health-check.md
+++ b/src/skf-drop-skill/references/health-check.md
@@ -1,9 +1,11 @@
 ---
-# `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# Note: `shared/health-check.md` resolves relative to the SKF module root
+# ({project-root}/_bmad/skf/ when installed, {project-root}/src/ during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 4: Workflow Health Check
 

--- a/src/skf-drop-skill/references/report.md
+++ b/src/skf-drop-skill/references/report.md
@@ -2,6 +2,8 @@
 nextStepFile: 'health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Render the report block in {document_output_language}. -->
+
 # Step 3: Report Drop Results
 
 ## STEP GOAL:
@@ -72,6 +74,14 @@ These require manual review — see the error-handling guidance in step 2.
 ### Result Contract
 
 Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/drop-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skills_output_folder}/drop-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all purged file paths in `outputs`; include `target_skill`, `drop_mode`, and `versions_affected` in `summary`.
+
+When `{headless_mode}` is true, also emit the single-line envelope on **stdout** before chaining to step 4 (matches the SKILL.md "Result Contract (Headless)" shape):
+
+```
+SKF_DROP_SKILL_RESULT_JSON: {"status":"success","skill":"{target_skill}","drop_mode":"{drop_mode}","versions_affected":{target_versions},"files_deleted":{files_deleted},"manifest_updated":{manifest_updated},"exit_code":0,"halt_reason":null}
+```
+
+Substitute `{target_versions}` as a JSON array (e.g. `["0.5.0"]`) or the literal string `"all"`; substitute `{files_deleted}` as a JSON array of absolute paths (`[]` in soft-drop mode); `manifest_updated` is the boolean from step 2's context.
 
 ### 3. Chain to Health Check
 

--- a/src/skf-drop-skill/references/select.md
+++ b/src/skf-drop-skill/references/select.md
@@ -3,6 +3,8 @@ nextStepFile: 'execute.md'
 versionPathsKnowledge: 'knowledge/version-paths.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Select Drop Target
 
 ## STEP GOAL:
@@ -38,7 +40,7 @@ Load `{skills_output_folder}/.export-manifest.json` if it exists.
 
 **If the file exists with entries:** Parse JSON and verify `schema_version` is `"2"`. If the manifest is v1 (no `schema_version` field), note this but continue — treat every entry as having a single active version derived from its current state. Store `manifest_exists = true`.
 
-**Hard halt condition:** If the file exists but is malformed (not valid JSON), halt with: "**Export manifest is corrupt** at `{skills_output_folder}/.export-manifest.json` — fix or remove the file before dropping."
+**Hard halt condition:** If the file exists but is malformed (not valid JSON), halt with: "**Export manifest is corrupt** at `{skills_output_folder}/.export-manifest.json` — fix or remove the file before dropping." HALT (exit code 3, `halt_reason: "manifest-corrupt"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with `skill: null`, `drop_mode: null`, `versions_affected: []`.
 
 ### 3. List Available Skills
 
@@ -53,7 +55,7 @@ For each skill in the manifest's `exports` (only if `manifest_exists = true` and
 
 Also scan `{skills_output_folder}/` for any top-level directories that are NOT present in the manifest's `exports` object. Record these as "(not in manifest)" — they represent draft or orphaned skills eligible for purge mode only. When the manifest is missing or empty, every on-disk skill appears in this category.
 
-**If the combined list is empty** (no manifest entries AND no on-disk skill directories): halt with "**Drop Skill — nothing to drop.** No skills found in `{skills_output_folder}/` and no entries in `.export-manifest.json`. Run `[CS] Create Skill` first."
+**If the combined list is empty** (no manifest entries AND no on-disk skill directories): halt with "**Drop Skill — nothing to drop.** No skills found in `{skills_output_folder}/` and no entries in `.export-manifest.json`. Run `[CS] Create Skill` first." HALT (exit code 3, `halt_reason: "nothing-to-drop"`). In headless mode, emit the error envelope with `skill: null`, `drop_mode: null`, `versions_affected: []`.
 
 Display the combined list:
 
@@ -73,11 +75,12 @@ Available skills:
 ### 4. Ask Which Skill
 
 "**Which skill would you like to drop?**
-Enter the skill name or its number from the list above."
+Enter the skill name or its number from the list above, or `cancel` / `exit` / `:q` to abort."
 
-Wait for user input. Accept either the numeric index or the skill name (exact match). **GATE [default: use args]** — If `{headless_mode}` and skill name was provided as argument: select that skill and auto-proceed. If not provided, HALT: "headless mode requires skill name argument."
+Wait for user input. Accept either the numeric index or the skill name (exact match). **GATE [default: use args]** — If `{headless_mode}` and skill name was provided as argument: select that skill and auto-proceed. If not provided, HALT (exit code 2, `halt_reason: "input-missing"`): "headless mode requires skill name argument." In headless mode, emit the error envelope with `skill: null`, `drop_mode: null`.
 
-**If the user's input does not match any listed skill:** Re-display the list and ask again.
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q`: Display "Cancelled — no changes were made." and HALT (exit code 6, `halt_reason: "user-cancelled"`).
+- **If the user's input does not match any listed skill:** Re-display the list and ask again.
 
 Store the selection as `target_skill`. Also store `target_in_manifest = true` if the selected skill has an entry in the manifest, `false` otherwise — subsequent sections use this flag to restrict the available drop options.
 
@@ -114,9 +117,12 @@ Store the selection as `target_skill`. Also store `target_in_manifest = true` if
 "**Drop which version(s)?**
 
 - **[N]** Specific version — soft deprecate or hard purge a single version
-- **[A]** All versions — drops the entire skill (skill-level operation)"
+- **[A]** All versions — drops the entire skill (skill-level operation)
+- **[X]** Cancel and exit (or type `cancel` / `exit` / `:q`)"
 
 Wait for user selection.
+
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q`: Display "Cancelled — no changes were made." and HALT (exit code 6, `halt_reason: "user-cancelled"`).
 
 **If [N] Specific version:**
 
@@ -149,7 +155,7 @@ Set `target_versions = "all"` and `is_skill_level = true`.
 
       **(b)** Use the `[A] All versions` option to drop every version of `{target_skill}` at once."
 
-      HALT the workflow. Do not proceed.
+      HALT (exit code 5, `halt_reason: "active-version-guard-refused"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with `skill: "{target_skill}"`, `drop_mode: null`, `versions_affected: ["{version}"]`. Do not proceed.
 
    c. If the count is `0` → the active version is the ONLY version; allow the drop to continue (it is functionally equivalent to a skill-level drop on a single-version skill)
 
@@ -159,12 +165,19 @@ Set `target_versions = "all"` and `is_skill_level = true`.
 
 **If `target_in_manifest = true`:**
 
+**If `{defaultMode}` is non-empty (`"deprecate"` or `"purge"`)**: skip the prompt, set `drop_mode = "{defaultMode}"`, and log the override source for the headless decision trail (`"customize.toml.workflow.default_mode"`).
+
+**Otherwise:**
+
 "**How should this be dropped?**
 
 - **[D]** Deprecate (soft) — Mark the version as `deprecated` in the manifest. Files remain on disk. Export-skill will exclude it from all platform context files. Reversible by editing the manifest.
-- **[P]** Purge (hard) — Deprecate AND delete files from disk (`{skill_package}` and `{forge_version}`, or full `{skill_group}` and `{forge_group}` for a skill-level drop). **Irreversible.**"
+- **[P]** Purge (hard) — Deprecate AND delete files from disk (`{skill_package}` and `{forge_version}`, or full `{skill_group}` and `{forge_group}` for a skill-level drop). **Irreversible.**
+- **[X]** Cancel and exit (or type `cancel` / `exit` / `:q`)"
 
 Wait for user selection.
+
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q`: Display "Cancelled — no changes were made." and HALT (exit code 6, `halt_reason: "user-cancelled"`).
 
 Set `drop_mode` to `"deprecate"` (on D) or `"purge"` (on P).
 
@@ -214,7 +227,7 @@ Proceed? [Y/N]
 Wait for explicit user response.
 
 - **If `Y`** → proceed to section 11
-- **If `N`** → "**Cancelled.** No changes were made." HALT the workflow
+- **If `N`** (or `cancel` / `exit` / `[X]` / `:q`) → "**Cancelled.** No changes were made." HALT (exit code 6, `halt_reason: "user-cancelled"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with the resolved `skill`, `drop_mode`, and `versions_affected`.
 - **Any other input** → re-display the confirmation and ask again
 
 ### 11. Store Decisions in Context

--- a/src/skf-export-skill/SKILL.md
+++ b/src/skf-export-skill/SKILL.md
@@ -29,6 +29,7 @@ These rules apply to every step in this workflow:
 - Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}`
+- At any interactive prompt, the inputs `cancel`, `exit`, `[X]`, `q`, or `:q` exit cleanly with exit code 6 (`halt_reason: "user-cancelled"`)
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages
@@ -47,11 +48,36 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | skill_name [one or more, required unless `--all`], `--all` [optional — exports every non-deprecated skill in `.export-manifest.json`] |
+| **Inputs** | `skill_name` [one or more, required unless `--all`] |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--all` (export every non-deprecated skill in `.export-manifest.json`); `--dry-run` (resolve and stage everything but exit before §4 writes to context files; envelope `status="dry-run"`) |
 | **Gates** | step 1: single Confirm Gate [C] for the whole batch | step 4: single Confirm Gate [C] for the whole batch |
-| **Outputs** | Updated .export-manifest.json (every skill in the batch), updated context files (CLAUDE.md/AGENTS.md/.cursorrules), one result contract per run |
+| **Outputs** | Updated `.export-manifest.json` (every skill in the batch), updated context files (CLAUDE.md/AGENTS.md/.cursorrules), per-skill `context-snippet.md`, per-run result contract `export-skill-result-{timestamp}.json` and `export-skill-result-latest.json` |
 | **Multi-skill mode** | Activated when more than one skill is selected (via `--all`, multi-selection, or multi-argument invocation). See `references/load-skill.md` §1c for the per-step iteration map. |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Each auto-resolved gate appends a `{gate, default_action, taken_action, reason}` entry to `headless_decisions[]`, surfaced in step 6's `SKF_EXPORT_RESULT_JSON` envelope so non-interactive runs can be audited post-hoc. |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                    |
+| ---- | -------------------- | -------------------------------------------------------------------------------------------- |
+| 0    | success              | step 7 (terminal); also `status="dry-run"` when `--dry-run` is set                          |
+| 2    | input-missing / input-invalid | step 1 (no `skill_name` and no `--all` in headless) → `input-missing`; non-existent or malformed skill → `input-invalid` |
+| 3    | resolution-failure   | step 1 §2 (no skills found / required artifacts missing); step 1 §1c (multi-skill batch contains a stack-skill that requires re-composition) |
+| 4    | write-failure        | On-Activation §3 pre-flight write probe; step 4 §6 (managed-section rewrite); step 4 §9 (manifest write); step 6 §4 (result-contract write) |
+| 5    | state-conflict       | step 4 §3b/§4c.1 (orphan context-files or manifest-orphan rows when user selects [c] Cancel); step 4 (malformed `<!-- SKF:BEGIN/END -->` markers in target context file) |
+| 6    | user-cancelled       | step 1 §6 confirmation gate `[X]`/cancel; step 4 §8 confirmation gate `[X]`/cancel; any prompt that accepted `cancel`/`exit`/`:q` |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 6 emits a single-line JSON envelope on **stdout** before chaining to step 7, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_EXPORT_RESULT_JSON: {"status":"success|error|dry-run","skills":[],"context_files_updated":[],"manifest_path":"…|null","headless_decisions":[],"exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"dry-run"` when `--dry-run` was set and the workflow exited before §4 writes, `"error"` on any HALT. `halt_reason` is one of: `null` (success / dry-run), `"input-missing"`, `"input-invalid"`, `"resolution-failure"`, `"stack-redirect"`, `"orphan-cancelled"`, `"malformed-markers"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 
@@ -60,6 +86,42 @@ These rules apply to every step in this workflow:
    - `skills_output_folder`, `forge_data_folder`, `sidecar_path`
    - `snippet_skill_root_override` (optional string) — when set, overrides the IDE-derived `skill_root` for snippet `root:` paths. Authoring repos that keep all skills under a single on-disk folder (e.g. `skills/`) set this once so exported snippets reference the real layout instead of a per-IDE directory that does not exist. Consuming projects omit it.
 
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+2. **Compute run-scoped variables:**
+   - `timestamp` ← UTC `YYYYMMDD-HHmmss` captured at activation time. Fixed for the entire workflow run; summary.md reuses this when writing the result contract.
 
-3. Load, read the full file, and then execute `references/load-skill.md` to begin the workflow.
+3. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in `{sidecar_path}/preferences.yaml`. Default: false.
+
+4. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each scalar, if the merged value is empty or absent, use the bundled default:
+
+   - `{managedSectionFormatPath}` ← `workflow.managed_section_format_path` if non-empty, else `assets/managed-section-format.md`
+   - `{snippetFormatPath}` ← `workflow.snippet_format_path` if non-empty, else `assets/snippet-format.md`
+   - `{exportManifestPath}` ← `workflow.export_manifest_path` if non-empty, else `{skills_output_folder}/.export-manifest.json`
+
+   Stash all three as workflow-context variables. Stage files reference them directly — no conditional at the usage site.
+
+5. **Pre-flight write probe.** Verify `{skills_output_folder}` is writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces at step 4's managed-section rewrite — by then the user has already confirmed the batch:
+
+   ```bash
+   mkdir -p "{skills_output_folder}" && \
+     printf 'probe' > "{skills_output_folder}/.skf-write-probe" && \
+     rm "{skills_output_folder}/.skf-write-probe"
+   ```
+
+   On any non-zero exit: HALT (exit code 4, `halt_reason: "write-failed"`). In headless mode, emit the error envelope per **Result Contract (Headless)** with `skills: []`, `context_files_updated: []`, `manifest_path: null`.
+
+6. Load, read the full file, and then execute `references/load-skill.md` to begin the workflow.

--- a/src/skf-export-skill/customize.toml
+++ b/src/skf-export-skill/customize.toml
@@ -1,0 +1,49 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-export-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any export work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (publishing standards, distribution-instruction house style, snippet
+# token-budget guardrails). Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All exported skills must include a CHANGELOG entry."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/export-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+managed_section_format_path = ""
+snippet_format_path = ""
+
+# Override the manifest location. Empty = use
+# {skills_output_folder}/.export-manifest.json. Useful for orgs that want
+# a cross-project manifest at a stable path (e.g. ~/.skf/export-manifest.json).
+
+export_manifest_path = ""

--- a/src/skf-export-skill/references/generate-snippet.md
+++ b/src/skf-export-skill/references/generate-snippet.md
@@ -1,7 +1,9 @@
 ---
 nextStepFile: 'update-context.md'
-snippetFormatData: 'assets/snippet-format.md'
+snippetFormatData: '{snippetFormatPath}'
 ---
+
+<!-- Config: communicate in {communication_language}. Generate snippet content in {document_output_language}. -->
 
 # Step 3: Generate Snippet
 

--- a/src/skf-export-skill/references/health-check.md
+++ b/src/skf-export-skill/references/health-check.md
@@ -1,9 +1,11 @@
 ---
-# `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# Note: `shared/health-check.md` resolves relative to the SKF module root
+# ({project-root}/_bmad/skf/ when installed, {project-root}/src/ during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 7: Workflow Health Check
 

--- a/src/skf-export-skill/references/load-skill.md
+++ b/src/skf-export-skill/references/load-skill.md
@@ -2,6 +2,8 @@
 nextStepFile: 'package.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Load Skill
 
 ## STEP GOAL:
@@ -236,11 +238,12 @@ Continue to step 5 regardless — this is advisory, not blocking.
 
 ### 6. Present MENU OPTIONS
 
-Display: "**Select:** [C] Continue to packaging" (multi-skill mode: the single [C] gate covers the whole batch)
+Display: "**Select:** [C] Continue to packaging | [X] Cancel and exit (or type `cancel` / `exit` / `:q`)" (multi-skill mode: the single [C] gate covers the whole batch)
 
 #### Menu Handling Logic:
 
 - IF C: Proceed with loaded skill data, then load, read entire file, then execute {nextStepFile}
+- IF X (or `cancel` / `exit` / `:q`): Display "Cancelled — no packaging or context file writes were performed." and HALT (exit code 6, `halt_reason: "user-cancelled"`). In headless, emit the error envelope per SKILL.md "Result Contract (Headless)" with the resolved `skills`, `context_files_updated: []`, and `manifest_path: null`.
 - IF Any other: help user respond, then [Redisplay Menu Options](#6-present-menu-options)
 
 #### EXECUTION RULES:

--- a/src/skf-export-skill/references/package.md
+++ b/src/skf-export-skill/references/package.md
@@ -2,6 +2,8 @@
 nextStepFile: 'generate-snippet.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Validate package contents in {document_output_language}. -->
+
 # Step 2: Package
 
 ## STEP GOAL:

--- a/src/skf-export-skill/references/summary.md
+++ b/src/skf-export-skill/references/summary.md
@@ -2,6 +2,8 @@
 nextStepFile: 'health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Render the user-facing summary in {document_output_language}. -->
+
 # Step 6: Summary
 
 ## STEP GOAL:
@@ -130,7 +132,15 @@ No files were written. To run the export for real:
 
 ### 6. Result Contract
 
-Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/export-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skills_output_folder}/export-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all context files and target managed-section files in `outputs`; include total always-on and on-trigger token counts in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/export-skill-result-{timestamp}.json` (reuse the activation-stored `{timestamp}`, resolution to seconds) and a copy at `{skills_output_folder}/export-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all context files and target managed-section files in `outputs`; include total always-on and on-trigger token counts in `summary`.
+
+When `{headless_mode}` is true, also emit the single-line envelope on **stdout** before chaining to step 7 (matches the SKILL.md "Result Contract (Headless)" shape):
+
+```
+SKF_EXPORT_RESULT_JSON: {"status":"success","skills":{skill_batch_names},"context_files_updated":{context_files_updated},"manifest_path":"{skills_output_folder}/.export-manifest.json","headless_decisions":{headless_decisions},"exit_code":0,"halt_reason":null}
+```
+
+Substitute `{skill_batch_names}`, `{context_files_updated}`, and `{headless_decisions}` as JSON arrays. When `--dry-run` was set, emit `"status":"dry-run"` instead and report what *would* have been written without performing the writes.
 
 **`deviations[]` field (export-skill-specific extension):** when step 4 §4c.1 detected manifest-orphan managed rows and the operator (or `{headless_mode}`) chose **(b) Preserve verbatim**, also include a `deviations[]` array in the contract. Each entry has the shape:
 

--- a/src/skf-export-skill/references/token-report.md
+++ b/src/skf-export-skill/references/token-report.md
@@ -2,6 +2,8 @@
 nextStepFile: 'summary.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Render the token report in {document_output_language}. -->
+
 # Step 5: Token Report
 
 ## STEP GOAL:

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -1,7 +1,31 @@
 ---
 nextStepFile: 'token-report.md'
-managedSectionData: 'assets/managed-section-format.md'
+managedSectionData: '{managedSectionFormatPath}'
+# Resolve `{rebuildManagedSectionsHelper}` by probing
+# `{rebuildManagedSectionsProbeOrder}` in order (installed SKF module path
+# first, src/ dev-checkout fallback); first existing path wins. §9 uses
+# the `replace` action for the surgical between-marker swap with
+# atomic temp-file + rename, marker preservation, and post-write verify.
+# HALT if no candidate exists — the in-prompt prose path silently regresses
+# the Case 4 (malformed markers) HARD HALT guarantee.
+rebuildManagedSectionsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-rebuild-managed-sections.py'
+  - '{project-root}/src/shared/scripts/skf-rebuild-managed-sections.py'
+# Resolve `{manifestOpsHelper}` similarly. §9b uses `read` / `set` for
+# atomic v2-schema-aware manifest mutation (handles v1→v2 migration and
+# `platforms`→`ides` rename internally).
+manifestOpsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-manifest-ops.py'
+  - '{project-root}/src/shared/scripts/skf-manifest-ops.py'
+# Resolve `{atomicWriteHelper}` similarly. §6 Case 1 (Create) and §6
+# Case 2 (Append) use it via `write` for safe artifact emission — the
+# in-prompt write would risk half-written files on process kill.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 ---
+
+<!-- Config: communicate in {communication_language}. Render the change preview and managed section in {document_output_language}. -->
 
 # Step 4: Update Context
 
@@ -246,8 +270,9 @@ Assemble the complete managed section:
 - Preserved: ALL content before `<!-- SKF:BEGIN` and after `<!-- SKF:END -->`
 
 **Case 4: Malformed markers (file contains `<!-- SKF:BEGIN` but no `<!-- SKF:END -->`)**
-- Action: HALT with warning: "Malformed SKF markers detected in `{target-file}` — `<!-- SKF:BEGIN` found but `<!-- SKF:END -->` is missing. Please restore the end marker manually before running export."
-- Do NOT attempt to write or append — the file is in an inconsistent state
+- Action: HALT (exit code 5, `halt_reason: "malformed-markers"`) with warning: "Malformed SKF markers detected in `{target-file}` — `<!-- SKF:BEGIN` found but `<!-- SKF:END -->` is missing. Please restore the end marker manually before running export."
+- Do NOT attempt to write or append — the file is in an inconsistent state.
+- In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with `manifest_path: null`, `context_files_updated: []`.
 
 ### 7. Present Change Preview
 
@@ -280,18 +305,19 @@ Auto-proceed to {nextStepFile}.
 
 **If NOT dry-run:**
 
-Display: "**Select:** [C] Continue — write changes to {target-file}"
+Display: "**Select:** [C] Continue — write changes to {target-file} | [X] Cancel and exit (or type `cancel` / `exit` / `:q`)"
 
 **Multi-target behavior:** When processing multiple context files, present all previews together before asking for a single confirmation. After confirmation, write all target files sequentially, verifying each one.
 
 "**Targets:** {list all context-file → target-file pairs}
 **Ready to write changes to all targets?**"
 
-Display: "**Select:** [C] Continue — write changes to all targets"
+Display: "**Select:** [C] Continue — write changes to all targets | [X] Cancel and exit"
 
 #### Menu Handling Logic:
 
 - IF C: Write the changes to all target files (or single target), verify each write succeeded, then load, read entire file, then execute {nextStepFile}
+- IF X (or `cancel` / `exit` / `:q`): Display "Cancelled — no context files were written." and HALT (exit code 6, `halt_reason: "user-cancelled"`). In headless, emit the error envelope per SKILL.md "Result Contract (Headless)" with the resolved `skills`, `context_files_updated: []`, and `manifest_path: null`.
 - IF Any other: help user respond, then [Redisplay Menu Options](#8-present-menu-options)
 
 #### EXECUTION RULES:
@@ -303,16 +329,49 @@ Display: "**Select:** [C] Continue — write changes to all targets"
 
 ### 9. Write and Verify (Non-Dry-Run Only)
 
-After user confirms with 'C':
+After user confirms with 'C', resolve the helpers in parallel — these are independent file-existence checks that batch into one tool-call message:
 
-1. Write the file using the appropriate case logic
-2. Re-read the written file
-3. Verify `<!-- SKF:BEGIN` and `<!-- SKF:END -->` markers are present
-4. Verify content outside markers is unchanged (for Cases 2 and 3)
-5. Report: "**{target-file} updated successfully.** Verified: markers present, external content preserved."
+- `{rebuildManagedSectionsHelper}` ← first existing path in `{rebuildManagedSectionsProbeOrder}` (used for Cases 2 and 3)
+- `{atomicWriteHelper}` ← first existing path in `{atomicWriteProbeOrder}` (used for Case 1)
+- `{manifestOpsHelper}` ← first existing path in `{manifestOpsProbeOrder}` (used in §9b)
 
-**If verification fails:**
-"**WARNING: Write verification failed.** {describe issue}. File may need manual review."
+If any helper has no existing candidate, HALT (exit code 4, `halt_reason: "context-rebuild-failed"`) and emit the error envelope per SKILL.md "Result Contract (Headless)" — the rewrite's safety guarantees depend on these helpers and a fall-through to LLM-driven writes would silently regress atomicity, marker preservation, and the Case 4 malformed-marker HARD HALT contract.
+
+For each target context file, dispatch by case:
+
+**Case 1 (Create — file does not exist):**
+
+```bash
+echo "{new_managed_section_text}" | python3 {atomicWriteHelper} write "{target-file}"
+```
+
+The helper stages the content into `<target>.skf-tmp`, fsyncs, and atomically renames into place.
+
+**Case 2 (Append — file exists, no `<!-- SKF:BEGIN` marker):**
+
+```bash
+python3 {rebuildManagedSectionsHelper} {target-file} insert --content "{new_managed_section_text}"
+```
+
+The helper appends the managed section to the end of the file via the same atomic temp-file + rename pattern.
+
+**Case 3 (Regenerate — file contains `<!-- SKF:BEGIN` and `<!-- SKF:END -->`):**
+
+```bash
+python3 {rebuildManagedSectionsHelper} {target-file} replace --content "{new_managed_section_text}"
+```
+
+The helper performs the surgical between-marker swap with post-write verification (markers present, content outside markers byte-identical).
+
+**Case 4 (malformed markers — already HALTed in §6):** never reaches here.
+
+**Verification (deferred to helpers):** the `replace`/`insert`/`write` actions above each perform their own verification. Treat any non-zero exit as a write failure:
+
+- HALT (exit code 4, `halt_reason: "context-rebuild-failed"`) and report `{target-file}: {captured stderr}`.
+- In headless mode, emit the error envelope.
+- Continue to the next target file only on success — partial-batch writes are acceptable in single-skill mode but the overall envelope reports per-target outcomes.
+
+On success per file, report: "**{target-file} updated successfully.** Verified by `{rebuildManagedSectionsHelper}` (or `{atomicWriteHelper}` for Case 1)."
 
 ### 9b. Update Export Manifest (Non-Dry-Run Only)
 
@@ -342,11 +401,17 @@ After user confirms with 'C':
      - If the version already exists in `versions`, union its existing `ides` with `ides_written` (deduplicate, keep sorted), refresh `last_exported`, and set `status: "active"`
      - If this is a new version, add it to `versions` with `status: "active"` and set any previously-active version's status to `"archived"`
      - Preserve all other version entries in `versions` (do not delete archived versions)
-5. Write the updated manifest once to `{skills_output_folder}/.export-manifest.json` after all skills in the batch have been applied
+5. Write the updated manifest atomically via `{manifestOpsHelper}` after all skills in the batch have been applied. For each skill / version pair, invoke:
+
+   ```bash
+   python3 {manifestOpsHelper} {skills_output_folder} set {skill-name} {version}
+   ```
+
+   The helper handles v2-schema validation, v1→v2 migration, and `platforms`→`ides` rename internally — no in-prompt JSON manipulation needed. Each `set` invocation merges the per-version `ides` and `last_exported` fields into the existing entry. After all skills have been set, re-read the manifest via `{manifestOpsHelper} {skills_output_folder} read` to confirm the final state matches expectations.
 
 **Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name-list} — ides: {ides_written}.**" (list every skill in `skill_batch`)
 
-**Error handling:** If manifest write fails, warn but do not fail the workflow — the managed section was already written successfully.
+**Error handling:** If `{manifestOpsHelper}` exits non-zero, HALT (exit code 4, `halt_reason: "manifest-write-failed"`) with the captured `stderr`. The managed section was already written successfully; the operator's recovery path is to manually reconcile the on-disk managed section with the manifest, then re-run `[EX] Export Skill --all` to refresh the manifest. In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with `manifest_path: null` and the partial `context_files_updated` list.
 
 ## CRITICAL STEP COMPLETION NOTE
 

--- a/src/skf-refine-architecture/SKILL.md
+++ b/src/skf-refine-architecture/SKILL.md
@@ -31,6 +31,7 @@ These rules apply to every step in this workflow:
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`
+- At any interactive prompt, the inputs `cancel`, `exit`, `[X]`, `q`, or `:q` exit cleanly with exit code 6 (`halt_reason: "user-cancelled"`)
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages
@@ -49,17 +50,80 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | architecture_doc_path [required] |
+| **Inputs** | architecture_doc_path [required], vs_report_path [optional] |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--architecture-doc <path>` (skip step 1 prompt for the required input); `--vs-report-path <path>` (skip step 1 prompt for the optional VS report) |
 | **Gates** | step 1: Input Gate [use args] | step 5: Review Gate [C] |
-| **Outputs** | refined-architecture-{project_name}.md |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Outputs** | `refined-architecture-{project_name}.md` at `{outputFolderPath}`, plus `refine-architecture-result-{timestamp}.json` and `refine-architecture-result-latest.json` |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Per-flag args (`--architecture-doc`, `--vs-report-path`) consumed at the gates that would otherwise prompt. |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                    |
+| ---- | -------------------- | -------------------------------------------------------------------------------------------- |
+| 0    | success              | step 7 (terminal)                                                                           |
+| 2    | input-missing / input-invalid | step 1 §1 (headless missing `architecture-doc` arg, or invalid path) → `input-missing`; non-existent file → `input-invalid` |
+| 3    | resolution-failure   | step 1 §3 (`output_folder` or `forge_data_folder` unconfigured) |
+| 4    | write-failure        | On-Activation §3 pre-flight write probe; step 1 §3c (RA state file write failed); step 5 §6 (refined-architecture write failed); step 6 §3 (result-contract write failed) |
+| 5    | state-conflict       | step 1 §3 (no skills found — refinement requires ≥1 skill) |
+| 6    | user-cancelled       | step 1 §1 prompt cancelled; any prompt that accepted `cancel`/`exit`/`:q`; step 5 review gate `[X]` |
+| 7    | inventory-unreliable | step 1 §2 (>20% skill-inventory warnings exceed budget) |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 6 emits a single-line JSON envelope on **stdout** before chaining to step 7, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_REFINE_ARCHITECTURE_RESULT_JSON: {"status":"success|error","refined_path":"…|null","gap_count":0,"issue_count":0,"improvement_count":0,"exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"insufficient-skills"`, `"output-folder-unconfigured"`, `"forge-folder-unconfigured"`, `"inventory-unreliable"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 
 1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
    - `project_name`, `user_name`, `communication_language`, `document_output_language`
-   - `skills_output_folder`, `forge_data_folder`, `output_folder`
+   - `skills_output_folder`, `forge_data_folder`, `output_folder`, `sidecar_path`
 
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+2. **Compute run-scoped variables:**
+   - `timestamp` ← UTC `YYYYMMDD-HHmmss` captured at activation time. Fixed for the entire workflow run; report.md reuses this when writing the result contract.
 
-3. Load, read the full file, and then execute `references/init.md` to begin the workflow.
+3. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in `{sidecar_path}/preferences.yaml`. Default: false.
+
+4. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each scalar, if the merged value is empty or absent, use the bundled default:
+
+   - `{refinementRulesPath}` ← `workflow.refinement_rules_path` if non-empty, else `references/refinement-rules.md`
+   - `{outputFolderPath}` ← `workflow.output_folder_path` if non-empty, else `{output_folder}`
+
+   Stash both as workflow-context variables. Stage files reference them directly — no conditional at the usage site.
+
+5. **Pre-flight write probe.** Verify both `{outputFolderPath}` and `{forge_data_folder}` are writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces at init.md §3c's RA state file write — by then the user has already gone through input prompts:
+
+   ```bash
+   for dir in "{outputFolderPath}" "{forge_data_folder}"; do
+     mkdir -p "$dir" && \
+       printf 'probe' > "$dir/.skf-write-probe" && \
+       rm "$dir/.skf-write-probe"
+   done
+   ```
+
+   On any non-zero exit: HALT (exit code 4, `halt_reason: "write-failed"`). In headless mode, emit the error envelope per **Result Contract (Headless)** with `refined_path: null`.
+
+6. Load, read the full file, and then execute `references/init.md` to begin the workflow.

--- a/src/skf-refine-architecture/customize.toml
+++ b/src/skf-refine-architecture/customize.toml
@@ -1,0 +1,49 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-refine-architecture.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede architecture refinement work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (refinement standards, evidence-citation rules, house-style preservation
+# guardrails). Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Refinements must cite specific API signatures, never speculate."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/refine-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical refinement-rules path so orgs can substitute house-style
+# rules (e.g. add domain-specific gap categories) without forking the skill.
+# Empty string = use the bundled default.
+
+refinement_rules_path = ""
+
+# Override the destination directory for the refined architecture document.
+# Empty = use {output_folder} from config.yaml. Useful for orgs that want
+# refined-architecture artifacts to land under a curated docs tree.
+
+output_folder_path = ""

--- a/src/skf-refine-architecture/references/compile.md
+++ b/src/skf-refine-architecture/references/compile.md
@@ -1,7 +1,9 @@
 ---
 nextStepFile: 'report.md'
-outputFile: '{output_folder}/refined-architecture-{project_name}.md'
+outputFile: '{outputFolderPath}/refined-architecture-{project_name}.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Compile the refined architecture document in {document_output_language}. -->
 
 # Step 5: Compile Refined Architecture
 

--- a/src/skf-refine-architecture/references/gap-analysis.md
+++ b/src/skf-refine-architecture/references/gap-analysis.md
@@ -1,7 +1,9 @@
 ---
 nextStepFile: 'issue-detection.md'
-refinementRulesData: 'references/refinement-rules.md'
+refinementRulesData: '{refinementRulesPath}'
 ---
+
+<!-- Config: communicate in {communication_language}. Append gap-analysis findings to the RA state file in {document_output_language}. -->
 
 # Step 2: Gap Analysis
 

--- a/src/skf-refine-architecture/references/health-check.md
+++ b/src/skf-refine-architecture/references/health-check.md
@@ -1,9 +1,11 @@
 ---
-# `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# Note: `shared/health-check.md` resolves relative to the SKF module root
+# ({project-root}/_bmad/skf/ when installed, {project-root}/src/ during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 7: Workflow Health Check
 

--- a/src/skf-refine-architecture/references/improvements.md
+++ b/src/skf-refine-architecture/references/improvements.md
@@ -1,7 +1,9 @@
 ---
 nextStepFile: 'compile.md'
-refinementRulesData: 'references/refinement-rules.md'
+refinementRulesData: '{refinementRulesPath}'
 ---
+
+<!-- Config: communicate in {communication_language}. Append improvement findings to the RA state file in {document_output_language}. -->
 
 # Step 4: Improvement Detection
 

--- a/src/skf-refine-architecture/references/init.md
+++ b/src/skf-refine-architecture/references/init.md
@@ -1,7 +1,18 @@
 ---
 nextStepFile: 'gap-analysis.md'
-refinementRulesData: 'references/refinement-rules.md'
+refinementRulesData: '{refinementRulesPath}'
+# Resolve `{enumerateStackSkillsHelper}` by probing
+# `{enumerateStackSkillsProbeOrder}` in order (installed SKF module path
+# first, src/ dev-checkout fallback); first existing path wins. §2 calls
+# it for the deterministic skill inventory (cascade-resolved exports,
+# metadata-hash, confidence-tier mapping) — replacing a hand-rolled
+# subagent fan-out that re-derived the same data on every run.
+enumerateStackSkillsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-enumerate-stack-skills.py'
+  - '{project-root}/src/shared/scripts/skf-enumerate-stack-skills.py'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 1: Initialize Refinement
 
@@ -20,68 +31,65 @@ Load the architecture document (required), scan the skills folder to build a ski
 
 ### 1. Accept Input Documents
 
-"**Refine Architecture — Evidence-Backed Refinement**
+"**Refine Architecture — Evidence-Backed Refinement** (additive — never deletes original content).
 
-Please provide the following:
+If you wanted to *verify* the stack first, type `cancel` and run `[VS] Verify Stack`; if no skills exist yet, run `[CS] Create Skill`. Otherwise, please provide the following:
 1. **Architecture document path** (REQUIRED) — your project's architecture doc to refine
-2. **VS feasibility report path** (OPTIONAL) — from a previous [VS] Verify Stack run, for additional context"
+2. **VS feasibility report path** (OPTIONAL) — from a previous [VS] Verify Stack run, for additional context
 
-Wait for user input. Store the validated architecture document path as `architecture_doc`. **GATE [default: use args]** — If `{headless_mode}` and architecture doc path was provided as argument: use that path and auto-proceed, log: "headless: using provided architecture path".
+Or type `cancel` / `exit` / `:q` at any prompt to abort cleanly."
+
+Wait for user input. Store the validated architecture document path as `architecture_doc`. **GATE [default: use args]** — If `{headless_mode}` and `--architecture-doc` was provided: use that path and auto-proceed, log: "headless: using provided architecture path". If `--vs-report-path` was provided, consume it at the VS validation below. If `--architecture-doc` is absent in headless: HALT (exit code 2, `halt_reason: "input-missing"`) and emit the error envelope.
+
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q` at any sub-prompt: Display "Cancelled — no refinement was performed." and HALT (exit code 6, `halt_reason: "user-cancelled"`).
 
 **Validate architecture document:**
 - Confirm the file exists and is readable
 - If missing or unreadable: "Architecture document not found at `{path}`. Provide a valid path."
-- HALT until a valid architecture document is provided
+- HALT (exit code 2, `halt_reason: "input-invalid"`) if the user cannot provide a valid path. In headless, emit the error envelope per SKILL.md "Result Contract (Headless)" immediately.
 
-**Validate VS report (if provided):**
+**Validate VS report (if provided via `--vs-report-path` or interactive input):**
 - Confirm the file exists and is readable
 - If missing at user-provided path: attempt auto-probe (below) before giving up
 - Store VS report availability as `vs_report_available: true|false` and `vs_report_path`
 
 ### 2. Scan Skills Folder
 
-Read the `{skills_output_folder}` directory. Skills use a version-nested directory structure (see `knowledge/version-paths.md`).
+**Resolve `{enumerateStackSkillsHelper}`** from `{enumerateStackSkillsProbeOrder}`; first existing path wins.
 
-**Version-aware skill discovery:**
-1. Read `{skills_output_folder}/.export-manifest.json` if it exists. For each skill in `exports`, use `active_version` to resolve `{skill_package}` = `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/`
-2. For any subdirectory not covered by the manifest, check for an `active` symlink at `{skills_output_folder}/{dir_name}/active` — resolve to `{skill_group}/active/{dir_name}/`
-3. Fall back to flat path `{skills_output_folder}/{dir_name}/` for unmigrated skills
+**Primary path — deterministic enumeration via shared helper:**
 
-For each resolved skill package, check for the presence of `SKILL.md` and `metadata.json`.
+```bash
+python3 {enumerateStackSkillsHelper} enumerate {skills_output_folder}
+```
 
-**For each valid skill directory, extract from metadata.json:**
-- `name` — skill name
-- `language` — primary language
-- `confidence_tier` — Quick, Forge, Forge+, or Deep
-- `exports_documented` — read from `stats.exports_documented` in metadata.json (count of documented exports)
-- `source_repo` or `source_root` — original source repository
+The helper walks `{skills_output_folder}`, reads each `metadata.json`, applies the version-aware resolution (export-manifest → `active` symlink → flat fallback), captures the exports cascade (metadata → references → SKILL.md), maps `confidence_tier`, and emits structured JSON with one entry per skill plus a top-level `warnings[]` array. Cache the result as `skill_inventory`.
 
-**Build a skill inventory** as an internal list of all loaded skills with the fields above.
+Each helper-emitted entry includes: `skill_name`, `version`, `language`, `confidence_tier`, `exports_documented`, `source_repo`, `source_root`, and a `metadata_hash` for change-detection across runs. The helper's `warnings[]` carries per-skill skip reasons (missing SKILL.md/metadata.json, non-symlink `active`, orphan-versions, schema-version violations).
 
-**If a resolved skill package lacks SKILL.md or metadata.json:**
-- Log: "Skipping `{dir_name}` — missing SKILL.md or metadata.json"
-- Do not include in inventory
+**Failure-budget guard:** If `len(warnings) / (len(skill_inventory) + len(warnings)) > 0.20`, HALT (exit code 7, `halt_reason: "inventory-unreliable"`) with: "Inventory scan unreliable — {len(warnings)}/{total} skills returned skip warnings. Re-run [RA] after skills stabilize." In headless, emit the error envelope.
+
+**Fallback path — graceful degradation when the helper is unavailable:** If `{enumerateStackSkillsHelper}` has no existing candidate, fall through to the LLM-driven inventory: walk `{skills_output_folder}` and for each `{skill_package}` read `metadata.json` and extract `name`, `language`, `confidence_tier`, `stats.exports_documented`, `source_repo`/`source_root`. Skip packages missing SKILL.md or metadata.json with a logged warning. Same 20% failure budget applies.
 
 ### 3. Validate Minimum Requirements
 
 **Check skill count:**
 - At least 1 valid skill must exist
 - If no skills found: "**Cannot proceed.** No skills found in `{skills_output_folder}`. Generate skills with [CS] Create Skill or [QS] Quick Skill, then re-run [RA]."
-- HALT workflow
+- HALT (exit code 5, `halt_reason: "insufficient-skills"`). In headless, emit the error envelope.
 - If exactly 1 valid skill found: "⚠️ Proceeding with 1 skill. Note: gap analysis will find no gaps — pairwise analysis requires at least 2 skills. Step 02 will still execute and issue an appropriate notice. Issue detection and improvement detection will proceed normally."
 
-**Check output_folder:**
-- Verify `output_folder` was resolved from config.yaml and is non-empty
+**Check `{outputFolderPath}`** (resolved at activation from `output_folder` config + customize override):
+- Verify the path is non-empty
 - If undefined or empty: "**Cannot proceed.** `output_folder` is not configured in config.yaml. Add an `output_folder` path and re-run [RA]."
-- HALT workflow
-- Verify the `output_folder` directory exists. If it does not exist, create it. HALT with error if creation fails.
+- HALT (exit code 3, `halt_reason: "output-folder-unconfigured"`). In headless, emit the error envelope.
+- The directory existence + writability was probed at On-Activation §5 — if it failed there, this section never runs.
 
 **Check forge_data_folder:**
 - Verify `forge_data_folder` was resolved from config.yaml and is non-empty
 - If undefined or empty: "**Cannot proceed.** `forge_data_folder` is not configured in config.yaml. Add a `forge_data_folder` path to your config.yaml and re-run [RA]."
-- HALT workflow
-- Verify the `forge_data_folder` directory exists. If it does not exist, attempt to create it. If creation fails: "**Cannot proceed.** `forge_data_folder` at `{forge_data_folder}` does not exist and could not be created. Create the directory manually and re-run [RA]."
-- HALT workflow on creation failure
+- HALT (exit code 3, `halt_reason: "forge-folder-unconfigured"`). In headless, emit the error envelope.
+- The directory existence + writability was probed at On-Activation §5.
 
 **Check architecture document:**
 - Confirm it was loaded successfully in section 1
@@ -105,6 +113,8 @@ Create (or overwrite) `{forge_data_folder}/ra-state-{project_name}.md` with a fr
 ```
 
 This ensures steps 02-04 append to a clean slate and context recovery in step 5 never loads stale findings from a prior run.
+
+On any write failure (read-only mount, disk full, permissions denied): HALT (exit code 4, `halt_reason: "write-failed"`) with the captured error and emit the error envelope. The On-Activation §5 probe should have caught this earlier — if it surfaces here, the filesystem state changed mid-workflow.
 
 ### 4. Load Refinement Rules
 

--- a/src/skf-refine-architecture/references/issue-detection.md
+++ b/src/skf-refine-architecture/references/issue-detection.md
@@ -1,7 +1,9 @@
 ---
 nextStepFile: 'improvements.md'
-refinementRulesData: 'references/refinement-rules.md'
+refinementRulesData: '{refinementRulesPath}'
 ---
+
+<!-- Config: communicate in {communication_language}. Append issue-detection findings to the RA state file in {document_output_language}. -->
 
 # Step 3: Issue Detection
 

--- a/src/skf-refine-architecture/references/refinement-rules.md
+++ b/src/skf-refine-architecture/references/refinement-rules.md
@@ -1,3 +1,5 @@
+<!-- Static reference loaded by gap-analysis.md, issue-detection.md, and improvements.md. -->
+
 # Architecture Refinement Rules
 
 ## Purpose

--- a/src/skf-refine-architecture/references/report.md
+++ b/src/skf-refine-architecture/references/report.md
@@ -1,7 +1,12 @@
 ---
-outputFile: '{output_folder}/refined-architecture-{project_name}.md'
+# {outputFile} resolves from the activation-stored {outputFolderPath}
+# variable (set in SKILL.md On Activation §4 from output_folder config +
+# customize override).
+outputFile: '{outputFolderPath}/refined-architecture-{project_name}.md'
 nextStepFile: 'health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Render the user-facing summary in {document_output_language}. -->
 
 # Step 6: Present Report
 
@@ -81,7 +86,13 @@ Re-run **[RA] Refine Architecture** anytime after updating your skills or archit
 
   ### Result Contract
 
-  Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{output_folder}/refine-architecture-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{output_folder}/refine-architecture-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the refined architecture doc path in `outputs`; include `gap_count`, `issue_count`, and `improvement_count` in `summary`.
+  Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{outputFolderPath}/refine-architecture-result-{timestamp}.json` (reuse the activation-stored `{timestamp}`, resolution to seconds) and a copy at `{outputFolderPath}/refine-architecture-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the refined architecture doc path in `outputs`; include `gap_count`, `issue_count`, and `improvement_count` in `summary`. On any write failure: HALT (exit code 4, `halt_reason: "write-failed"`) and emit the error envelope.
+
+  When `{headless_mode}` is true, also emit the single-line envelope on **stdout** before chaining to step 7 (matches the SKILL.md "Result Contract (Headless)" shape):
+
+  ```
+  SKF_REFINE_ARCHITECTURE_RESULT_JSON: {"status":"success","refined_path":"{outputFile}","gap_count":{gap_count},"issue_count":{issue_count},"improvement_count":{improvement_count},"exit_code":0,"halt_reason":null}
+  ```
 
   Then load, read the full file, and execute `{nextStepFile}` — the health-check step is the true terminal step of this workflow.
 

--- a/src/skf-rename-skill/SKILL.md
+++ b/src/skf-rename-skill/SKILL.md
@@ -33,6 +33,7 @@ These rules apply to every step in this workflow:
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`
+- At any interactive prompt, the inputs `cancel`, `exit`, `[X]`, `q`, or `:q` exit cleanly with exit code 6 (`halt_reason: "user-cancelled"`)
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages
@@ -49,9 +50,35 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | old_name [required], new_name [required] |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates) |
 | **Gates** | step 1: Input Gate [use args] x2, Confirm Gate [Y] |
-| **Outputs** | Renamed skill directories, updated manifest, updated context files |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Outputs** | Renamed skill directories, updated manifest, updated context files, `{new_name}/rename-skill-result-{timestamp}.json` and `{new_name}/rename-skill-result-latest.json` |
+| **Concurrency** | Two simultaneous rename runs against the same `old_name` would corrupt state mid-copy. select.md §4b acquires a PID-file lock at `{forge_data_folder}/{old_name}/.skf-rename.lock` once `old_name` is resolved; live-PID collisions HALT with `halt_reason: "halted-for-concurrent-run"`. Stale locks (dead PID) are cleared silently with a warning. The lock is released by the terminal health-check step (step 4) and by every documented halt path. |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. The §6 source-authority warning HALTs by default in headless when `source_authority="official"`; set `force_source_authority_in_headless = "true"` in `customize.toml` to auto-acknowledge and proceed (the override is recorded in `headless_decisions[]`). |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                    |
+| ---- | -------------------- | -------------------------------------------------------------------------------------------- |
+| 0    | success              | step 4 (terminal)                                                                           |
+| 2    | input-missing / input-invalid | step 1 §4/§5 (headless missing `old_name`/`new_name` arg) → `input-missing`; new name fails kebab-case / length / same-as-old → `input-invalid` |
+| 3    | resolution-failure   | step 1 §2 (manifest is malformed JSON); step 1 §3 (no skills found anywhere)               |
+| 4    | write-failure        | On-Activation §3 pre-flight write probe (skills_output_folder / forge_data_folder unwritable); step 2 §1 (copy); step 2 §3 (file content update); step 2 §6 (manifest write); step 2 §7 (context-file rewrite) |
+| 5    | state-conflict       | step 1 §5 (name-collision check fails: target name already in use); step 1 §6 (source-authority="official" headless without `force_source_authority_in_headless`); concurrency lock collision (`halted-for-concurrent-run`) |
+| 6    | user-cancelled       | step 1 §6 (source-authority warning [N]); step 1 §8 confirmation gate `[N]`; any prompt that accepted `cancel`/`exit`/`:q` |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 3 emits a single-line JSON envelope on **stdout** before chaining to step 4, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_RENAME_SKILL_RESULT_JSON: {"status":"success|error","old_name":"…|null","new_name":"…|null","versions_renamed":[],"manifest_rekeyed":false,"context_files_updated":[],"exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"manifest-corrupt"`, `"nothing-to-rename"`, `"name-collision"`, `"source-authority-blocked"`, `"halted-for-concurrent-run"`, `"copy-failed"`, `"verify-failed"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 
@@ -61,6 +88,41 @@ These rules apply to every step in this workflow:
    - `snippet_skill_root_override` (optional string) — when set, the context-file rebuild in step 2 preserves any snippet `root:` prefix that matches the override instead of rewriting it to the target IDE's skill root. See `skf-export-skill/assets/managed-section-format.md` for full semantics.
    - Generate and store `timestamp` as `YYYYMMDD-HHmmss` format. This value is fixed for the entire workflow run.
 
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in `{sidecar_path}/preferences.yaml`. Default: false.
 
-3. Load, read the full file, and then execute `references/select.md` to begin the workflow.
+3. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each scalar.
+
+   Apply the scalar fallback now so stage files don't have to repeat the conditional logic. For each of the three scalars, if the merged value is empty or absent, the bundled default applies:
+
+   - `{forceSourceAuthorityInHeadless}` ← `workflow.force_source_authority_in_headless` (empty or non-`"true"` = HALT in headless on `"official"` source-authority)
+   - `{unknownIdeDefaultContextFile}` ← `workflow.unknown_ide_default_context_file` if non-empty, else `AGENTS.md`
+   - `{unknownIdeDefaultSkillRoot}` ← `workflow.unknown_ide_default_skill_root` if non-empty, else `.agents/skills/`
+
+   Stash all three as workflow-context variables. Stage files reference them directly — no conditional at the usage site.
+
+4. **Pre-flight write probe.** Verify both `{skills_output_folder}` and `{forge_data_folder}` are writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces inside step 2's transactional copy — by then the user has already gone through name validation and confirmation:
+
+   ```bash
+   for dir in "{skills_output_folder}" "{forge_data_folder}"; do
+     mkdir -p "$dir" && \
+       printf 'probe' > "$dir/.skf-write-probe" && \
+       rm "$dir/.skf-write-probe"
+   done
+   ```
+
+   On any non-zero exit: HALT (exit code 4, `halt_reason: "write-failed"`). In headless mode, emit the error envelope per **Result Contract (Headless)** with `old_name: null` and `new_name: null` (neither is resolved yet at activation time).
+
+5. Load, read the full file, and then execute `references/select.md` to begin the workflow.

--- a/src/skf-rename-skill/customize.toml
+++ b/src/skf-rename-skill/customize.toml
@@ -1,0 +1,52 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-rename-skill.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (audit-log emit,
+# ticket-reference enforcement) that must precede any rename work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (rename-policy reminders, public-name-stability rules, audit guardrails).
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Renames of skills tagged `published` require approval."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/rename-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional safety + default scalars ---
+#
+# Auto-acknowledge the source-authority="official" warning in headless mode.
+# Empty string = HALT in headless when source_authority is "official"
+# (the safe default — local renames diverge from any registry-published
+# name). Set to "true" to silently proceed and record the override in the
+# headless decision trail.
+
+force_source_authority_in_headless = ""
+
+# Fallback IDE → context-file mapping for unknown IDEs in `config.yaml.ides`.
+# Empty string = use bundled defaults (AGENTS.md / .agents/skills/).
+# Used by execute.md §7 when rebuilding context files.
+
+unknown_ide_default_context_file = ""
+unknown_ide_default_skill_root = ""

--- a/src/skf-rename-skill/references/execute.md
+++ b/src/skf-rename-skill/references/execute.md
@@ -2,7 +2,36 @@
 nextStepFile: 'report.md'
 versionPathsKnowledge: 'knowledge/version-paths.md'
 managedSectionLogic: 'skf-export-skill/assets/managed-section-format.md'
+# Resolve `{atomicWriteHelper}` by probing `{atomicWriteProbeOrder}` in
+# order (installed SKF module path first, src/ dev-checkout fallback);
+# first existing path wins. §3 + §6 use it for crash-safe file rewrites
+# (stage to .skf-tmp, fsync, rename) — letting the LLM write directly
+# risks half-written artifacts on process kill or disk-full mid-write.
+# HALT if neither candidate exists.
+atomicWriteProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-atomic-write.py'
+  - '{project-root}/src/shared/scripts/skf-atomic-write.py'
+# Resolve `{updateActiveSymlinkHelper}` similarly. §4 uses it to
+# atomically repair the `active` symlink with `flock` and the Windows
+# junction fallback — `rm + ln -s` would race against concurrent readers
+# and silently break on Windows.
+updateActiveSymlinkProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-update-active-symlink.py'
+  - '{project-root}/src/shared/scripts/skf-update-active-symlink.py'
+# Resolve `{manifestOpsHelper}` similarly. §6 uses the `rename` action
+# for atomic re-key (preserves `active_version`, `versions` map, all
+# fields, then writes via temp + rename).
+manifestOpsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-manifest-ops.py'
+  - '{project-root}/src/shared/scripts/skf-manifest-ops.py'
+# Resolve `{rebuildManagedSectionsHelper}` similarly. §7.7 uses the
+# `replace` action for the surgical between-marker rewrite.
+rebuildManagedSectionsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-rebuild-managed-sections.py'
+  - '{project-root}/src/shared/scripts/skf-rebuild-managed-sections.py'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 2: Execute Rename (Transactional)
 
@@ -22,9 +51,20 @@ Execute the rename decisions recorded in step 1 as a transaction. Copy the old `
 
 **CRITICAL:** This is transactional. After section 1 (copy), the old skill is untouched. If any section between 2 and 7 fails, delete `{new_skill_group}` and `{new_forge_group}`, report the failure, and halt — the old skill remains intact. Only section 8 (delete old) makes the operation irreversible. Do not skip, reorder, or improvise.
 
-### 0. Re-read Version-Paths Knowledge
+### 0. Re-read Version-Paths Knowledge + Resolve Helpers
 
 Read `{versionPathsKnowledge}` again and confirm the templates (`{skill_package}`, `{skill_group}`, `{forge_version}`, `{forge_group}`) and the Rename section. Also read `{managedSectionLogic}` for the managed-section format template and the skill index rebuild rules that will be reused in section 7.
+
+**Resolve helpers** in parallel — these are independent file-existence checks that batch into one tool-call message:
+
+- `{atomicWriteHelper}` ← first existing path in `{atomicWriteProbeOrder}` (used in §3, §6 for crash-safe writes)
+- `{updateActiveSymlinkHelper}` ← first existing path in `{updateActiveSymlinkProbeOrder}` (used in §4 for atomic symlink repair)
+- `{manifestOpsHelper}` ← first existing path in `{manifestOpsProbeOrder}` (used in §6 for the manifest re-key)
+- `{rebuildManagedSectionsHelper}` ← first existing path in `{rebuildManagedSectionsProbeOrder}` (used in §7.7 for between-marker swap)
+
+If any helper has no existing candidate, release the lock and HALT (exit code 4, `halt_reason: "write-failed"`) — the rename's safety guarantees depend on these helpers and a fall-through to LLM-driven writes would silently regress atomicity.
+
+**Lock release contract:** every halt path in this step ends with `rm -f "{forge_data_folder}/{old_name}/.skf-rename.lock"` before exiting. The terminal health-check (step 4) is the success-path release.
 
 ### 1. Copy skill_group and forge_group
 
@@ -64,17 +104,24 @@ Report: "**Renamed {count} inner directories** to `{new_name}/`."
 
 For each version `v` in `affected_versions`, operate on the files inside `{new_skill_group}/{v}/{new_name}/` (the freshly renamed inner directory) and `{new_forge_group}/{v}/`:
 
+**Write semantics (apply to 3a / 3b / 3c / 3d):** Compute the new file content in memory (LLM judgment work), then pipe it to `{atomicWriteHelper} write <target>` so the rewrite is staged in `<target>.skf-tmp`, fsync'd, and atomically renamed into place. A process kill or disk-full event mid-rewrite leaves the original file intact — no half-written artifacts.
+
+```bash
+echo "{new_content}" | python3 {atomicWriteHelper} write "{target_path}"
+```
+
 **3a. SKILL.md frontmatter:**
 
 - Path: `{new_skill_group}/{v}/{new_name}/SKILL.md`
 - In the YAML frontmatter (between the leading `---` markers), replace the `name:` field value from `{old_name}` to `{new_name}`
 - Only replace within the frontmatter block — do not substitute matches inside the body text
+- Pipe via `{atomicWriteHelper} write` per the write semantics above
 - If the file is missing, record it in `section3_warnings` and continue
 
 **3b. metadata.json:**
 
 - Path: `{new_skill_group}/{v}/{new_name}/metadata.json`
-- Parse the JSON, set `name` = `{new_name}`, write back preserving formatting
+- Parse the JSON, set `name` = `{new_name}`, write back preserving formatting via `{atomicWriteHelper} write`
 - If the file is missing, record it in `section3_warnings` and continue
 
 **3c. context-snippet.md:**
@@ -85,36 +132,43 @@ For each version `v` in `affected_versions`, operate on the files inside `{new_s
   - Example: `root: .windsurf/skills/{old_name}/` → `root: .windsurf/skills/{new_name}/`
   - Example: `root: skills/{old_name}/` → `root: skills/{new_name}/`
   - Legacy pre-fix form `root: skills/{old_name}/active/{old_name}/` → `root: skills/{new_name}/` (normalize to flat form during rename)
+- Pipe via `{atomicWriteHelper} write` per the write semantics above
 - If the file is missing, record it in `section3_warnings` and continue
 
 **3d. provenance-map.json:**
 
 - Path: `{new_forge_group}/{v}/provenance-map.json`
-- Parse JSON, set `skill_name` = `{new_name}`, write back preserving formatting
+- Parse JSON, set `skill_name` = `{new_name}`, write back via `{atomicWriteHelper} write`
 - If the file is missing (some versions may not have a provenance map), record it in `section3_warnings` and continue
 
 **Rollback on any update failure (not just a missing file):**
 
 - `rm -rf {new_skill_group}` and `rm -rf {new_forge_group}`
-- Halt with: "**File update failed** at `{path}`: {error}. Rolled back both new directories. Old skill is intact."
+- Release the lock: `rm -f "{forge_data_folder}/{old_name}/.skf-rename.lock"`
+- Halt with: "**File update failed** at `{path}`: {error}. Rolled back both new directories. Old skill is intact." HALT (exit code 4, `halt_reason: "write-failed"`). In headless, emit the error envelope.
 
 Report: "**Updated file contents** across {affected_versions_count} version(s): SKILL.md, metadata.json, context-snippet.md, provenance-map.json."
 
 ### 4. Fix the `active` Symlink in the New Location
 
-Recreate or repair the `active` symlink in `{new_skill_group}`:
+Recreate or repair the `active` symlink in `{new_skill_group}` via `{updateActiveSymlinkHelper}` — the helper holds an `flock` on `{new_skill_group}/active.lock`, surfaces a clear error on Windows non-dev-mode (no silent fallback), and uses the `ln -sfn tmp && mv -Tf tmp link` pattern to make the flip atomic against concurrent readers.
 
-1. Inspect `{old_skill_group}/active` to determine the target version (the value the symlink points to — typically just the version string, not an absolute path)
-2. Check `{new_skill_group}/active`:
-   - If the copy in section 1 preserved it correctly and it points to the same version string → leave it as-is
-   - If it exists but points somewhere invalid (e.g., an absolute path back into the old location) → remove and recreate it
-   - If it is missing (some copy tools do not preserve symlinks) → create it
-3. The symlink target should be a relative path: the version string alone (e.g., `0.6.0`), so that `{new_skill_group}/active/{new_name}/` resolves correctly
+1. Inspect `{old_skill_group}/active` to determine the target version (the value the symlink points to — typically just the version string, not an absolute path). If `{old_skill_group}/active` does not exist, skip this section — there is no symlink to repair.
+2. Invoke:
 
-**Rollback on failure:**
+   ```bash
+   python3 {updateActiveSymlinkHelper} flip-link \
+     --link {new_skill_group}/active \
+     --target {target_version}
+   ```
+
+3. The helper handles all four cases (missing, present-and-correct, present-and-stale, present-and-invalid) uniformly via atomic replace.
+
+**Rollback on helper non-zero exit:**
 
 - `rm -rf {new_skill_group}` and `rm -rf {new_forge_group}`
-- Halt with: "**Failed to repair `active` symlink** in `{new_skill_group}`: {error}. Rolled back both new directories. Old skill is intact."
+- Release the lock: `rm -f "{forge_data_folder}/{old_name}/.skf-rename.lock"`
+- Halt with: "**Failed to repair `active` symlink** in `{new_skill_group}`: {captured stderr}. Rolled back both new directories. Old skill is intact." HALT (exit code 4, `halt_reason: "write-failed"`). In headless, emit the error envelope.
 
 ### 5. Verify — No Trace of `{old_name}` Inside the New Location
 
@@ -136,7 +190,8 @@ Also check the directory listing itself:
 **On hard failure (any structural reference to `{old_name}` remains):**
 
 - `rm -rf {new_skill_group}` and `rm -rf {new_forge_group}`
-- Halt with: "**Verification failed.** `{old_name}` still appears in: {list of paths}. Rolled back both new directories. Old skill is intact."
+- Release the lock: `rm -f "{forge_data_folder}/{old_name}/.skf-rename.lock"`
+- Halt with: "**Verification failed.** `{old_name}` still appears in: {list of paths}. Rolled back both new directories. Old skill is intact." HALT (exit code 5, `halt_reason: "verify-failed"`). In headless, emit the error envelope.
 
 Report: "**Verified** — no structural references to `{old_name}` remain inside the new location across {affected_versions_count} version(s). {if verification_warnings is non-empty: 'Informational body-text mentions retained in SKILL.md: {list}.'}"
 
@@ -150,19 +205,21 @@ Report: "**Manifest update skipped** — no `.export-manifest.json` on disk. The
 
 **If `manifest_exists = true`:**
 
-1. Load `{skills_output_folder}/.export-manifest.json`
-2. **Hold a deep copy in memory** as `manifest_backup` — required for rollback in this section and section 7 on failure
-3. If the manifest contains `exports.{old_name}`:
-   - Set `exports.{new_name}` = deep copy of `exports.{old_name}` (preserving `active_version`, `versions` map, and all fields)
-   - Delete `exports.{old_name}`
-4. If the manifest does NOT contain `exports.{old_name}` (the skill was on disk but never exported), skip the re-key — the manifest has nothing to change for this skill
-5. Write the updated manifest back to `{skills_output_folder}/.export-manifest.json`
+1. **Hold a deep copy in memory** as `manifest_backup` — required for rollback in this section and section 7 on failure. Read `{skills_output_folder}/.export-manifest.json` once and stash the parsed object.
+2. **Re-key via the helper.** If the manifest contains `exports.{old_name}`, invoke:
 
-**Rollback on write failure:**
+   ```bash
+   python3 {manifestOpsHelper} {skills_output_folder} rename {old_name} {new_name}
+   ```
 
-- Restore the manifest from `manifest_backup` (write it back to disk)
+   The helper preserves `active_version`, `versions` map, and all fields, then writes the manifest atomically via temp + rename. If the manifest does NOT contain `exports.{old_name}` (the skill was on disk but never exported), skip the invocation — the manifest has nothing to change.
+
+**Rollback on helper non-zero exit:**
+
+- Restore the manifest from `manifest_backup` via `{atomicWriteHelper} write {skills_output_folder}/.export-manifest.json` (re-pipe the JSON-serialized backup)
 - `rm -rf {new_skill_group}` and `rm -rf {new_forge_group}`
-- Halt with: "**Manifest update failed:** {error}. Restored manifest from backup and rolled back new directories. Old skill is intact."
+- Release the lock: `rm -f "{forge_data_folder}/{old_name}/.skf-rename.lock"`
+- Halt with: "**Manifest update failed:** {captured stderr}. Restored manifest from backup and rolled back new directories. Old skill is intact." HALT (exit code 4, `halt_reason: "manifest-write-failed"`). In headless, emit the error envelope.
 
 Set context flag `manifest_updated = true`.
 
@@ -219,18 +276,15 @@ For each entry in `target_context_files`:
    <!-- SKF:END -->
    ```
 
-7. **Surgical replacement — Regenerate case only:**
-   - Locate the `<!-- SKF:BEGIN` line — preserve everything before it
-   - Locate the `<!-- SKF:END -->` line — preserve everything after it
-   - Replace everything between the markers (inclusive) with the new managed section
-   - Write the file back
+7. **Surgical replacement — atomic, deterministic.** Invoke `{rebuildManagedSectionsHelper}` for the surgical between-marker swap:
 
-8. **Verify:**
-   - Re-read the written file
-   - Confirm both markers are present
-   - Confirm `{old_name}` no longer appears between the markers
-   - Confirm `{new_name}` appears between the markers (if this skill's active version is not deprecated)
-   - Confirm content outside the markers is byte-identical to what was preserved
+   ```bash
+   python3 {rebuildManagedSectionsHelper} {context_file} replace --content "{new_managed_section_text}"
+   ```
+
+   The helper handles marker location, between-marker swap, atomic temp-file + rename, and post-write verification (markers preserved, content outside markers byte-identical). It exits non-zero on any failure with a clear `stderr` reason.
+
+8. **Verify (deferred to helper).** The `replace` action above performs verification internally. Treat any non-zero exit code as a per-file failure (next bullet).
 
 9. **On per-file failure:** record the error against that context file and continue to the next entry. Do not halt the rename on a recoverable per-context-file error — the manifest and filesystem are already consistent; context files can be re-rebuilt later via `[EX] Export Skill`.
 

--- a/src/skf-rename-skill/references/health-check.md
+++ b/src/skf-rename-skill/references/health-check.md
@@ -1,9 +1,11 @@
 ---
-# `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# Note: `shared/health-check.md` resolves relative to the SKF module root
+# ({project-root}/_bmad/skf/ when installed, {project-root}/src/ during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 4: Workflow Health Check
 
@@ -19,4 +21,10 @@ Chain to the shared workflow self-improvement health check at `{nextStepFile}`. 
 
 ## MANDATORY SEQUENCE
 
-Load `{nextStepFile}`, read it fully, then execute it.
+1. **Release the rename lock.** Delete `{forge_data_folder}/{old_name}/.skf-rename.lock` if it still exists (the lock is acquired in select.md §4b and released here as the terminal cleanup). A no-op when `old_name` was never resolved or the lock was already removed by an earlier halt path.
+
+   ```bash
+   rm -f "{forge_data_folder}/{old_name}/.skf-rename.lock"
+   ```
+
+2. Load `{nextStepFile}`, read it fully, then execute it.

--- a/src/skf-rename-skill/references/report.md
+++ b/src/skf-rename-skill/references/report.md
@@ -2,6 +2,8 @@
 nextStepFile: 'health-check.md'
 ---
 
+<!-- Config: communicate in {communication_language}. Render the report block in {document_output_language}. -->
+
 # Step 3: Report Rename Results
 
 ## STEP GOAL:
@@ -71,7 +73,15 @@ Informational: the old name still appears in SKILL.md body text (prose only, non
 
 ### Result Contract
 
-Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/{new_name}/rename-skill-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{skills_output_folder}/{new_name}/rename-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all updated file paths (SKILL.md, metadata.json, context-snippet.md, provenance-map.json) in `outputs`; include `old_name`, `new_name`, and `versions_renamed` in `summary`.
+Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{skills_output_folder}/{new_name}/rename-skill-result-{timestamp}.json` (reuse the activation-stored `{timestamp}`, resolution to seconds) and a copy at `{skills_output_folder}/{new_name}/rename-skill-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include all updated file paths (SKILL.md, metadata.json, context-snippet.md, provenance-map.json) in `outputs`; include `old_name`, `new_name`, and `versions_renamed` in `summary`.
+
+When `{headless_mode}` is true, also emit the single-line envelope on **stdout** before chaining to step 4 (matches the SKILL.md "Result Contract (Headless)" shape):
+
+```
+SKF_RENAME_SKILL_RESULT_JSON: {"status":"success","old_name":"{old_name}","new_name":"{new_name}","versions_renamed":{affected_versions},"manifest_rekeyed":{manifest_rekeyed},"context_files_updated":{context_files_updated},"exit_code":0,"halt_reason":null}
+```
+
+Substitute `{affected_versions}` and `{context_files_updated}` as JSON arrays; `manifest_rekeyed` is the boolean from step 2's context.
 
 ### 2. Chain to Health Check
 

--- a/src/skf-rename-skill/references/select.md
+++ b/src/skf-rename-skill/references/select.md
@@ -3,6 +3,8 @@ nextStepFile: 'execute.md'
 versionPathsKnowledge: 'knowledge/version-paths.md'
 ---
 
+<!-- Config: communicate in {communication_language}. -->
+
 # Step 1: Select Rename Target
 
 ## STEP GOAL:
@@ -40,7 +42,7 @@ Load `{skills_output_folder}/.export-manifest.json` if it exists.
 
 **If the file exists with entries:** Parse JSON and verify `schema_version` is `"2"`. If the manifest is v1 (no `schema_version` field), note this but continue — treat every entry as having a single active version derived from its current state. Store `manifest_exists = true`.
 
-**Hard halt condition:** If the file exists but is malformed (not valid JSON), halt with: "**Export manifest is corrupt** at `{skills_output_folder}/.export-manifest.json` — fix or remove the file before renaming."
+**Hard halt condition:** If the file exists but is malformed (not valid JSON), halt with: "**Export manifest is corrupt** at `{skills_output_folder}/.export-manifest.json` — fix or remove the file before renaming." HALT (exit code 3, `halt_reason: "manifest-corrupt"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with `old_name: null`, `new_name: null`.
 
 ### 3. List Available Skills
 
@@ -54,7 +56,7 @@ For each skill in the manifest's `exports` (if `manifest_exists` and entries exi
 
 Also scan `{skills_output_folder}/` for any top-level directories that are NOT present in the manifest's `exports` object. Record these as "(not in manifest)" — they represent draft or orphaned skills that the rename workflow can also handle. When the manifest is missing or empty, every on-disk skill appears in this category.
 
-**If the combined list is empty** (no manifest entries AND no on-disk skill directories): halt with "**Rename Skill — nothing to rename.** No skills found in `{skills_output_folder}/`. Run `[CS] Create Skill` first."
+**If the combined list is empty** (no manifest entries AND no on-disk skill directories): halt with "**Rename Skill — nothing to rename.** No skills found in `{skills_output_folder}/`. Run `[CS] Create Skill` first." HALT (exit code 3, `halt_reason: "nothing-to-rename"`). In headless mode, emit the error envelope with `old_name: null`, `new_name: null`.
 
 Display the combined list:
 
@@ -70,20 +72,55 @@ Available skills:
 ### 4. Ask Which Skill
 
 "**Which skill would you like to rename?**
-Enter the skill name or its number from the list above."
+Enter the skill name or its number from the list above, or `cancel` / `exit` / `:q` to abort."
 
-Wait for user input. Accept either the numeric index or the skill name (exact match). **GATE [default: use args]** — If `{headless_mode}` and old skill name was provided as argument: select that skill and auto-proceed. If not provided, HALT: "headless mode requires old_name argument."
+Wait for user input. Accept either the numeric index or the skill name (exact match). **GATE [default: use args]** — If `{headless_mode}` and old skill name was provided as argument: select that skill and auto-proceed. If not provided, HALT (exit code 2, `halt_reason: "input-missing"`): "headless mode requires old_name argument." In headless, emit the error envelope.
 
-**If the user's input does not match any listed skill:** Re-display the list and ask again.
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q`: Display "Cancelled — no changes were made." and HALT (exit code 6, `halt_reason: "user-cancelled"`).
+- **If the user's input does not match any listed skill:** Re-display the list and ask again.
 
 Store the selection as `old_name`.
+
+### 4b. Concurrency Guard
+
+Two concurrent rename runs against the same `old_name` would corrupt state mid-copy: one would `rm -rf` the other's freshly-staged new directories, or both would race on the manifest re-key. The lock below catches the common accidental-double-invoke case. It is a **best-effort PID-file guard**, not a held flock — the LLM-driven workflow spans many turn boundaries and no single bash invocation can hold flock across them.
+
+**Mirror this exactly so the guard works the same way every run:**
+
+```bash
+LOCK={forge_data_folder}/{old_name}/.skf-rename.lock
+mkdir -p "$(dirname "$LOCK")"
+
+if [ -f "$LOCK" ]; then
+  HELD_PID=$(head -n1 "$LOCK" 2>/dev/null | awk '{print $1}')
+  if [ -n "$HELD_PID" ] && kill -0 "$HELD_PID" 2>/dev/null; then
+    echo "skf-rename-skill: another rename is in progress (pid=$HELD_PID, started $(awk 'NR==2' "$LOCK" 2>/dev/null))"
+    exit 1
+  fi
+  echo "skf-rename-skill: clearing stale lock from pid=$HELD_PID"
+fi
+
+printf '%s\n%s\n' "$$" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOCK"
+```
+
+**Halt protocol on live-PID collision:**
+
+- Display: `"**Another rename is in progress.** The skill {old_name} is locked by pid={HELD_PID} (started {timestamp from line 2 of the lock file}). Wait for that run to finish, or — if you know that pid is no longer running — delete {LOCK} manually and re-run."`
+- HALT (exit code 5, `halt_reason: "halted-for-concurrent-run"`). In `{headless_mode}`, emit the error envelope per SKILL.md "Result Contract (Headless)" with `old_name: "{old_name}"`, `new_name: null`. **No `headless_decisions[]` entry** — this is a hard halt before any gate fires.
+
+**Release contract:**
+
+- The terminal health-check step (step 4) deletes the lock as its final action.
+- **Every halted-for-\* path in this workflow must delete the lock before exiting** — otherwise the next attempt would see a stale lock from this run. The lock-release is a single `rm -f "$LOCK"` per halt site.
 
 ### 5. Ask for New Name
 
 "**What is the new name for this skill?**
-The new name must be kebab-case: lowercase alphanumeric with hyphens, 1-64 characters, matching the regex `^[a-z][a-z0-9-]*[a-z0-9]$` (single-character names may be a single lowercase letter or digit)."
+The new name must be kebab-case: lowercase alphanumeric with hyphens, 1-64 characters, matching the regex `^[a-z][a-z0-9-]*[a-z0-9]$` (single-character names may be a single lowercase letter or digit). Or type `cancel` / `exit` / `:q` to abort."
 
-Wait for user input. Trim whitespace. **GATE [default: use args]** — If `{headless_mode}` and new_name was provided as argument: use it and auto-proceed through validation. If not provided, HALT: "headless mode requires new_name argument."
+Wait for user input. Trim whitespace. **GATE [default: use args]** — If `{headless_mode}` and new_name was provided as argument: use it and auto-proceed through validation. If not provided, release the lock and HALT (exit code 2, `halt_reason: "input-missing"`): "headless mode requires new_name argument." In headless, emit the error envelope.
+
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q`: release the lock (`rm -f {forge_data_folder}/{old_name}/.skf-rename.lock`), display "Cancelled — no changes were made.", and HALT (exit code 6, `halt_reason: "user-cancelled"`).
 
 Apply the following validations in order:
 
@@ -106,7 +143,7 @@ Apply the following validations in order:
 
    If any collision is detected:
    "**Name collision.** `{new-name}` already exists at: {list the colliding locations}. Pick a different name."
-   Re-ask.
+   Re-ask. In headless mode, instead of re-asking, release the lock and HALT (exit code 5, `halt_reason: "name-collision"`) and emit the error envelope.
 
 Only after all four validations pass, store the input as `new_name`.
 
@@ -129,11 +166,13 @@ registry will still get the original name. Rename is a LOCAL operation only — 
 does not rename anything at the registry.
 ```
 
-Ask: "**Continue anyway?** [Y/N]"
+Ask: "**Continue anyway?** [Y/N] (or `cancel` / `exit` / `:q` to abort)"
 
 Wait for response.
-- **If `N`** or anything other than `Y` → "**Cancelled.** No changes were made." HALT the workflow.
-- **If `Y`** → proceed.
+- **If `N`** (or `cancel` / `exit` / `[X]` / `:q`) → release the lock (`rm -f {forge_data_folder}/{old_name}/.skf-rename.lock`), display "**Cancelled.** No changes were made.", HALT (exit code 6, `halt_reason: "user-cancelled"`).
+- **If `Y`** → proceed. Set `source_authority_override = true`.
+
+**Headless behavior:** If `{headless_mode}` is true AND `{forceSourceAuthorityInHeadless}` is `"true"`, auto-proceed and record `{gate: "source-authority", default_action: "halt", taken_action: "proceed", reason: "force_source_authority_in_headless override"}` in `headless_decisions[]`. Otherwise, release the lock and HALT (exit code 5, `halt_reason: "source-authority-blocked"`) and emit the error envelope — the safe default protects against silent registry-divergence on `published`-tagged skills.
 
 **If `source_authority` is absent, or any value other than `"official"`:** skip the warning and proceed.
 
@@ -193,7 +232,7 @@ Proceed? [Y/N]
 Wait for explicit user response.
 
 - **If `Y`** → proceed to section 9
-- **If `N`** → "**Cancelled.** No changes were made." HALT the workflow
+- **If `N`** (or `cancel` / `exit` / `[X]` / `:q`) → release the lock (`rm -f {forge_data_folder}/{old_name}/.skf-rename.lock`), display "**Cancelled.** No changes were made.", HALT (exit code 6, `halt_reason: "user-cancelled"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with the resolved `old_name` and `new_name`.
 - **Any other input** → re-display the confirmation and ask again
 
 ### 9. Store Decisions in Context

--- a/src/skf-verify-stack/SKILL.md
+++ b/src/skf-verify-stack/SKILL.md
@@ -34,6 +34,7 @@ These rules apply to every step in this workflow:
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`
+- At any interactive prompt, the inputs `cancel`, `exit`, `[X]`, `q`, or `:q` exit cleanly with exit code 6 (`halt_reason: "user-cancelled"`)
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision
 
 ## Stages
@@ -52,17 +53,82 @@ These rules apply to every step in this workflow:
 
 | Aspect | Detail |
 |--------|--------|
-| **Inputs** | architecture_doc_path [required], prd_path [optional] |
+| **Inputs** | architecture_doc_path [required], prd_path [optional], previous_report_path [optional] |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--architecture-doc <path>` (skip step 1 prompt for the required input); `--prd <path>` (skip step 1 prompt for the optional PRD); `--previous-report <path>` (skip step 1 prompt for delta comparison) |
 | **Gates** | step 1: Input Gate [use args] | step 6: Confirm Gate [C] |
-| **Outputs** | `feasibility-report-{projectSlug}-{timestamp}.md` and `feasibility-report-{projectSlug}-latest.md` (copy, not symlink) per `src/shared/references/feasibility-report-schema.md` — with integration verdicts, coverage analysis, recommendations, and evidence sources |
-| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
+| **Outputs** | `feasibility-report-{projectSlug}-{timestamp}.md` and `feasibility-report-{projectSlug}-latest.md` (copy, not symlink) per `src/shared/references/feasibility-report-schema.md` — with integration verdicts, coverage analysis, recommendations, and evidence sources; plus `verify-stack-result-{timestamp}.json` and `verify-stack-result-latest.json` |
+| **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Per-flag args (`--architecture-doc`, `--prd`, `--previous-report`) consumed at the gates that would otherwise prompt. |
+| **Exit codes** | See "Exit Codes" below |
+
+## Exit Codes
+
+Every HARD HALT in this workflow exits with a stable code so headless automators can branch on the failure class without grepping message text:
+
+| Code | Meaning              | Raised by                                                                                    |
+| ---- | -------------------- | -------------------------------------------------------------------------------------------- |
+| 0    | success              | step 7 (terminal)                                                                           |
+| 2    | input-missing / input-invalid | step 1 §1 (headless missing `architecture-doc` arg, or invalid path) → `input-missing`; non-existent file → `input-invalid` |
+| 3    | resolution-failure   | step 1 §2 (`{skills_output_folder}` does not exist or is empty); step 1 §3 (forge_data_folder unconfigured) |
+| 4    | write-failure        | On-Activation §3 pre-flight write probe; step 1 §4 (atomic write of report skeleton failed); step 6 §4b (result-contract write failed) |
+| 5    | state-conflict       | step 1 §3 (fewer than 2 valid skills found — stack requires ≥2); step 1 §1 (`previousReport` resolves to same inode as `{outputFile}`); step 6 §1 (report section order or schemaVersion mismatch — schema-violation) |
+| 6    | user-cancelled       | step 1 §1 prompt cancelled; any prompt that accepted `cancel`/`exit`/`:q`; step 6 menu cancelled |
+| 7    | inventory-unreliable | step 1 §2 (>20% subagent failures or enumerate-stack-skills warnings exceed budget) |
+
+## Result Contract (Headless)
+
+When `{headless_mode}` is true, step 6 emits a single-line JSON envelope on **stdout** before chaining to step 7, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
+
+```
+SKF_VERIFY_STACK_RESULT_JSON: {"status":"success|error","report_path":"…|null","report_latest_path":"…|null","overall_verdict":"…|null","coverage_percentage":0,"recommendation_count":0,"exit_code":0,"halt_reason":null}
+```
+
+`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"skills-folder-missing"`, `"insufficient-skills"`, `"forge-folder-unconfigured"`, `"previous-report-collision"`, `"inventory-unreliable"`, `"schema-violation"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above. `overall_verdict` uses the schema tokens (`FEASIBLE`/`CONDITIONALLY_FEASIBLE`/`NOT_FEASIBLE`).
 
 ## On Activation
 
 1. Load config from `{project-root}/_bmad/skf/config.yaml` and resolve:
-   - `project_name`, `user_name`, `communication_language`
-   - `skills_output_folder`, `forge_data_folder`, `document_output_language`
+   - `project_name`, `user_name`, `communication_language`, `document_output_language`
+   - `skills_output_folder`, `forge_data_folder`, `sidecar_path`
 
-2. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in preferences.yaml. Default: false.
+2. **Compute run-scoped variables** (same place as config so every stage can reference them without re-derivation):
+   - `project_slug` ← slugify `project_name` (lowercase, hyphens only, no unicode, no whitespace)
+   - `timestamp` ← UTC `YYYYMMDD-HHmmss` captured at activation time
+   - These two combine in init.md §4 into `{outputFile}` per the stage frontmatter template, but the values themselves are fixed for the entire workflow run — every later reference to `{outputFile}` resolves consistently. (Computing them here resolves an order-of-operations bug where the §1 §3 inode-collision check referenced `{outputFile}` before `{project_slug}` and `{timestamp}` were defined.)
 
-3. Load, read the full file, and then execute `references/init.md` to begin the workflow.
+3. **Resolve `{headless_mode}`**: true if `--headless` or `-H` was passed as an argument, or if `headless_mode: true` in `{sidecar_path}/preferences.yaml`. Default: false.
+
+4. **Resolve workflow customization.** Run:
+
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_customization.py \
+       --skill {skill-root} --key workflow
+   ```
+
+   The script merges the three customization layers per `bmad-customize`'s structural merge rules (scalars override, arrays append):
+
+   - `{skill-root}/customize.toml` — bundled defaults
+   - `_bmad/custom/<skill-name>.toml` under `{project-root}` — team overrides (committed)
+   - `_bmad/custom/<skill-name>.user.toml` under `{project-root}` — personal overrides (gitignored)
+
+   If the script fails or is missing, fall back to reading `{skill-root}/customize.toml` directly — the bundled defaults are an empty string for each path scalar.
+
+   Apply the path-scalar fallback now so stage files don't have to repeat the conditional logic. For each of the four scalars, if the merged value is empty or absent, use the bundled default:
+
+   - `{reportTemplatePath}` ← `workflow.report_template_path` if non-empty, else `assets/feasibility-report-template.md`
+   - `{integrationRulesPath}` ← `workflow.integration_rules_path` if non-empty, else `references/integration-verification-rules.md`
+   - `{coveragePatternsPath}` ← `workflow.coverage_patterns_path` if non-empty, else `references/coverage-patterns.md`
+   - `{outputFolderPath}` ← `workflow.output_folder_path` if non-empty, else `{forge_data_folder}`
+
+   Stash all four as workflow-context variables. Stage files reference them directly — no conditional at the usage site. Empty-string overrides cleanly fall through to the bundled default.
+
+5. **Pre-flight write probe.** Verify `{outputFolderPath}` is writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces at init.md §4 atomic write — by then the user has already gone through the input prompts:
+
+   ```bash
+   mkdir -p "{outputFolderPath}" && \
+     printf 'probe' > "{outputFolderPath}/.skf-write-probe" && \
+     rm "{outputFolderPath}/.skf-write-probe"
+   ```
+
+   On any non-zero exit: HALT (exit code 4, `halt_reason: "write-failed"`). In headless mode, emit the error envelope per **Result Contract (Headless)** with `report_path: null`, `report_latest_path: null`, `overall_verdict: null`.
+
+6. Load, read the full file, and then execute `references/init.md` to begin the workflow.

--- a/src/skf-verify-stack/customize.toml
+++ b/src/skf-verify-stack/customize.toml
@@ -1,0 +1,50 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for skf-verify-stack.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (uv probe, config load).
+# Overrides append. Use for org-wide pre-flight checks (auth, network,
+# compliance) that must precede any verification work.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the first stage executes.
+# Overrides append. Use for context loads or banner customization that
+# should run once activation completes successfully.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (verification standards, evidence-citation rules, house-style verdict
+# language). Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Verdict citations must include file:line spans."
+#   - a file reference prefixed with `file:`, e.g.
+#     "file:{project-root}/docs/verify-policy.md" (globs supported; file
+#     contents are loaded and treated as facts).
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Optional asset overrides ---
+#
+# Lift the canonical asset paths so orgs can substitute house-style copies
+# without forking the skill. Empty string = use the bundled default.
+
+report_template_path = ""
+integration_rules_path = ""
+coverage_patterns_path = ""
+
+# Override the destination directory for the feasibility report. Empty =
+# use {forge_data_folder} from config.yaml. Useful for orgs that want
+# verification artifacts to land outside the per-skill forge tree.
+
+output_folder_path = ""

--- a/src/skf-verify-stack/references/coverage.md
+++ b/src/skf-verify-stack/references/coverage.md
@@ -1,11 +1,13 @@
 ---
 nextStepFile: 'integrations.md'
-coveragePatternsData: 'references/coverage-patterns.md'
+coveragePatternsData: '{coveragePatternsPath}'
 feasibilitySchemaRef: 'src/shared/references/feasibility-report-schema.md'
 atomicWriteScript: '{project-root}/src/shared/scripts/skf-atomic-write.py'
-outputFile: '{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md'
-outputFileLatest: '{forge_data_folder}/feasibility-report-{project_slug}-latest.md'
+outputFile: '{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md'
+outputFileLatest: '{outputFolderPath}/feasibility-report-{project_slug}-latest.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Append the Coverage Analysis section to the report in {document_output_language}. -->
 
 # Step 2: Technology Coverage Analysis
 

--- a/src/skf-verify-stack/references/health-check.md
+++ b/src/skf-verify-stack/references/health-check.md
@@ -1,9 +1,11 @@
 ---
-# `shared/health-check.md` resolves relative to the SKF module root
-# (`_bmad/skf/` when installed, `src/` during development), NOT relative
-# to this step file.
+# Note: `shared/health-check.md` resolves relative to the SKF module root
+# ({project-root}/_bmad/skf/ when installed, {project-root}/src/ during
+# development), NOT relative to this step file.
 nextStepFile: 'shared/health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. -->
 
 # Step 7: Workflow Health Check
 

--- a/src/skf-verify-stack/references/init.md
+++ b/src/skf-verify-stack/references/init.md
@@ -1,11 +1,27 @@
 ---
 nextStepFile: 'coverage.md'
-reportTemplate: 'assets/feasibility-report-template.md'
 feasibilitySchemaRef: 'src/shared/references/feasibility-report-schema.md'
 atomicWriteScript: '{project-root}/src/shared/scripts/skf-atomic-write.py'
-outputFile: '{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md'
-outputFileLatest: '{forge_data_folder}/feasibility-report-{project_slug}-latest.md'
+# {outputFile} and {outputFileLatest} resolve from the activation-stored
+# {project_slug}, {timestamp}, and {outputFolderPath} variables (set in
+# SKILL.md On Activation §2 + §4). The activation-stored values are
+# fixed for the entire run, so every later reference sees the same
+# filename — no order-of-operations bug.
+outputFile: '{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md'
+outputFileLatest: '{outputFolderPath}/feasibility-report-{project_slug}-latest.md'
+# Resolve `{enumerateStackSkillsHelper}` by probing
+# `{enumerateStackSkillsProbeOrder}` in order (installed SKF module path
+# first, src/ dev-checkout fallback); first existing path wins. §2 calls
+# it for the deterministic skills inventory (cascade-resolved exports,
+# metadata-hash for change-detection, confidence-tier mapping). HALT if
+# neither candidate exists — falls through to LLM-driven subagent fan-out
+# only as graceful degradation, see §2.
+enumerateStackSkillsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-enumerate-stack-skills.py'
+  - '{project-root}/src/shared/scripts/skf-enumerate-stack-skills.py'
 ---
+
+<!-- Config: communicate in {communication_language}. Initialize the feasibility report skeleton in {document_output_language}. -->
 
 # Step 1: Initialize Verification
 
@@ -24,19 +40,23 @@ Load all generated skills from the skills output folder, accept the architecture
 
 ### 1. Accept Input Documents
 
-"**Verify Stack — Feasibility Analysis**
+"**Verify Stack — Feasibility Analysis** (read-only — never modifies your skills, architecture doc, or PRD).
 
-Please provide the following:
+If you meant to *generate* skills first, type `cancel` and run `[CS] Create Skill` or `[QS] Quick Skill`. Otherwise, please provide the following:
 1. **Architecture document path** (REQUIRED) — your project's architecture doc
 2. **PRD or vision document path** (OPTIONAL) — for requirements coverage analysis
-3. **Previous feasibility report path** (OPTIONAL) — for delta comparison with a prior run (provide a backup copy)"
+3. **Previous feasibility report path** (OPTIONAL) — for delta comparison with a prior run (provide a backup copy)
 
-Wait for user input. **GATE [default: use args]** — If `{headless_mode}` and architecture doc path was provided as argument: use that path and auto-proceed, log: "headless: using provided architecture path".
+Or type `cancel` / `exit` / `:q` at any prompt to abort cleanly."
+
+Wait for user input. **GATE [default: use args]** — If `{headless_mode}` and `--architecture-doc` was provided: use that path and auto-proceed, log: "headless: using provided architecture path". If `--prd` and/or `--previous-report` were provided, consume them at the corresponding sub-validations below. If `--architecture-doc` is absent in headless: HALT (exit code 2, `halt_reason: "input-missing"`) and emit the error envelope.
+
+- If the user enters `cancel`, `exit`, `[X]`, `q`, or `:q` at any sub-prompt below: Display "Cancelled — no analysis was performed." and HALT (exit code 6, `halt_reason: "user-cancelled"`).
 
 **Validate architecture document:**
 - Confirm the file exists and is readable
 - If missing or unreadable → "Architecture document not found at `{path}`. Provide a valid path."
-- HALT until a valid architecture document is provided
+- HALT (exit code 2, `halt_reason: "input-invalid"`) if the user cannot provide a valid path. In headless, emit the error envelope per SKILL.md "Result Contract (Headless)" immediately.
 
 **Validate PRD document (if provided):**
 - Confirm the file exists and is readable
@@ -45,77 +65,45 @@ Wait for user input. **GATE [default: use args]** — If `{headless_mode}` and a
 
 **Validate previous report (if provided):**
 - Confirm the file exists and is readable
-- **Collision check:** Compare both the provided path and `{outputFile}` via `(st_dev, st_ino)` tuples obtained from `stat(2)` on each path (do not rely on absolute-path string equality — symlinks, bind mounts, and case-insensitive filesystems can defeat string comparison; the `(st_dev, st_ino)` comparison is the canonical kernel-level equivalent of `os.path.realpath`-based equality and is strictly stronger because it also catches hardlinks). If `{outputFile}` does not yet exist, resolve its parent via `realpath`, stat that directory, and combine `(st_dev, parent_ino, basename)` for comparison. If the two paths resolve to the same inode, warn: "The previous report path points to the same inode as the new report. This file will be overwritten during this run. Provide a path to a backup copy, or leave empty to skip delta comparison." HALT until resolved.
+- **Collision check:** Resolve `{outputFile}` from the activation-stored `{outputFolderPath}`, `{project_slug}`, and `{timestamp}` (all three computed in SKILL.md On Activation §2 + §4 — they are fixed for the entire run). Then compare both the provided path and `{outputFile}` via `(st_dev, st_ino)` tuples obtained from `stat(2)` on each path (do not rely on absolute-path string equality — symlinks, bind mounts, and case-insensitive filesystems can defeat string comparison; the `(st_dev, st_ino)` comparison is the canonical kernel-level equivalent of `os.path.realpath`-based equality and is strictly stronger because it also catches hardlinks). If `{outputFile}` does not yet exist, resolve its parent via `realpath`, stat that directory, and combine `(st_dev, parent_ino, basename)` for comparison. If the two paths resolve to the same inode, warn: "The previous report path points to the same inode as the new report. This file will be overwritten during this run. Provide a path to a backup copy, or leave empty to skip delta comparison." HALT (exit code 5, `halt_reason: "previous-report-collision"`) until resolved. In headless, emit the error envelope.
 - If missing → "Previous report not found at `{path}`. Proceeding without delta comparison."
 - Store as `previousReport: {path}` (or empty string if not provided)
 
 ### 2. Scan Skills Folder
 
 **Pre-flight — skills folder existence:**
-- If `{skills_output_folder}` does not exist on disk: HALT with "**Cannot proceed.** `{skills_output_folder}` does not exist — run **[SF] Setup Forge** to initialize the forge, then generate skills with [CS] or [QS]."
-- If `{skills_output_folder}` exists but is empty (no subdirectories at all): HALT with "**Cannot proceed.** `{skills_output_folder}` contains 0 skills. Generate skills with [CS] Create Skill or [QS] Quick Skill, then re-run [VS]."
+- If `{skills_output_folder}` does not exist on disk: HALT (exit code 3, `halt_reason: "skills-folder-missing"`) with "**Cannot proceed.** `{skills_output_folder}` does not exist — run **[SF] Setup Forge** to initialize the forge, then generate skills with [CS] or [QS]." In headless, emit the error envelope.
+- If `{skills_output_folder}` exists but is empty (no subdirectories at all): HALT (exit code 3, `halt_reason: "skills-folder-missing"`) with "**Cannot proceed.** `{skills_output_folder}` contains 0 skills. Generate skills with [CS] Create Skill or [QS] Quick Skill, then re-run [VS]." In headless, emit the error envelope.
 
-Read the `{skills_output_folder}` directory. Skills use a version-nested directory structure (see `knowledge/version-paths.md`).
+**Resolve `{enumerateStackSkillsHelper}`** from `{enumerateStackSkillsProbeOrder}`; first existing path wins.
 
-**Version-aware skill discovery:**
-1. Read `{skills_output_folder}/.export-manifest.json` if it exists. For each skill in `exports`, use `active_version` to resolve `{skill_package}` = `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/`
-2. For any subdirectory not covered by the manifest, check for an `active` symlink at `{skills_output_folder}/{dir_name}/active` — resolve to `{skill_group}/active/{dir_name}/`
-3. Fall back to flat path `{skills_output_folder}/{dir_name}/` for unmigrated skills
+**Primary path — deterministic enumeration via shared helper:**
 
-For each resolved skill package, check for the presence of `SKILL.md`, `metadata.json`, and `bmad-skill-manifest.yaml`. If `bmad-skill-manifest.yaml` is missing in the resolved package, log "Skipping `{dir_name}` — missing bmad-skill-manifest.yaml" and exclude from inventory (do not spawn a subagent).
-
-**Non-symlink `active` check:** When resolving via the `active` symlink pattern (case 2 above), perform an explicit `is_symlink` check on `{skills_output_folder}/{dir_name}/active`. If the path exists but is NOT a symlink, log "Skipping `{dir_name}` — `active` is not a symlink (repair with [SKF-update-skill])" and treat as missing.
-
-**Orphan-versions detection:** For any `{skills_output_folder}/{dir_name}/` that contains subdirectories matching semver (`^\d+\.\d+\.\d+`) but has no `active` symlink at all, emit: "**Error:** Skill `{dir_name}` has versions `{list_of_version_dirs}` but no `active` symlink — run [SKF-update-skill] to repair before re-running [VS]." Exclude the skill from inventory; count it toward the failure budget for the run summary.
-
-<!-- Subagent delegation: read metadata.json files in parallel, return compact JSON -->
-
-**Read all metadata.json files in parallel using subagents.** Launch up to **8 subagents concurrently** (batch larger inventories in rounds of 8 — the 8-way cap keeps the aggregate token window for the parent manageable while still parallelizing most typical stack sizes; tune in a future minor if inventories routinely exceed ~40 skills). Each subagent receives one resolved skill package path and MUST:
-1. Read `{skill_package}/metadata.json`
-2. ONLY return this compact JSON — no prose, no extra commentary:
-
-```json
-{
-  "skill_name": "...",
-  "language": "...",
-  "confidence_tier": "...",
-  "exports_documented": 0,
-  "source_repo": "...",
-  "source_root": "..."
-}
+```bash
+python3 {enumerateStackSkillsHelper} enumerate {skills_output_folder}
 ```
 
-Parent collects all subagent JSON summaries. Fields map directly from metadata.json:
-- `skill_name` ← `name`
-- `language` ← `language`
-- `confidence_tier` ← `confidence_tier`
-- `exports_documented` ← `stats.exports_documented`
-- `source_repo` ← `source_repo` (or empty string if absent)
-- `source_root` ← `source_root` (or empty string if absent)
+The helper walks `{skills_output_folder}`, reads each `metadata.json`, applies the exports cascade (metadata → references/ → SKILL.md prose), maps `confidence_tier` (T1/T2/T1-low), captures stack-skill cycles via `composes:`, and emits structured JSON with one entry per skill plus a top-level `warnings[]` array. Cache the result as `skill_inventory` (used by §3, §4, §5, and the integrations + coverage stages).
 
-**Subagent JSON schema validation:** For each subagent response, require keys `skill_name`, `language`, and an integer `exports_documented`. Wrap each JSON parse in try/catch. On parse failure or missing required key, log "Skipping `{dir_name}` — metadata.json unparseable (skill may be under active modification)" and exclude from the inventory. If more than **20%** (the failure-budget threshold — chosen so a single malformed skill in a small 3-5 skill inventory does not trip the halt, while larger inventories still halt before evidence quality collapses) of subagent calls fail schema validation, HALT the workflow with: "Inventory scan unreliable — {failed_count}/{total_count} skills returned malformed metadata. Re-run [VS] after skills stabilize."
+Each helper-emitted entry includes: `skill_name`, `version`, `language`, `confidence_tier`, `exports` (cascade-resolved), `source_repo`, `source_root`, plus a `metadata_hash` for change-detection across runs. The helper's `warnings[]` carries per-skill skip reasons (missing manifest, malformed JSON, non-symlink `active`, orphan-versions, schema-version violations).
 
-**Capture mtime:** For each accepted skill, also record `metadata.json`'s mtime (via `stat`) into the inventory as `metadata_mtime`. Step-03 will re-verify this to detect mid-run modifications.
+**Failure-budget guard:** If `len(warnings) / len(skill_inventory) + len(warnings) > 0.20` (the same 20% threshold chosen so a single malformed skill in a small 3-5 skill inventory does not trip the halt), HALT (exit code 7, `halt_reason: "inventory-unreliable"`) with: "Inventory scan unreliable — {len(warnings)}/{total} skills returned malformed metadata or skip warnings. Re-run [VS] after skills stabilize." In headless, emit the error envelope.
 
-**metadata_schema_version check:** For each accepted skill, read `metadata_schema_version` from `metadata.json`. If missing or below minimum (`1.0`), log "Skipping `{dir_name}` — metadata_schema_version `{value}` below minimum `1.0`. Re-run [SKF-update-skill] to migrate." and exclude from the inventory.
+**Capture mtime:** For each accepted skill in `skill_inventory`, also record `metadata.json`'s mtime via `stat` into the entry as `metadata_mtime`. Step-03 will re-verify this to detect mid-run modifications.
 
-**Build a skill inventory** as an internal list of all loaded skills with the fields above.
-
-**If a resolved skill package lacks SKILL.md or metadata.json:**
-- Log: "Skipping `{dir_name}` — missing SKILL.md or metadata.json"
-- Do not include in inventory
+**Fallback path — graceful degradation when the helper is unavailable:** If `{enumerateStackSkillsHelper}` has no existing candidate (e.g. partial installation), fall through to the LLM-driven subagent fan-out: launch up to **8 subagents concurrently**, each reading one resolved skill package's `metadata.json` and returning the same JSON shape the helper would emit. Apply the same 20% failure-budget guard. This path exists so verify-stack survives a missing helper, but the deterministic helper is preferred — it has a tested cascade resolver, captures the metadata-hash, and surfaces every skip reason in `warnings[]` consistently.
 
 ### 3. Validate Minimum Requirements
 
 **Check skill count:**
 - At least 2 valid skills must exist (a stack requires multiple libraries)
 - If fewer than 2 → "**Cannot proceed.** Only {count} skill(s) found in `{skills_output_folder}`. A stack requires at least 2 skills. Generate more skills with [CS] Create Skill or [QS] Quick Skill, then re-run [VS]."
-- HALT workflow
+- HALT (exit code 5, `halt_reason: "insufficient-skills"`). In headless, emit the error envelope.
 
 **Check forge_data_folder:**
 - Verify `forge_data_folder` was resolved from config.yaml and is non-empty
 - If undefined or empty → "**Cannot proceed.** `forge_data_folder` is not configured in config.yaml. Re-run [SF] Setup Forge to initialize."
-- HALT workflow
+- HALT (exit code 3, `halt_reason: "forge-folder-unconfigured"`). In headless, emit the error envelope.
 
 **Check architecture document:**
 - Confirm it was loaded successfully in section 1
@@ -125,13 +113,13 @@ Parent collects all subagent JSON summaries. Fields map directly from metadata.j
 
 This skill is the PRODUCER of the feasibility report schema defined in `{feasibilitySchemaRef}`. All outputs MUST conform to that schema — in particular: `schemaVersion: "1.0"`, the defined verdict token set (`Verified|Plausible|Risky|Blocked`; overall `FEASIBLE|CONDITIONALLY_FEASIBLE|NOT_FEASIBLE`), the filename pattern, and the section-heading order.
 
-**Compute filename variables:**
-- `project_slug`: slugify `project_name` (lowercase, hyphens only, no unicode, no whitespace)
-- `timestamp`: UTC `YYYYMMDD-HHmmss` captured at step 1 start
-- `outputFile` resolves to `{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md`
-- `outputFileLatest` resolves to `{forge_data_folder}/feasibility-report-{project_slug}-latest.md` (a copy, not a symlink — per schema)
+**Filename variables** (already computed at activation — do not re-derive):
+- `project_slug`: set in SKILL.md On Activation §2 from `project_name`
+- `timestamp`: set in SKILL.md On Activation §2 (UTC `YYYYMMDD-HHmmss`, fixed for the run)
+- `outputFile` resolves to `{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md` per the stage frontmatter template
+- `outputFileLatest` resolves to `{outputFolderPath}/feasibility-report-{project_slug}-latest.md` (a copy, not a symlink — per schema)
 
-**Load** `{reportTemplate}` and stage the initial content.
+**Load** `{reportTemplatePath}` (the customize-aware template path resolved in SKILL.md On Activation §4) and stage the initial content.
 
 **Populate frontmatter (per shared schema — required keys):**
 - `schemaVersion: "1.0"`
@@ -152,6 +140,8 @@ This skill is the PRODUCER of the feasibility report schema defined in `{feasibi
 - `stepsCompleted: ['init']`
 
 **Atomic write:** Pipe the staged content through `python3 {atomicWriteScript} write --target {outputFile}` and then again with `--target {outputFileLatest}`. Both writes use the same staged content. Do NOT use `rm`+rewrite; do NOT create a symlink for the `-latest` copy.
+
+On any non-zero exit from either write: HALT (exit code 4, `halt_reason: "write-failed"`) and emit the error envelope per SKILL.md "Result Contract (Headless)" with `report_path: null`, `report_latest_path: null`, `overall_verdict: null`.
 
 ### 5. Display Initialization Summary
 

--- a/src/skf-verify-stack/references/integrations.md
+++ b/src/skf-verify-stack/references/integrations.md
@@ -1,12 +1,14 @@
 ---
 nextStepFile: 'requirements.md'
-integrationRulesData: 'references/integration-verification-rules.md'
-coveragePatternsData: 'references/coverage-patterns.md'
+integrationRulesData: '{integrationRulesPath}'
+coveragePatternsData: '{coveragePatternsPath}'
 feasibilitySchemaRef: 'src/shared/references/feasibility-report-schema.md'
 atomicWriteScript: '{project-root}/src/shared/scripts/skf-atomic-write.py'
-outputFile: '{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md'
-outputFileLatest: '{forge_data_folder}/feasibility-report-{project_slug}-latest.md'
+outputFile: '{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md'
+outputFileLatest: '{outputFolderPath}/feasibility-report-{project_slug}-latest.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Append the Integration Verdicts section to the report in {document_output_language}. -->
 
 # Step 3: Integration Verification
 

--- a/src/skf-verify-stack/references/report.md
+++ b/src/skf-verify-stack/references/report.md
@@ -1,10 +1,16 @@
 ---
-outputFile: '{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md'
-outputFileLatest: '{forge_data_folder}/feasibility-report-{project_slug}-latest.md'
+# {outputFile} and {outputFileLatest} resolve from the activation-stored
+# {project_slug}, {timestamp}, and {outputFolderPath} variables (set in
+# SKILL.md On Activation §2 + §4) — same template as init.md frontmatter
+# so every stage sees the same path.
+outputFile: '{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md'
+outputFileLatest: '{outputFolderPath}/feasibility-report-{project_slug}-latest.md'
 feasibilitySchemaRef: 'src/shared/references/feasibility-report-schema.md'
 atomicWriteScript: '{project-root}/src/shared/scripts/skf-atomic-write.py'
 nextStepFile: 'health-check.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Render the user-facing summary in {document_output_language}. -->
 
 # Step 6: Present Report
 
@@ -25,11 +31,11 @@ Present the complete feasibility report to the user. Display the overall verdict
 
 Read the entire `{outputFile}` to have all data available for presentation.
 
-Verify all expected sections are present in order per `{feasibilitySchemaRef}`: `## Executive Summary`, `## Coverage Analysis`, `## Integration Verdicts`, `## Recommendations`, `## Evidence Sources`. If any section is missing or out of order, HALT and report the schema violation — do not display partial results.
+Verify all expected sections are present in order per `{feasibilitySchemaRef}`: `## Executive Summary`, `## Coverage Analysis`, `## Integration Verdicts`, `## Recommendations`, `## Evidence Sources`. If any section is missing or out of order, HALT (exit code 5, `halt_reason: "schema-violation"`) and report the schema violation — do not display partial results. In headless, emit the error envelope per SKILL.md "Result Contract (Headless)" with `report_path: "{outputFile}"`, `overall_verdict: null`.
 
 **Extract metrics from `{outputFile}` frontmatter** (per shared schema in `{feasibilitySchemaRef}`): `skillsAnalyzed`, `coveragePercentage`, `pairsVerified` (as `verified_count`), `pairsPlausible` (as `plausible_count`), `pairsRisky` (as `risky_count`), `pairsBlocked` (as `blocked_count`), `requirementsFulfilled` (as `fulfilled_count`), `requirementsPartial` (as `partial_count`), `requirementsNotAddressed` (as `not_addressed_count`), `requirementsPass`, `overallVerdict`, and `recommendationCount`. Use these mapped display names in the summary table and next steps below.
 
-**Schema guard:** Verify `schemaVersion == "1.0"` in the frontmatter. If mismatched, HALT with "Report frontmatter schemaVersion `{value}` does not match producer schema `1.0` — report was corrupted between steps. Re-run [VS]." (Producer never proceeds past a schema mismatch.)
+**Schema guard:** Verify `schemaVersion == "1.0"` in the frontmatter. If mismatched, HALT (exit code 5, `halt_reason: "schema-violation"`) with "Report frontmatter schemaVersion `{value}` does not match producer schema `1.0` — report was corrupted between steps. Re-run [VS]." (Producer never proceeds past a schema mismatch.) In headless, emit the error envelope.
 
 ### 2. Present Summary
 
@@ -124,7 +130,15 @@ Based on the overall verdict, present the appropriate recommendation:
 
 Write the result contract per `shared/references/output-contract-schema.md`: the per-run record at `{forge_data_folder}/verify-stack-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{forge_data_folder}/verify-stack-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include the feasibility report path (both `{outputFile}` and `{outputFileLatest}`) in `outputs`; include `overallVerdict` (`FEASIBLE` / `CONDITIONALLY_FEASIBLE` / `NOT_FEASIBLE`), `coveragePercentage`, and `recommendationCount` in `summary` — use the case-sensitive schema tokens.
 
-Write both JSON files through `python3 {atomicWriteScript} write --target ...` to avoid partial-write corruption.
+Write both JSON files through `python3 {atomicWriteScript} write --target ...` to avoid partial-write corruption. On any non-zero exit: HALT (exit code 4, `halt_reason: "write-failed"`) and emit the error envelope.
+
+When `{headless_mode}` is true, also emit the single-line envelope on **stdout** before chaining to step 7 (matches the SKILL.md "Result Contract (Headless)" shape):
+
+```
+SKF_VERIFY_STACK_RESULT_JSON: {"status":"success","report_path":"{outputFile}","report_latest_path":"{outputFileLatest}","overall_verdict":"{overallVerdict}","coverage_percentage":{coveragePercentage},"recommendation_count":{recommendationCount},"exit_code":0,"halt_reason":null}
+```
+
+`{overallVerdict}` uses the schema tokens (`FEASIBLE` / `CONDITIONALLY_FEASIBLE` / `NOT_FEASIBLE`).
 
 **Result-contract ordering:** The result contract is written exactly once on the first entry to step 6 (the `[X] Exit verification` path). Re-walks of the report via the `[R] Review full report` menu option do NOT regenerate it — the contract captures the run, not the presentation loop. If the user selects `[R]` repeatedly before exiting, the single on-disk contract written on first entry remains authoritative.
 

--- a/src/skf-verify-stack/references/requirements.md
+++ b/src/skf-verify-stack/references/requirements.md
@@ -2,9 +2,11 @@
 nextStepFile: 'synthesize.md'
 feasibilitySchemaRef: 'src/shared/references/feasibility-report-schema.md'
 atomicWriteScript: '{project-root}/src/shared/scripts/skf-atomic-write.py'
-outputFile: '{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md'
-outputFileLatest: '{forge_data_folder}/feasibility-report-{project_slug}-latest.md'
+outputFile: '{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md'
+outputFileLatest: '{outputFolderPath}/feasibility-report-{project_slug}-latest.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Append the Requirements Coverage section to the report in {document_output_language}. -->
 
 # Step 4: Requirements Coverage
 

--- a/src/skf-verify-stack/references/synthesize.md
+++ b/src/skf-verify-stack/references/synthesize.md
@@ -2,9 +2,11 @@
 nextStepFile: 'report.md'
 feasibilitySchemaRef: 'src/shared/references/feasibility-report-schema.md'
 atomicWriteScript: '{project-root}/src/shared/scripts/skf-atomic-write.py'
-outputFile: '{forge_data_folder}/feasibility-report-{project_slug}-{timestamp}.md'
-outputFileLatest: '{forge_data_folder}/feasibility-report-{project_slug}-latest.md'
+outputFile: '{outputFolderPath}/feasibility-report-{project_slug}-{timestamp}.md'
+outputFileLatest: '{outputFolderPath}/feasibility-report-{project_slug}-latest.md'
 ---
+
+<!-- Config: communicate in {communication_language}. Append the Executive Summary, synthesized verdict, and Recommendations to the report in {document_output_language}. -->
 
 # Step 5: Synthesize Verdict
 


### PR DESCRIPTION
## Summary

Brings the 5 remaining SKF workflows — **VS** (Verify Stack), **RA** (Refine Architecture), **EX** (Export Skill), **RS** (Rename Skill), **DS** (Drop Skill) — to Foundation parity with the Core- and Feature-elevated peers.

This is a single Foundation+Determinism pass merging two layers of work that the Feature cycle ran as separate PRs:
- Foundation patterns (customize.toml + resolver, Exit Codes, Result Contract, language headers, cancel-line, write-probe, Broken-bug fixes)
- Determinism wiring (5 skills × 1-3 existing shared scripts each — total of 9 high-severity helper-bypass findings closed)

The merge is safe because the script wiring touches the same files Foundation touches (per-skill SKILL.md frontmatter, On-Activation, references/execute.md), so doing both in one pass avoids merge conflicts and duplicate file touches.

## Per-skill summary

| Skill | Customize scalars | Wired shared scripts | Notable Broken-bug fixes |
|---|---|---|---|
| **VS** | 4 (report/integration/coverage/output paths) | `skf-enumerate-stack-skills` | `sidecar_path` resolution; `{outputFile}` order-of-ops bug |
| **RA** | 2 (refinement-rules path, output folder) | `skf-enumerate-stack-skills` | `vs_report_path` Invocation Contract gap |
| **EX** | 3 (managed-section format, snippet format, manifest) | `skf-rebuild-managed-sections` + `skf-manifest-ops` + `skf-atomic-write` | bare-bmad in health-check |
| **RS** | 3 (force-source-authority, unknown-IDE defaults) | `skf-update-active-symlink` + `skf-rebuild-managed-sections` + `skf-atomic-write` + `skf-manifest-ops rename` | bare-bmad; PID concurrency lock added |
| **DS** | 4 (default-mode, forbid-purge, unknown-IDE defaults) | `skf-manifest-ops` + `skf-rebuild-managed-sections` | bare-bmad; `forbid_purge_in_headless` safety scalar |

All 5 skills now ship a `## Exit Codes` table, a `## Result Contract (Headless)` section with per-skill envelope (`SKF_VERIFY_STACK_RESULT_JSON` / `SKF_REFINE_ARCHITECTURE_RESULT_JSON` / `SKF_EXPORT_RESULT_JSON` / `SKF_RENAME_SKILL_RESULT_JSON` / `SKF_DROP_SKILL_RESULT_JSON`), HTML-comment language headers across `references/*.md`, universal cancel-line affordance on every interactive prompt, and a pre-flight write probe at On-Activation.

## Destructive-op safety

- **DS** — `forbid_purge_in_headless` customize scalar HALTs at activation if a headless run requests purge mode (exit 6, `headless-purge-forbidden`).
- **RS** — `select.md §4b` PID-file concurrency lock at `{forge_data_folder}/{old_name}/.skf-rename.lock`. Released by terminal health-check and every documented halt path.
- **RS** — source-authority="official" warning HALTs in headless by default (exit 5, `source-authority-blocked`) unless `force_source_authority_in_headless = "true"`.

## Test plan

- [x] `npm test` passes (pre-commit hook — 12 sub-suites green: schemas, install, cli, workflow, python, knowledge, validate-schemas, validate-skills, validate-refs, lint, lint:md, format:check)
- [x] `tools/validate-file-refs.js --strict` — 0 broken references, 0 absolute path leaks
- [x] `tools/validate-skills.js --strict` — 0 findings across 15 skills
- [x] Path-standards scanner on each elevated skill matches `skf-brief-skill` (Excellent peer) — 2 high false-positives in customize-resolver prose only (`_bmad/custom/<skill-name>.toml` text), same as the peer
- [x] Smoke-run each elevated workflow interactively to confirm no regressions in conversational prompts
- [x] Smoke-run each elevated workflow in `--headless` mode to confirm Result Contract envelope shape

## Tightening follow-up

A second PR (`refactor/skf-arch-utility-mgmt-elevation-tightening`) will close the remaining low-severity items from the Phase A quality scans: drop redundant LLM-native workflow rules, document Conventions block exceptions (knowledge/ path resolution, cross-skill data coupling), structural carves on EX `update-context.md` (354 lines → ~210) and EX `load-skill.md` (255 → ~180), `--dry-run` flag wiring on DS/RS, and various polish items.

Substantial deferrals (EX multi-context-file orphan probe correctness, EX distribution-instruction customization, DS resume protocol, RS source-authority audit log) will be tracked in a follow-up issue mirroring the pattern of the Feature elevation tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)