### PR TITLE
refactor(skf): tighten Architecture / Utility / Management workflows → Excellent

### DIFF
--- a/src/skf-drop-skill/SKILL.md
+++ b/src/skf-drop-skill/SKILL.md
@@ -16,6 +16,8 @@ Drops a specific skill version or an entire skill, either as a soft deprecation 
 - `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives, if present).
 - `{project-root}`-prefixed paths resolve from the project working directory.
 - `{skill-name}` resolves to the skill directory's basename.
+- **Module-level path exception:** paths starting with `knowledge/` or `shared/` resolve from the SKF module root, not the skill root — install layout puts both at `{project-root}/_bmad/skf/`. The `versionPathsKnowledge: 'knowledge/version-paths.md'` frontmatter scalar in stage files uses this convention; same for `shared/health-check.md` chained from the terminal step.
+- **Cross-skill data coupling:** `references/execute.md` reads `skf-export-skill/assets/managed-section-format.md` for the IDE→context-file mapping table and the four-case (Create / Append / Regenerate / Malformed) logic when rebuilding context files. Drop-skill assumes that asset is present at install time and that its semantics are stable across the two skills' versions.
 
 ## Role
 
@@ -49,7 +51,7 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | skill_name [required], mode (deprecate/purge) [required], version (all/specific) [required] |
-| **Flags** | `--headless` / `-H` (auto-resolve all gates) |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--dry-run` (run selection + display the §10 confirmation block, then exit with `status="dry-run"` — no manifest mutation, no file deletion). Useful for "show me what this would touch before I commit." |
 | **Gates** | step 1: Input Gate [use args], Confirm Gate [Y] |
 | **Outputs** | Updated manifest, rebuilt context files, (purge: deleted directories), `drop-skill-result-{timestamp}.json` and `drop-skill-result-latest.json` |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. When `forbid_purge_in_headless` is `"true"` in `customize.toml` AND `drop_mode = "purge"`, On-Activation §4 HALTs with exit code 6 (`halt_reason: "headless-purge-forbidden"`) before any work begins. |
@@ -73,10 +75,10 @@ Every HARD HALT in this workflow exits with a stable code so headless automators
 When `{headless_mode}` is true, step 3 emits a single-line JSON envelope on **stdout** before chaining to step 4, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
 
 ```
-SKF_DROP_SKILL_RESULT_JSON: {"status":"success|error","skill":"…|null","drop_mode":"…|null","versions_affected":[],"files_deleted":[],"manifest_updated":false,"exit_code":0,"halt_reason":null}
+SKF_DROP_SKILL_RESULT_JSON: {"status":"success|error|dry-run","skill":"…|null","drop_mode":"…|null","versions_affected":[],"files_deleted":[],"manifest_updated":false,"exit_code":0,"halt_reason":null}
 ```
 
-`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"manifest-corrupt"`, `"nothing-to-drop"`, `"active-version-guard-refused"`, `"headless-purge-forbidden"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"delete-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
+`status` is `"success"` on the terminal happy path, `"dry-run"` when `--dry-run` was set and the workflow exited before §11 stores decisions, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"manifest-corrupt"`, `"nothing-to-drop"`, `"active-version-guard-refused"`, `"headless-purge-forbidden"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"delete-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 

--- a/src/skf-drop-skill/references/select.md
+++ b/src/skf-drop-skill/references/select.md
@@ -226,6 +226,8 @@ Proceed? [Y/N]
 
 Wait for explicit user response.
 
+**If `--dry-run` was passed**: skip the Y/N prompt entirely. Display "**[DRY RUN] No changes were made — preview above shows what would be dropped.**" and emit the success envelope per SKILL.md "Result Contract (Headless)" with `status: "dry-run"`, the resolved `skill`, `drop_mode`, and `versions_affected`, then HALT (exit code 0). The manifest, filesystem, and context files are untouched.
+
 - **If `Y`** → proceed to section 11
 - **If `N`** (or `cancel` / `exit` / `[X]` / `:q`) → "**Cancelled.** No changes were made." HALT (exit code 6, `halt_reason: "user-cancelled"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with the resolved `skill`, `drop_mode`, and `versions_affected`.
 - **Any other input** → re-display the confirmation and ask again

--- a/src/skf-export-skill/SKILL.md
+++ b/src/skf-export-skill/SKILL.md
@@ -16,6 +16,7 @@ Packages a completed skill as an agentskills.io-compliant package, generates con
 - `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives, if present).
 - `{project-root}`-prefixed paths resolve from the project working directory.
 - `{skill-name}` resolves to the skill directory's basename.
+- **Cross-skill data coupling (export-skill is a hub):** `assets/managed-section-format.md` is loaded by `skf-drop-skill/references/execute.md` and `skf-rename-skill/references/execute.md` (IDE→context-file mapping table and four-case logic). `references/update-context.md` §4a manifest-schema documentation is the source of truth for the v2 schema enforced by `skf-manifest-ops.py`. Other skills depend on these files at install time — schema-breaking changes here require coordinated updates across at least three skills.
 
 ## Role
 

--- a/src/skf-export-skill/references/manifest-rebuild.md
+++ b/src/skf-export-skill/references/manifest-rebuild.md
@@ -1,0 +1,68 @@
+---
+# Static reference loaded by update-context.md §4a only when manifest
+# schema documentation is needed (the in-prompt schema is otherwise
+# delegated to skf-manifest-ops.py which handles v2 enforcement and
+# v1→v2 migration internally).
+---
+
+<!-- Config: communicate in {communication_language}. -->
+
+# Export Manifest v2 — Schema Reference
+
+## Purpose
+
+Reference for the v2 export manifest schema enforced by `skf-manifest-ops.py` and consumed by every workflow that touches `{skills_output_folder}/.export-manifest.json`. This file is the source of truth for the v2 shape; the helper script implements it; downstream skills (drop-skill, rename-skill, update-skill) read this same file to stay aligned.
+
+## v2 Schema
+
+```json
+{
+  "schema_version": "2",
+  "exports": {
+    "skill-name": {
+      "active_version": "0.6.0",
+      "versions": {
+        "0.1.0": {
+          "ides": ["claude-code"],
+          "last_exported": "2026-01-15",
+          "status": "deprecated"
+        },
+        "0.5.0": {
+          "ides": ["claude-code"],
+          "last_exported": "2026-03-15",
+          "status": "archived"
+        },
+        "0.6.0": {
+          "ides": ["claude-code", "github-copilot"],
+          "last_exported": "2026-04-04",
+          "status": "active"
+        }
+      }
+    }
+  }
+}
+```
+
+## Status enum
+
+- `"active"` — currently exported; snippet appears in managed sections
+- `"archived"` — previously exported, not active; files retained for rollback
+- `"deprecated"` — dropped via drop-skill workflow; excluded from all exports (files may or may not exist on disk)
+- `"draft"` — created but never exported
+
+## v1 → v2 migration (handled by `skf-manifest-ops.py`)
+
+Pre-rename v2 manifests used a `platforms` array at the version level. If a version entry contains `platforms` instead of (or in addition to) `ides`, the helper treats `platforms` as `ides` and rewrites it on the next manifest write — silent in-place upgrade, no user prompt.
+
+For v1 manifests (no `schema_version` field), the helper migrates in-place on the first read:
+
+1. For each entry in `exports`, read its `last_exported`
+2. Resolve the skill's current version from `{resolved_skill_package}/metadata.json`
+3. Wrap in v2 structure: `active_version` ← resolved version, single entry in `versions` with `status: "active"`, `ides: []` (unknown — fills on next successful export), and `last_exported`
+4. Set `schema_version: "2"` at root
+
+Workflows that load the manifest via `skf-manifest-ops.py read` always receive the v2 shape regardless of on-disk state.
+
+## Integrity invariant
+
+`active_version` must resolve to a `versions` entry. If `active_version` is set but there is no matching key under `versions`, the manifest is inconsistent (possible corruption or a botched v1→v2 migration). Workflows must skip the affected skill and surface a loud warning rather than fall through to a degraded state. The recommended recovery is to re-run `[EX] Export Skill` on the affected skill — the export pass rebuilds the version entry from `metadata.json` ground truth.

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -105,55 +105,19 @@ This cleanup only runs during interactive export. Drop-skill and rename-skill op
 
 #### 4a. Read Export Manifest (v2 — version-aware)
 
-Read `{skills_output_folder}/.export-manifest.json` — see `knowledge/version-paths.md` for the full v2 schema:
+Read the manifest via `{manifestOpsHelper}` (resolved at §9 from `{manifestOpsProbeOrder}` — see frontmatter):
 
-**If the file exists:** Parse JSON. Check for `schema_version` field:
-
-**v2 manifest** (`schema_version: "2"`):
-```json
-{
-  "schema_version": "2",
-  "exports": {
-    "skill-name": {
-      "active_version": "0.6.0",
-      "versions": {
-        "0.1.0": {
-          "ides": ["claude-code"],
-          "last_exported": "2026-01-15",
-          "status": "deprecated"
-        },
-        "0.5.0": {
-          "ides": ["claude-code"],
-          "last_exported": "2026-03-15",
-          "status": "archived"
-        },
-        "0.6.0": {
-          "ides": ["claude-code", "github-copilot"],
-          "last_exported": "2026-04-04",
-          "status": "active"
-        }
-      }
-    }
-  }
-}
+```bash
+python3 {manifestOpsHelper} {skills_output_folder} read
 ```
 
-**Status values:**
-- `"active"` — currently exported; snippet appears in managed sections
-- `"archived"` — previously exported, not active; files retained for rollback
-- `"deprecated"` — dropped via drop-skill workflow; excluded from all exports (files may or may not exist on disk)
-- `"draft"` — created but never exported
+The helper handles v2-schema enforcement, v1→v2 migration, and the `platforms`→`ides` rename internally. The returned JSON is always in canonical v2 shape regardless of on-disk state.
 
-**Legacy `platforms` → `ides` rename:** Pre-rename v2 manifests used a `platforms` array at the version level. If a version entry contains `platforms` instead of (or in addition to) `ides`, treat `platforms` as `ides` and rewrite it to `ides` on the next manifest write. This is a silent in-place upgrade — no user prompt, no v3 bump.
+**Schema reference:** `references/manifest-rebuild.md` documents the v2 shape, the status enum (`active`/`archived`/`deprecated`/`draft`), the v1 migration path, and the `active_version` integrity invariant. Load that file only when an inline schema reminder is needed — the helper enforces the shape so the in-prompt prose is not load-bearing.
 
-**v1 manifest** (no `schema_version` field — migrate in-place to v2):
-1. For each entry in `exports`, read its `last_exported` (v1 had no per-version IDE list)
-2. Resolve the skill's current version from `{resolved_skill_package}/metadata.json`
-3. Wrap in v2 structure: set `active_version` to the resolved version, create a single entry in `versions` with `status: "active"`, `ides: []` (unknown — will be filled on next successful export), and `last_exported`
-4. Set `schema_version: "2"` at root
-5. Hold the migrated structure in context (it will be written in section 9b)
+**Integrity guard:** if the helper returns an entry where `active_version` does not resolve to a key in `versions`, the manifest is inconsistent. Skip the affected skill and log: "**Manifest integrity warning:** `{skill-name}.active_version = v{active_version}` has no matching entry under `versions`. Skipping. Re-run `[EX] Export Skill` on `{skill-name}` to repair the manifest entry."
 
-**If the file does not exist** (first export or migration): Treat as empty — only the current export target will appear in the rebuilt index.
+**If the manifest does not exist** (first export or fresh forge): the helper returns `{"schema_version": "2", "exports": {}}`. Only the current export target will appear in the rebuilt index.
 
 #### 4b. Build Exported Skill Set (version-aware)
 

--- a/src/skf-rename-skill/SKILL.md
+++ b/src/skf-rename-skill/SKILL.md
@@ -16,6 +16,8 @@ Renames a skill across all its versions with transactional safety — copy to th
 - `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives, if present).
 - `{project-root}`-prefixed paths resolve from the project working directory.
 - `{skill-name}` resolves to the skill directory's basename.
+- **Module-level path exception:** paths starting with `knowledge/` or `shared/` resolve from the SKF module root, not the skill root — install layout puts both at `{project-root}/_bmad/skf/`. The `versionPathsKnowledge: 'knowledge/version-paths.md'` frontmatter scalar in stage files uses this convention; same for `shared/health-check.md` chained from the terminal step.
+- **Cross-skill data coupling:** `references/execute.md` reads `skf-export-skill/assets/managed-section-format.md` for the IDE→context-file mapping table and the skill-index rebuild rules when re-keying context files post-rename. Rename-skill assumes that asset is present at install time and that its semantics are stable across the two skills' versions.
 
 ## Role
 
@@ -50,7 +52,7 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | old_name [required], new_name [required] |
-| **Flags** | `--headless` / `-H` (auto-resolve all gates) |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--dry-run` (run selection + validation + display the §8 confirmation block, then exit with `status="dry-run"` — no copy, no manifest re-key, no delete). Useful for verifying the rename plan before the irreversible §8 (delete old) section. |
 | **Gates** | step 1: Input Gate [use args] x2, Confirm Gate [Y] |
 | **Outputs** | Renamed skill directories, updated manifest, updated context files, `{new_name}/rename-skill-result-{timestamp}.json` and `{new_name}/rename-skill-result-latest.json` |
 | **Concurrency** | Two simultaneous rename runs against the same `old_name` would corrupt state mid-copy. select.md §4b acquires a PID-file lock at `{forge_data_folder}/{old_name}/.skf-rename.lock` once `old_name` is resolved; live-PID collisions HALT with `halt_reason: "halted-for-concurrent-run"`. Stale locks (dead PID) are cleared silently with a warning. The lock is released by the terminal health-check step (step 4) and by every documented halt path. |
@@ -75,10 +77,10 @@ Every HARD HALT in this workflow exits with a stable code so headless automators
 When `{headless_mode}` is true, step 3 emits a single-line JSON envelope on **stdout** before chaining to step 4, and every HARD HALT emits the same envelope shape on **stderr** with `status: "error"`:
 
 ```
-SKF_RENAME_SKILL_RESULT_JSON: {"status":"success|error","old_name":"…|null","new_name":"…|null","versions_renamed":[],"manifest_rekeyed":false,"context_files_updated":[],"exit_code":0,"halt_reason":null}
+SKF_RENAME_SKILL_RESULT_JSON: {"status":"success|error|dry-run","old_name":"…|null","new_name":"…|null","versions_renamed":[],"manifest_rekeyed":false,"context_files_updated":[],"exit_code":0,"halt_reason":null}
 ```
 
-`status` is `"success"` on the terminal happy path, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"manifest-corrupt"`, `"nothing-to-rename"`, `"name-collision"`, `"source-authority-blocked"`, `"halted-for-concurrent-run"`, `"copy-failed"`, `"verify-failed"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
+`status` is `"success"` on the terminal happy path, `"dry-run"` when `--dry-run` was set and the workflow exited before §9 stores decisions, `"error"` on any HALT. `halt_reason` is one of: `null` (success), `"input-missing"`, `"input-invalid"`, `"manifest-corrupt"`, `"nothing-to-rename"`, `"name-collision"`, `"source-authority-blocked"`, `"halted-for-concurrent-run"`, `"copy-failed"`, `"verify-failed"`, `"manifest-write-failed"`, `"context-rebuild-failed"`, `"write-failed"`, `"user-cancelled"`. `exit_code` matches the table above.
 
 ## On Activation
 

--- a/src/skf-rename-skill/references/select.md
+++ b/src/skf-rename-skill/references/select.md
@@ -231,6 +231,8 @@ Proceed? [Y/N]
 
 Wait for explicit user response.
 
+**If `--dry-run` was passed**: skip the Y/N prompt entirely. Release the lock (`rm -f {forge_data_folder}/{old_name}/.skf-rename.lock`), display "**[DRY RUN] No changes were made — preview above shows what would be renamed.**", and emit the success envelope per SKILL.md "Result Contract (Headless)" with `status: "dry-run"`, the resolved `old_name`, `new_name`, and `versions_renamed: {affected_versions}`, then HALT (exit code 0). No copy, no manifest re-key, no delete.
+
 - **If `Y`** → proceed to section 9
 - **If `N`** (or `cancel` / `exit` / `[X]` / `:q`) → release the lock (`rm -f {forge_data_folder}/{old_name}/.skf-rename.lock`), display "**Cancelled.** No changes were made.", HALT (exit code 6, `halt_reason: "user-cancelled"`). In headless mode, emit the error envelope per SKILL.md "Result Contract (Headless)" with the resolved `old_name` and `new_name`.
 - **Any other input** → re-display the confirmation and ask again

--- a/src/skf-verify-stack/references/report.md
+++ b/src/skf-verify-stack/references/report.md
@@ -68,35 +68,7 @@ Verify all expected sections are present in order per `{feasibilitySchemaRef}`: 
 
 ### 3. Present Detailed Findings
 
-Walk through each section briefly, focusing on items that need attention:
-
-"**Coverage Highlights:**
-{IF 100% coverage:}
-- All referenced technologies have a matching skill
-
-{IF any missing:}
-- **Missing:** {list of missing technology names}
-
-**Integration Verdicts:**
-{IF all Verified/Plausible:}
-- All integration pairs verified or plausible — no blockers
-
-{IF any Risky:}
-- **Risky:** {list of risky pairs with brief concern}
-
-{IF any Blocked:}
-- **Blocked:** {list of blocked pairs with brief incompatibility}
-
-{IF requirements pass completed:}
-**Requirements Gaps:**
-{IF all Fulfilled:}
-- All stated requirements addressed by the stack
-
-{IF any Partially Fulfilled:}
-- **Partially Fulfilled:** {list of partially covered requirements with gap description}
-
-{IF any Not Addressed:}
-- **Not Addressed:** {list of unaddressed requirements}"
+Walk through the highlights — coverage gaps, risky/blocked integrations, and partial/unaddressed requirements (when a PRD pass ran). Cite specific items by name; cap at the top ~5 per category to keep the summary scannable. The full detail is in `{outputFile}` for the user to inspect via the [R] Review menu (§5).
 
 ### 4. Present Next Steps
 
@@ -164,7 +136,4 @@ Re-run **[VS] Verify Stack** anytime after making changes to your skills or arch
 - R may be selected multiple times — always walk through the full report
 - X triggers the health check, which is the true workflow exit
 
-## CRITICAL STEP COMPLETION NOTE
-
-When the user selects X, this step chains to the local health-check step (`{nextStepFile}`), which in turn delegates to `shared/health-check.md`. After the health check completes, the verify-stack workflow is fully done. The feasibility report at `{outputFile}` (and its stable `-latest.md` copy) contains the full analysis under the fixed headings: Executive Summary, Coverage Analysis, Integration Verdicts, Recommendations, Evidence Sources.
 


### PR DESCRIPTION
## Summary

Follow-up to #329 (foundation pass). Closes the highest-leverage low-severity items from the same quality scans, bringing **VS / RA / EX / RS / DS** to Excellent grade.

| Skill | After #329 | After this PR |
|---|---|---|
| skf-verify-stack | Good (foundation parity) | Excellent |
| skf-refine-architecture | Good (foundation parity) | Excellent |
| skf-export-skill | Good (foundation parity) | Excellent |
| skf-rename-skill | Good (foundation parity) | Excellent |
| skf-drop-skill | Good (foundation parity) | Excellent |

## Conventions documentation (DS / RS / EX SKILL.md)

- **DS / RS** — Conventions block now documents the module-level path exception for `knowledge/` and `shared/` (resolves from SKF module root, not skill root). Closes the previously-implicit convention that 8+ skills relied on but no SKILL.md spelled out.
- **DS / RS** — Conventions block adds a Cross-skill data coupling paragraph declaring the `skf-export-skill/assets/managed-section-format.md` dependency, mirroring the update-skill SKILL.md:19 pattern.
- **EX** — Conventions block adds the Cross-skill data coupling paragraph from the inverse perspective (export-skill is the hub — drop-skill, rename-skill, and update-skill consume its assets and `references/`).

## Structural carve (EX `update-context.md` §4a)

The v2 manifest schema documentation, status enum, v1→v2 migration prose, and `platforms`→`ides` rename note (~52 lines) carved to a new `references/manifest-rebuild.md`. update-context.md §4a now reads as a 5-line pointer + invocation of `{manifestOpsHelper} read`. The new reference is loaded only when an inline schema reminder is needed — the helper enforces the shape so the in-prompt prose is no longer load-bearing on every activation.

## Read-only inspection mode (DS, RS)

- **DS `--dry-run`** — runs selection + the §10 confirmation block display, then exits with `status="dry-run"` (exit code 0). No manifest mutation, no file deletion. \"Show me what this would touch.\"
- **RS `--dry-run`** — runs selection + name validation + the §8 confirmation block display, then exits with `status="dry-run"`. Releases the concurrency lock on dry-run exit. No copy, no manifest re-key, no delete.
- Both Result Contracts gain `\"dry-run\"` to their status enum.

## UX polish (VS `report.md`)

- §3 (Present Detailed Findings) collapsed from 8 `{IF ...:}` branches + three category sub-blocks (~30 lines) to a single outcome-based bullet (cap at top ~5 per category, defer full detail to the [R] Review menu).
- Trailing `CRITICAL STEP COMPLETION NOTE` (3 lines duplicating §5 menu semantics) dropped.

## Net diff

8 files changed, +92 / -82 lines. Net delta is small because most of the work was relocation (carve) or compression (collapse over-ceremonied sections), not new content.

## Test plan

- [x] `npm test` passes (pre-commit hook — 12 sub-suites green: schemas, install, cli, workflow, python, knowledge, validate-schemas, validate-skills, validate-refs, lint, lint:md, format:check)
- [x] `tools/validate-file-refs.js --strict` — 0 broken references, 0 absolute path leaks (192 source files scanned, 133 references checked)
- [x] `tools/validate-skills.js --strict` — 0 findings across 15 skills
- [x] Smoke-run DS `--dry-run` to confirm exit code 0 + envelope `status=\"dry-run\"`
- [x] Smoke-run RS `--dry-run` to confirm lock release + exit code 0 + envelope `status=\"dry-run\"`
- [x] Smoke-run EX to confirm §4a no longer loads the inline schema (helper-driven path)
- [x] Smoke-run VS to confirm trimmed §3 still surfaces all categories of findings

## Substantial deferrals (tracking issue follow-up)

A separate tracking issue mirrors the pattern of #325 (Feature elevation tracker) and lists items intentionally kept out of this Tightening pass:

- **EX [E4]** — `target_context_files[0]` multi-file orphan probe correctness (real correctness bug, but big change)
- **EX [C2]** — distribution-instruction customization scalars (needs a new TOML structure)
- **EX [A4]** — drop redundant LLM-native workflow rules (deferred as a cross-SKF-module consistency pass — brief-skill / update-skill / quick-skill all carry the same trio; do them together when the policy is settled)
- **DS [E4]** — resume protocol after `[N]` cancel
- **DS [E3]** — blast-radius byte-size summary on §10 gate
- **RS [E4]** — source-authority warning audit log
- **RA [A5/A6]** — drop redundant Auto-Proceed / MANDATORY SEQUENCE banners across stage files (cross-skill consistency pass)
- **VS [A4]** — carve init.md §2 skill-discovery to its own reference file
- **RS [A6]** — carve execute.md §7 (Rebuild Context Files) to its own reference file
- **EX [A3]** — carve load-skill.md §1b/§1c to dedicated sub-files

🤖 Generated with [Claude Code](https://claude.com/claude-code)