### PR TITLE
refactor(skf-issue-331): carve 3 conditional protocols + RS rebuild-context to references/

### DIFF
--- a/src/skf-export-skill/references/load-skill.md
+++ b/src/skf-export-skill/references/load-skill.md
@@ -66,54 +66,15 @@ For each IDE in `config.yaml.ides`:
 
 ### 1b. Detect Snippet Root Prefix Mismatch
 
-**Skip entirely if `snippet_skill_root_override` is already set in `config.yaml`** — the authoring-repo escape hatch is already configured and any on-disk prefix that matches it is ground truth (see `assets/managed-section-format.md` override rules).
+**Skip entirely if `snippet_skill_root_override` is set in `config.yaml`** — the authoring-repo escape hatch is already configured and any on-disk prefix that matches it is ground truth (see `assets/managed-section-format.md` override rules).
 
-Otherwise, probe existing snippets to catch the authoring-repo case (skills live under a single shared directory like `skills/` that does not match any per-IDE `skill_root`) before step 4 silently rewrites their root paths:
-
-1. Collect candidate snippet paths:
-   - Read `{skills_output_folder}/.export-manifest.json` if it exists. For each skill in `exports` with a resolvable `active_version`, add `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/context-snippet.md`
-   - Also include the current skill's snippet if present (resolved via manifest / `active` symlink / flat path per `knowledge/version-paths.md`)
-2. For each snippet that exists on disk, read the first line and parse the `root:` value. Strip the trailing `{skill-name}/` to extract the prefix (e.g. `skills/`, `.claude/skills/`)
-3. Collect unique prefixes into `observed_prefixes`
-4. Compare against `target_context_files[0].skill_root` (the first entry's IDE-mapped skill root — used as reference since step 3 §2.7 picks this same entry for snippet generation when no override is set)
-
-**If `observed_prefixes` contains any value that does not match the reference `skill_root`:**
-
-Emit a single warning (once, not per snippet) and present resolution options before proceeding:
-
-"**Snippet root prefix mismatch detected.**
-Existing snippets use: `{observed_prefixes}`
-IDE-mapped skill_root:  `{target_context_files[0].skill_root}`
-
-This usually means you are in an authoring repo where skills live under a single shared directory. Options:
-- **(a) Set override** — add `snippet_skill_root_override: {observed_prefix}` to `config.yaml`. Snippets keep their on-disk prefix; the managed section references the real location.
-- **(b) Proceed with IDE mapping** — step 4 will rewrite every snippet's root path to the IDE's skill_root. Use this only if the IDE's skill directory actually contains the skill files.
-- **(c) Cancel** — abort export and investigate.
-
-If multiple distinct prefixes were observed, the snippets disagree with each other — investigate before choosing (a)."
-
-In `{headless_mode}`, default to (b) and log the observed prefix(es) so the mismatch is visible in run logs. In interactive mode, wait for user choice before continuing to section 2.
-
-**If all observed prefixes match the reference `skill_root` (or no existing snippets were found):** Proceed silently.
+**Otherwise:** load `references/preflight-snippet-root-probe.md` and follow its probe + (a) Set override / (b) Proceed with IDE mapping / (c) Cancel gate protocol. The reference handles candidate snippet collection (manifest-driven), prefix observation, the mismatch warning, and headless default ((b) Proceed). Returns control to §1c on no-mismatch fast path or after a (b) choice.
 
 ### 1c. Multi-skill Mode (when `len(skill_batch) > 1`)
 
-When multiple skills are being exported in a single run (via `--all`, multi-selection at the discovery menu, or an explicit multi-argument invocation), the workflow does NOT loop the full step 1→step 7 sequence once per skill. Instead, it partitions work across steps to avoid repeated gates and redundant batch work:
+**If `len(skill_batch) == 1`:** single-skill mode (legacy behavior) — every section below operates on the one skill without iteration. Skip this subsection.
 
-| Step | Behavior in multi-skill mode |
-|------|------------------------------|
-| step 1 §2–5 | **Iterate per skill** — load, validate, read metadata, and check the test report for every skill in `skill_batch`. Collect per-skill results. |
-| step 1 §6 | **Single gate** — present one consolidated summary table (one row per skill) and a single [C] gate for the whole batch. |
-| step 2 | **Iterate per skill** — validate each skill's package structure and collect per-skill readiness. |
-| step 3 | **Iterate per skill** — regenerate each skill's `context-snippet.md` independently (each skill has its own prior-gotchas carry-forward state). |
-| step 4 | **Batch once** — §3b orphan detection, §4 skill-index rebuild, §5 managed-section assembly, and §6–9 diff + write all execute once for the entire batch. The exported skill set in §4b already enumerates every skill in the manifest — it does not need per-skill iteration. §9b adds/updates a manifest entry per skill in `skill_batch` (not just the last one), then writes the manifest once. |
-| step 5 | **Iterate per skill** — compute token counts per skill, then present one aggregate report. |
-| step 6 | **One batch summary + one result contract** — the files-written table lists every skill; the result contract JSON covers the whole run, and `outputs` enumerates every context-snippet + target context file touched. |
-| step 7 | **Runs once** — health check is per-workflow-run, not per-skill. |
-
-**Halt semantics in batch mode:** if any single skill fails validation in §2 (required-file or metadata-field failure), halt the entire batch before §5 — do not partially export. Report which skill failed and why.
-
-**Single-skill mode (`len(skill_batch) == 1`)** preserves the legacy behavior: every section below operates on the one skill without iteration.
+**If `len(skill_batch) > 1`:** load `references/multi-skill-mode.md` and apply its per-step behavior matrix. The reference partitions work so that step 1 §2–5 iterates per skill, step 1 §6 presents a single consolidated [C] gate, step 4 batches once across the whole run, and step 7 health check runs once. It also defines the all-or-nothing halt semantics if any single skill fails §2 validation.
 
 ### 2. Load and Validate Skill Artifacts
 

--- a/src/skf-export-skill/references/multi-skill-mode.md
+++ b/src/skf-export-skill/references/multi-skill-mode.md
@@ -1,0 +1,38 @@
+---
+# Static reference loaded by load-skill.md §1c only when
+# `len(skill_batch) > 1` (multi-skill mode activated via `--all`,
+# multi-selection at the discovery menu, or explicit multi-argument
+# invocation). In single-skill mode the per-step matrix below does
+# not apply and this file is never loaded. Loaded once per export run.
+---
+
+<!-- Config: communicate in {communication_language}. -->
+
+# Multi-skill Mode — Per-step Behavior Matrix
+
+## Purpose
+
+When multiple skills are exported in a single run, the workflow does NOT loop the full step 1 → step 7 sequence once per skill. Instead, it partitions work across steps to avoid repeated gates and redundant batch work (one §3b orphan-detection pass, one §4 skill-index rebuild, one §6 user gate, one health check, etc.).
+
+Loaded by `load-skill.md` §1c when `len(skill_batch) > 1`.
+
+## Per-step matrix
+
+| Step | Behavior in multi-skill mode |
+|------|------------------------------|
+| step 1 §2–5 | **Iterate per skill** — load, validate, read metadata, and check the test report for every skill in `skill_batch`. Collect per-skill results. |
+| step 1 §6 | **Single gate** — present one consolidated summary table (one row per skill) and a single [C] gate for the whole batch. |
+| step 2 | **Iterate per skill** — validate each skill's package structure and collect per-skill readiness. |
+| step 3 | **Iterate per skill** — regenerate each skill's `context-snippet.md` independently (each skill has its own prior-gotchas carry-forward state). |
+| step 4 | **Batch once** — §3b orphan detection, §4 skill-index rebuild, §5 managed-section assembly, and §6–9 diff + write all execute once for the entire batch. The exported skill set in §4b already enumerates every skill in the manifest — it does not need per-skill iteration. §9b adds/updates a manifest entry per skill in `skill_batch` (not just the last one), then writes the manifest once. |
+| step 5 | **Iterate per skill** — compute token counts per skill, then present one aggregate report. |
+| step 6 | **One batch summary + one result contract** — the files-written table lists every skill; the result contract JSON covers the whole run, and `outputs` enumerates every context-snippet + target context file touched. |
+| step 7 | **Runs once** — health check is per-workflow-run, not per-skill. |
+
+## Halt semantics
+
+If any single skill fails validation in step 1 §2 (required-file or metadata-field failure), halt the entire batch before step 4 §5 — do not partially export. Report which skill failed and why. The principle: a multi-skill run is a unit of work, not a per-skill best-effort sweep — partial exports leave the manifest and managed sections in an ambiguous state that's expensive for the operator to reconcile.
+
+## Single-skill mode (reference)
+
+`len(skill_batch) == 1` preserves the legacy behavior: every section operates on the one skill without iteration, no gate consolidation, no per-step table consultation. This file does not need to be loaded.

--- a/src/skf-export-skill/references/orphan-context-detection.md
+++ b/src/skf-export-skill/references/orphan-context-detection.md
@@ -1,0 +1,75 @@
+---
+# Static reference loaded by update-context.md §3b only when
+# `orphaned_context_files` is non-empty (i.e. the cheap pre-check in
+# §3b found a context file on disk with an SKF managed section that
+# is no longer in the current `target_context_files`). The reference
+# carries the (a)/(b)/(c) gate protocol, headless default, and
+# downstream-state contract; the trigger detection itself stays
+# inline in §3b so the LLM knows when to invoke this protocol.
+---
+
+<!-- Config: communicate in {communication_language}. Render the orphan list and gate prompt in {document_output_language}. -->
+
+# Orphan Context-File Detection — Gate Protocol
+
+## Purpose
+
+Handle the (a) clear / (b) keep / (c) rewrite gate when one or more known context files (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`) on disk contain an SKF managed section but their owning IDE is no longer listed in `config.yaml.ides`. Loaded by `update-context.md` §3b after the cheap pre-check populates `orphaned_context_files`.
+
+## Inputs
+
+- `orphaned_context_files` — list of `{context_file, file_path}` entries built by §3b's pre-check
+- `target_context_files` — current export's IDE → context-file map (from step 1)
+- `{headless_mode}` — boolean flag from workflow context
+
+## Gate Protocol
+
+Emit the warning and gate:
+
+> **Orphaned context files detected.** The following files contain SKF managed sections but no configured IDEs target them:
+> {list: context file → file path}
+>
+> The managed sections in these files are stale. Options:
+>
+> - **(a) clear** — remove the SKF managed section from each orphaned file (surgical marker replacement, leaves user content intact)
+> - **(b) keep** — leave them untouched (they will remain stale until you re-add an IDE that targets this file or delete the file)
+> - **(c) rewrite** — also rewrite the orphaned files with the current skill index (use this if the IDE was removed by mistake)
+
+Wait for user choice.
+
+**Headless / non-interactive default:** when `{headless_mode}` (or dry-run, or unattended), default to **(b) keep** and print the warning only — no destructive action without explicit consent.
+
+## Choice handling
+
+### (a) clear
+
+For each file in `orphaned_context_files`:
+
+1. Replace everything between `<!-- SKF:BEGIN` and `<!-- SKF:END -->` (inclusive) with an empty string, preserving surrounding content byte-exactly.
+2. Append the file path to `orphans_cleared` (workflow-context list, surfaced in the §6 result contract).
+
+### (b) keep
+
+Record nothing. The orphaned files remain on disk, untouched. Proceed.
+
+### (c) rewrite
+
+Add each entry in `orphaned_context_files` to a separate `rewrite_context_files` list. This list is kept distinct from `target_context_files` so the user's intent to only export to configured IDEs is preserved in the manifest update at §9b — `rewrite_context_files` participates in the §4–§9a write loop for this run only and is not promoted into the manifest's `ides` arrays.
+
+Use `.agents/skills/` as the default skill root for rewritten orphans (the IDE-neutral path used when the original IDE mapping is no longer available).
+
+Record each rewritten file in `orphans_rewritten` (workflow-context list, surfaced in the §6 result contract).
+
+## Downstream contract
+
+After this protocol completes, §3b returns control to §4 with these workflow-context variables populated:
+
+- `orphans_cleared: []` — set when the user chose (a) or stayed empty otherwise
+- `orphans_rewritten: []` — set when the user chose (c) or stayed empty otherwise
+- `rewrite_context_files: []` — extends the per-context-file iteration in §4–§9a when the user chose (c)
+
+The §4–§9a loop iterates over `target_context_files + rewrite_context_files`. The §9b manifest update reads only `target_context_files` (rewritten orphans are not promoted into the manifest).
+
+## Scope note
+
+This cleanup only runs during interactive export (and the headless default explicitly does nothing destructive). Drop-skill and rename-skill operate on the manifest's declared context files and are not responsible for orphan detection — their scope is the active manifest, not arbitrary on-disk markers.

--- a/src/skf-export-skill/references/orphan-row-detection.md
+++ b/src/skf-export-skill/references/orphan-row-detection.md
@@ -21,23 +21,23 @@ Strict ADR-K would silently drop such rows, but the user's managed section is lo
 
 ## Inputs
 
-- `orphan_managed_rows` — list of `{skill_name, version, snippet_text}` entries built by §4c.1's pre-check (each `snippet_text` is the original snippet line(s) captured verbatim from the prior section, so they can be re-emitted unchanged if (b) is chosen)
-- `target_context_files[0].context_file` — the file the orphans were detected in (used in the gate prompt for traceability)
+- `orphan_managed_rows` — list of `{skill_name, version, snippet_text, source_files: []}` entries built by §4c.1's pre-check across **every** target context file, deduplicated by `(skill_name, version)`. `source_files` carries the file paths the orphan appeared in (one entry per file in which the row was found). `snippet_text` is the original snippet line(s) captured verbatim from the first encountered occurrence, used for re-emission if (b) is chosen.
+- `target_context_files` — the full IDE → context-file list (referenced in the gate's framing copy so the user understands the consolidation scope)
 - `{headless_mode}` — boolean flag from workflow context
 
 ## Gate Protocol
 
 Emit the gate:
 
-> **Managed-section rows present but absent from manifest:**
+> **Managed-section rows present but absent from manifest** (consolidated across {len(target_context_files)} target context file(s)):
 >
-> {list each as `- {skill_name} v{version}`}
+> {list each as `- {skill_name} v{version} (in: {comma-separated source_files})`}
 >
-> These skills appear in the existing managed section in `{first-context-file}` but no entry exists in `.export-manifest.json` and no source draft exists under `{skills_output_folder}/{skill_name}/`. They were likely installed from a different repo and never run through export-skill in this project. Options:
+> These skills appear in one or more existing managed sections but no entry exists in `.export-manifest.json` and no source draft exists under `{skills_output_folder}/{skill_name}/`. They were likely installed from a different repo and never run through export-skill in this project. Options:
 >
-> - **(a) Drop** — remove these rows from the rebuilt managed section (strict ADR-K behavior). The skills' on-disk files are not touched, but they will no longer appear in any context file's managed index.
-> - **(b) Preserve verbatim** — copy each orphan's existing snippet line(s) into the rebuilt managed section unchanged. Records `deviations[].kind = "preserve_external_skills"` with the affected skill names and versions in the result contract for audit.
-> - **(c) Cancel** — abort export. Run export-skill against each external skill (or remove the orphan rows from the context file manually) before re-running.
+> - **(a) Drop** — remove these rows from the rebuilt managed section across **all** target context files (strict ADR-K behavior). The skills' on-disk files are not touched, but they will no longer appear in any context file's managed index.
+> - **(b) Preserve verbatim** — copy each orphan's existing snippet line(s) into the rebuilt managed section across **all** target context files unchanged (one canonical row per `(skill, version)` written everywhere — orphans become symmetric across IDEs as a side effect, which is the correct outcome since the user's intent is "these external skills should appear in my managed index"). Records `deviations[].kind = "preserve_external_skills"` with the affected skill names, versions, and `source_files` in the result contract for audit.
+> - **(c) Cancel** — abort export. Run export-skill against each external skill (or remove the orphan rows from the context files manually) before re-running.
 
 Wait for user choice.
 
@@ -61,19 +61,23 @@ in workflow context for the §6 result contract.
 
 ### (b) Preserve verbatim
 
-Append each captured `snippet_text` to the assembled section after the manifest-driven entries, preserving alphabetical order in the merged list (sort the combined set of `manifest-driven` + `orphan` snippets by `skill_name`).
+Append each captured `snippet_text` to the assembled section after the manifest-driven entries, preserving alphabetical order in the merged list (sort the combined set of `manifest-driven` + `orphan` snippets by `skill_name`). Each `(skill, version)` is written **once** per rebuilt managed section — the deduplication done by §4c.1 means there is no per-file divergence to reconcile here.
 
 Append the following entry to the `deviations[]` array in the §6 result contract:
 
 ```json
 {
   "kind": "preserve_external_skills",
-  "skills": [{"name": "...", "version": "..."}, …],
+  "skills": [
+    {"name": "...", "version": "...", "source_files": ["..."]}
+  ],
   "rationale": "managed-section row exists but no manifest entry / no source draft"
 }
 ```
 
-The same orphans are written to **every** target context file in the §4–§9a loop, so all configured IDEs end up with consistent managed sections.
+`source_files` per skill records the prior context files the orphan was found in (asymmetric provenance preserved for audit) — useful when an operator later debugs which IDE's managed section originally carried the row.
+
+The same orphans are written to **every** target context file in the §4–§9a loop, so all configured IDEs end up with consistent managed sections (asymmetric prior orphans become symmetric — the correct outcome for the "preserve external skills" intent).
 
 ### (c) Cancel
 
@@ -95,4 +99,4 @@ After this protocol completes, §4c.1 returns control to §4d with these workflo
 
 ## Scope note
 
-This detection runs once per export run (not per target context file) — orphan rows are inherent to the prior state of the first context file and the choice is global. The §B1 multi-file fix (issue #331 — Workstream B1) tracks expanding this to iterate over every entry in `target_context_files`; until then, asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, when `target_context_files[0]` is `CLAUDE.md`) are not detected by this protocol.
+This detection runs once per export run (not per target context file) — the §4c.1 pre-check iterates **every** entry in `target_context_files` and deduplicates by `(skill_name, version)` before invoking this protocol, so the gate's choice applies globally and asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, or vice versa) are detected and surfaced with `source_files` provenance.

--- a/src/skf-export-skill/references/orphan-row-detection.md
+++ b/src/skf-export-skill/references/orphan-row-detection.md
@@ -1,0 +1,98 @@
+---
+# Static reference loaded by update-context.md §4c.1 only when
+# `orphan_managed_rows` is non-empty (i.e. the cheap pre-check in
+# §4c.1 found `[skill-name v...]` entries in the prior managed
+# section that are absent from the manifest-driven exported skill
+# set built in §4b). The reference carries the (a)/(b)/(c) gate
+# protocol, headless default, deviations[] contract, and §6
+# result-contract integration; the trigger detection itself stays
+# inline in §4c.1 so the LLM knows when to invoke this protocol.
+---
+
+<!-- Config: communicate in {communication_language}. Render the orphan list and gate prompt in {document_output_language}. -->
+
+# Orphan Managed-Section Rows — Gate Protocol
+
+## Purpose
+
+Handle the (a) Drop / (b) Preserve verbatim / (c) Cancel gate when the prior managed section in the first target context file contains `[skill-name v...]` rows for skills that are not in the manifest-driven exported skill set — typically externally-installed skills authored in a different repo and dropped into `{skills_output_folder}` without going through export-skill.
+
+Strict ADR-K would silently drop such rows, but the user's managed section is load-bearing — silent removal of an installed skill is a regression. The convention captured in `skills/export-skill-result-latest.json` deviations is to make this an explicit operator (or `{headless_mode}`) choice.
+
+## Inputs
+
+- `orphan_managed_rows` — list of `{skill_name, version, snippet_text}` entries built by §4c.1's pre-check (each `snippet_text` is the original snippet line(s) captured verbatim from the prior section, so they can be re-emitted unchanged if (b) is chosen)
+- `target_context_files[0].context_file` — the file the orphans were detected in (used in the gate prompt for traceability)
+- `{headless_mode}` — boolean flag from workflow context
+
+## Gate Protocol
+
+Emit the gate:
+
+> **Managed-section rows present but absent from manifest:**
+>
+> {list each as `- {skill_name} v{version}`}
+>
+> These skills appear in the existing managed section in `{first-context-file}` but no entry exists in `.export-manifest.json` and no source draft exists under `{skills_output_folder}/{skill_name}/`. They were likely installed from a different repo and never run through export-skill in this project. Options:
+>
+> - **(a) Drop** — remove these rows from the rebuilt managed section (strict ADR-K behavior). The skills' on-disk files are not touched, but they will no longer appear in any context file's managed index.
+> - **(b) Preserve verbatim** — copy each orphan's existing snippet line(s) into the rebuilt managed section unchanged. Records `deviations[].kind = "preserve_external_skills"` with the affected skill names and versions in the result contract for audit.
+> - **(c) Cancel** — abort export. Run export-skill against each external skill (or remove the orphan rows from the context file manually) before re-running.
+
+Wait for user choice.
+
+**Headless default** (when `{headless_mode}`): auto-select **(b) Preserve verbatim**, with the same `deviations[]` entry. Emit a loud log line:
+
+> `headless: {N} managed-section rows had no manifest entry; preserving verbatim with deviations[].kind = preserve_external_skills. Run export-skill against each to migrate them into the manifest.`
+
+Silent drop under automation would regress the user's managed section without consent; cancel under automation would block the whole export over an externally-installed skill the user did not author. Preservation matches the prior-attentive-operator convention.
+
+## Choice handling
+
+### (a) Drop
+
+Do not include any orphan rows in the rebuilt section. Record:
+
+```
+orphans_dropped = [{skill_name, version}, …]
+```
+
+in workflow context for the §6 result contract.
+
+### (b) Preserve verbatim
+
+Append each captured `snippet_text` to the assembled section after the manifest-driven entries, preserving alphabetical order in the merged list (sort the combined set of `manifest-driven` + `orphan` snippets by `skill_name`).
+
+Append the following entry to the `deviations[]` array in the §6 result contract:
+
+```json
+{
+  "kind": "preserve_external_skills",
+  "skills": [{"name": "...", "version": "..."}, …],
+  "rationale": "managed-section row exists but no manifest entry / no source draft"
+}
+```
+
+The same orphans are written to **every** target context file in the §4–§9a loop, so all configured IDEs end up with consistent managed sections.
+
+### (c) Cancel
+
+HALT the workflow:
+
+- Do not rewrite any context file.
+- Do not update the manifest.
+- Do not produce a result contract.
+- Exit code 6, `halt_reason: "user-cancelled"` (matches the §8 Menu cancel semantics).
+- In headless mode this branch is never taken (headless default is (b)), so this exit path is interactive-only.
+
+## Downstream contract
+
+After this protocol completes, §4c.1 returns control to §4d with these workflow-context variables populated:
+
+- `orphans_dropped: []` — set when the user chose (a) or stayed empty otherwise
+- `deviations[]` — extended with the `preserve_external_skills` entry when the user chose (b)
+- The assembled managed section contains the orphan rows verbatim when (b) was chosen, and excludes them when (a) was chosen
+
+## Scope note
+
+This detection runs once per export run (not per target context file) — orphan rows are inherent to the prior state of the first context file and the choice is global. The §B1 multi-file fix (issue #331 — Workstream B1) tracks expanding this to iterate over every entry in `target_context_files`; until then, asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, when `target_context_files[0]` is `CLAUDE.md`) are not detected by this protocol.

--- a/src/skf-export-skill/references/preflight-snippet-root-probe.md
+++ b/src/skf-export-skill/references/preflight-snippet-root-probe.md
@@ -1,0 +1,74 @@
+---
+# Static reference loaded by load-skill.md §1b only when
+# `snippet_skill_root_override` is UNSET in config.yaml. When the
+# override is set, every existing snippet's on-disk prefix is ground
+# truth by contract — no probe needed and the entire authoring-repo
+# escape hatch is already configured. Loaded once per export run, not
+# per skill.
+---
+
+<!-- Config: communicate in {communication_language}. Render the warning and gate prompt in {document_output_language}. -->
+
+# Snippet Root Prefix Mismatch — Pre-flight Probe
+
+## Purpose
+
+Catch the authoring-repo case before step 4 silently rewrites root paths. In an authoring repo, skills typically live under a single shared directory (`skills/`) that does not match any per-IDE `skill_root` (`.claude/skills/`, `.cursor/skills/`, etc.). Without this probe, step 4's root-rewrite algorithm would replace the on-disk prefix with an IDE-mapped one that the snippet files do not actually reside under.
+
+Loaded by `load-skill.md` §1b after `target_context_files` is resolved and `snippet_skill_root_override` is confirmed unset.
+
+## Inputs
+
+- `target_context_files[0].skill_root` — the reference IDE-mapped skill root (used because step 3 §2.7 picks this same entry for snippet generation when no override is set)
+- `{skills_output_folder}` — for manifest-driven candidate enumeration
+- Current skill's snippet path (resolved via manifest / `active` symlink / flat path per `knowledge/version-paths.md`)
+- `{headless_mode}` — boolean flag from workflow context
+
+## Probe Algorithm
+
+1. Collect candidate snippet paths:
+   - Read `{skills_output_folder}/.export-manifest.json` if it exists. For each skill in `exports` with a resolvable `active_version`, add `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/context-snippet.md`.
+   - Also include the current skill's snippet if present.
+2. For each snippet that exists on disk, read the first line and parse the `root:` value. Strip the trailing `{skill-name}/` to extract the prefix (e.g. `skills/`, `.claude/skills/`).
+3. Collect unique prefixes into `observed_prefixes`.
+4. Compare against `target_context_files[0].skill_root` (the reference).
+
+## Mismatch Gate
+
+**If `observed_prefixes` contains any value that does not match the reference `skill_root`:**
+
+Emit a single warning (once, not per snippet) and present resolution options before continuing to §2:
+
+> **Snippet root prefix mismatch detected.**
+> Existing snippets use: `{observed_prefixes}`
+> IDE-mapped skill_root:  `{target_context_files[0].skill_root}`
+>
+> This usually means you are in an authoring repo where skills live under a single shared directory. Options:
+>
+> - **(a) Set override** — add `snippet_skill_root_override: {observed_prefix}` to `config.yaml`. Snippets keep their on-disk prefix; the managed section references the real location.
+> - **(b) Proceed with IDE mapping** — step 4 will rewrite every snippet's root path to the IDE's skill_root. Use this only if the IDE's skill directory actually contains the skill files.
+> - **(c) Cancel** — abort export and investigate.
+>
+> If multiple distinct prefixes were observed, the snippets disagree with each other — investigate before choosing (a).
+
+Wait for user choice.
+
+**Headless default:** when `{headless_mode}`, default to **(b) Proceed with IDE mapping** and log the observed prefix(es) so the mismatch is visible in run logs (not silent).
+
+## Choice handling
+
+### (a) Set override
+
+Halt and instruct the user to update `config.yaml` with `snippet_skill_root_override: {observed_prefix}`, then re-run export. Exit code 6, `halt_reason: "user-cancelled"` (configuration change is out-of-band — workflow does not edit config.yaml on the user's behalf).
+
+### (b) Proceed with IDE mapping
+
+Continue to §2. Step 4's root-rewrite algorithm will rewrite every snippet's prefix to the reference `skill_root`. The user is accepting that the IDE's skill directory contains the actual files; if it does not, the resulting managed section will reference paths that don't resolve.
+
+### (c) Cancel
+
+HALT. Exit code 6, `halt_reason: "user-cancelled"`. No files written.
+
+## No-mismatch fast path
+
+**If all observed prefixes match the reference `skill_root` (or no existing snippets were found):** no warning, no gate. Return control to §1b and proceed silently to §2.

--- a/src/skf-export-skill/references/summary.md
+++ b/src/skf-export-skill/references/summary.md
@@ -147,10 +147,14 @@ Substitute `{skill_batch_names}`, `{context_files_updated}`, and `{headless_deci
 ```json
 {
   "kind": "preserve_external_skills",
-  "skills": [{"name": "skill-name", "version": "1.0.0"}, …],
+  "skills": [
+    {"name": "skill-name", "version": "1.0.0", "source_files": ["CLAUDE.md", ".cursorrules"]}
+  ],
   "rationale": "managed-section row exists but no manifest entry / no source draft"
 }
 ```
+
+`source_files` per skill records the prior context files the orphan was found in (the §4c.1 multi-file scan deduplicates by `(skill, version)` and tracks which target context files originally carried the row — useful when an operator later debugs which IDE's managed section first introduced the external skill).
 
 Other workflow choices that diverge from the strict spec path may add their own entries with a distinct `kind` value — auditors then have one place to look for "what did this run choose to do differently from the canonical flow." Omit the field when there are no deviations rather than writing an empty array, so the absence is readable as "ran the canonical path."
 

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -126,17 +126,21 @@ Instead of globbing `{skills_output_folder}/*/context-snippet.md`, resolve snipp
 
 A managed-section row becomes orphaned when a `[skill-name v...]` entry already exists in the prior managed section but the skill is not in the exported skill set built in 4b — typically an externally-installed skill authored in a different repo and dropped into `{skills_output_folder}` without going through export-skill. Strict ADR-K would silently drop such rows, but the user's managed section is load-bearing — silent removal is a regression.
 
-**Cheap pre-check (always run before §5 assembly):**
+**Cheap pre-check (always run before §5 assembly).** Scan **every** target context file (not just the first), deduplicate by `(skill_name, version)`, and present one consolidated gate. Asymmetric orphans — a row present in `.cursorrules` but absent from `CLAUDE.md`, or vice versa — must be detected; otherwise the §4 rebuild loop silently overwrites the orphan-bearing file's content (ADR-J violation: silent loss of user content).
 
-1. Read the prior managed section from the first target context file (`target_context_files[0].context_file`). If the file does not exist or has no `<!-- SKF:BEGIN -->` marker, set `orphan_managed_rows = []` and skip to §4d.
-2. Parse the `[skill-name v...]` rows between `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` into `prior_section_rows` — a list of `{skill_name, version, snippet_text}` triples (capture the original snippet line(s) verbatim so they can be re-emitted unchanged if (b) is chosen).
-3. Build `orphan_managed_rows` — every entry in `prior_section_rows` whose `skill_name` is NOT in the exported skill set built in 4b (manifest entries plus current-export targets).
+1. Initialize `orphan_managed_rows = []` (a list of `{skill_name, version, snippet_text, source_files: []}` entries — `source_files` carries provenance for the gate display and the audit `deviations[]` entry).
+2. **Iterate every entry in `target_context_files`:**
+   a. Read the prior managed section from `{entry.context_file}`. If the file does not exist or has no `<!-- SKF:BEGIN -->` marker, skip this entry — it has no orphans by definition.
+   b. Parse the `[skill-name v...]` rows between `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` into `file_rows` — a list of `{skill_name, version, snippet_text}` triples (capture the original snippet line(s) verbatim so they can be re-emitted unchanged if (b) is chosen).
+   c. For each `row` in `file_rows`:
+      - If `row.skill_name` is in the exported skill set built in 4b (manifest entries plus current-export targets), skip — not an orphan.
+      - Otherwise look up `(row.skill_name, row.version)` in `orphan_managed_rows`:
+        - If already present, append `entry.context_file` to that row's `source_files` list (deduplicated). Keep the first-encountered `snippet_text` — divergent snippets across files for the same `(skill, version)` are themselves a user-content asymmetry but the `(b) Preserve verbatim` semantic writes one canonical row to every target file, so picking the first is deterministic and avoids silently choosing.
+        - If new, append `{skill_name: row.skill_name, version: row.version, snippet_text: row.snippet_text, source_files: [entry.context_file]}`.
 
-**If `orphan_managed_rows` is non-empty:** load `references/orphan-row-detection.md` and follow its (a) Drop / (b) Preserve verbatim / (c) Cancel gate protocol. The reference handles user prompting, headless default (Preserve verbatim), `deviations[]` recording, and §6 result-contract integration.
+**If `orphan_managed_rows` is non-empty:** load `references/orphan-row-detection.md` and follow its (a) Drop / (b) Preserve verbatim / (c) Cancel gate protocol. The reference handles user prompting (with per-orphan `source_files` provenance), headless default (Preserve verbatim), `deviations[]` recording (including `source_files` per orphan for audit), and §6 result-contract integration.
 
 **If `orphan_managed_rows` is empty:** proceed to §4d.
-
-**Scope note:** the pre-check above reads only `target_context_files[0]` — asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, when the first target is `CLAUDE.md`) are not detected. Tracked as Workstream B1 in issue #331 for a multi-file iteration with deduplication by `(skill_name, version)`.
 
 #### 4d. Rewrite Root Paths for Target Context File
 

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -73,33 +73,11 @@ For each entry in `target_context_files`, resolve target file path: `{context_fi
 
 A context file becomes orphaned when its IDE is removed from `config.yaml` after a prior export. The file still contains an SKF managed section pointing to stale skill versions, but no future export will rewrite it.
 
-Build `orphaned_context_files` — the set of context files that exist on disk with an `<!-- SKF:BEGIN -->` marker but whose context file is NOT in the current `target_context_files` list:
+**Cheap pre-check (always run, ~3 file existence checks):** build `orphaned_context_files` — for each known context file in `{CLAUDE.md, .cursorrules, AGENTS.md}` that is NOT in `target_context_files`, check whether it exists on disk and contains the `<!-- SKF:BEGIN -->` marker. If yes, add `{context_file, file_path}` to `orphaned_context_files`.
 
-1. For each known context file in `{CLAUDE.md, .cursorrules, AGENTS.md}`:
-   - If the context file is in `target_context_files`, skip (it will be rewritten in the main loop)
-   - Otherwise, check whether the file exists at `{context_file}`
-   - If the file exists, read it and check for the `<!-- SKF:BEGIN -->` marker
-   - If the marker is present, add the file path to `orphaned_context_files` along with the context file name
+**If `orphaned_context_files` is non-empty:** load `references/orphan-context-detection.md` and follow its (a) clear / (b) keep / (c) rewrite gate protocol. The reference handles user prompting, headless default (keep), and downstream-state recording (`orphans_cleared`, `orphans_rewritten`, `rewrite_context_files`). When the user chooses (c), the §4–§9a loop iterates over `target_context_files + rewrite_context_files`.
 
-2. If `orphaned_context_files` is non-empty, emit a warning:
-
-   "**Orphaned context files detected.** The following files contain SKF managed sections but no configured IDEs target them:
-   {list: context file → file path}
-
-   The managed sections in these files are stale. Options:
-   - **(a) clear** — remove the SKF managed section from each orphaned file (surgical marker replacement, leaves user content intact)
-   - **(b) keep** — leave them untouched (they will remain stale until you re-add an IDE that targets this file or delete the file)
-   - **(c) rewrite** — also rewrite the orphaned files with the current skill index (use this if the IDE was removed by mistake)"
-
-3. Wait for user choice. In non-interactive mode (dry-run or unattended), default to **(b) keep** and print the warning only.
-
-4. If the user chose **(a) clear**: for each orphaned file, replace everything between `<!-- SKF:BEGIN` and `<!-- SKF:END -->` (inclusive) with an empty string, preserving surrounding content byte-exactly. Record the cleared files in `orphans_cleared`.
-
-5. If the user chose **(c) rewrite**: add each orphaned context file to a separate `rewrite_context_files` list (kept distinct from `target_context_files` so the user's intent to only export to configured IDEs is preserved in the manifest). Use `.agents/skills/` as the default skill root for rewritten orphans. Sections 4–9a will loop over `target_context_files + rewrite_context_files` for this run only. Record the rewritten files in `orphans_rewritten`.
-
-6. If the user chose **(b) keep**: record nothing and proceed.
-
-This cleanup only runs during interactive export. Drop-skill and rename-skill operate on the manifest's declared context files and are not responsible for orphan detection.
+**If `orphaned_context_files` is empty:** proceed to §4.
 
 ### 4. Rebuild Complete Skill Index
 
@@ -146,32 +124,19 @@ Instead of globbing `{skills_output_folder}/*/context-snippet.md`, resolve snipp
 
 #### 4c.1 Detect Orphaned Managed-Section Rows (manifest-absent skills)
 
-A managed-section row becomes orphaned when a `[skill-name v...]` entry already exists in the prior managed section but the skill is not in the exported skill set built in 4b — typically an externally-installed skill that was authored in a different repo and dropped into the user's `{skills_output_folder}` without going through export-skill. Strict ADR-K would silently drop such rows, but the user's managed section is load-bearing — silent removal of an installed skill is a regression an attentive operator caught manually in this run, recording a `deviations[].kind = "preserve_external_skills"` ad-hoc.
+A managed-section row becomes orphaned when a `[skill-name v...]` entry already exists in the prior managed section but the skill is not in the exported skill set built in 4b — typically an externally-installed skill authored in a different repo and dropped into `{skills_output_folder}` without going through export-skill. Strict ADR-K would silently drop such rows, but the user's managed section is load-bearing — silent removal is a regression.
 
-Detect this case before §5 assembly so the operator (or `{headless_mode}`) makes an explicit choice:
+**Cheap pre-check (always run before §5 assembly):**
 
-1. Read the prior managed section from the **first target context file** (`target_context_files[0].context_file`). Parse the `[skill-name v...]` rows between `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` into `prior_section_rows` — a list of `{skill_name, version}` pairs. If the file does not exist or has no managed section, set `prior_section_rows = []` and skip to §5.
-2. Build `orphan_managed_rows` — every entry in `prior_section_rows` whose `skill_name` is NOT in the exported skill set built in 4b (manifest entries plus current-export targets). For each orphan, capture the original snippet line(s) verbatim from the prior section.
-3. **If `orphan_managed_rows` is non-empty**, present a halt-gate:
+1. Read the prior managed section from the first target context file (`target_context_files[0].context_file`). If the file does not exist or has no `<!-- SKF:BEGIN -->` marker, set `orphan_managed_rows = []` and skip to §4d.
+2. Parse the `[skill-name v...]` rows between `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` into `prior_section_rows` — a list of `{skill_name, version, snippet_text}` triples (capture the original snippet line(s) verbatim so they can be re-emitted unchanged if (b) is chosen).
+3. Build `orphan_managed_rows` — every entry in `prior_section_rows` whose `skill_name` is NOT in the exported skill set built in 4b (manifest entries plus current-export targets).
 
-   "**Managed-section rows present but absent from manifest:**
+**If `orphan_managed_rows` is non-empty:** load `references/orphan-row-detection.md` and follow its (a) Drop / (b) Preserve verbatim / (c) Cancel gate protocol. The reference handles user prompting, headless default (Preserve verbatim), `deviations[]` recording, and §6 result-contract integration.
 
-   {list each as `- {skill_name} v{version}`}
+**If `orphan_managed_rows` is empty:** proceed to §4d.
 
-   These skills appear in the existing managed section in `{first-context-file}` but no entry exists in `.export-manifest.json` and no source draft exists under `{skills_output_folder}/{skill_name}/`. They were likely installed from a different repo and never run through export-skill in this project. Options:
-
-   - **(a) Drop** — remove these rows from the rebuilt managed section (strict ADR-K behavior). The skills' on-disk files are not touched, but they will no longer appear in any context file's managed index.
-   - **(b) Preserve verbatim** — copy each orphan's existing snippet line(s) into the rebuilt managed section unchanged. Records `deviations[].kind = \"preserve_external_skills\"` with the affected skill names and versions in the result contract for audit.
-   - **(c) Cancel** — abort export. Run export-skill against each external skill (or remove the orphan rows from the context file manually) before re-running."
-
-4. **Gate handling:**
-   - **(a) Drop:** Do not include any orphan rows in the rebuilt section. Record `orphans_dropped = [{skill_name, version}, …]` in workflow context for the §6 result contract.
-   - **(b) Preserve verbatim:** Append each captured snippet to the assembled section after the manifest-driven entries, preserving alphabetical order in the merged list. Append `{kind: "preserve_external_skills", skills: [{name, version}, …], rationale: "managed-section row exists but no manifest entry / no source draft"}` to the `deviations[]` array in the §6 result contract. The same orphans are written to **every** target context file in the loop (so all configured IDEs end up with consistent managed sections).
-   - **(c) Cancel:** HALT the workflow. Do not rewrite any context file. Do not update the manifest. Do not produce a result contract.
-
-5. **Headless default** (when `{headless_mode}`): auto-select **(b) Preserve verbatim**, with the same `deviations[]` entry. Emit a loud log line: `"headless: {N} managed-section rows had no manifest entry; preserving verbatim with deviations[].kind = preserve_external_skills. Run export-skill against each to migrate them into the manifest."` Silent drop under automation would regress the user's managed section without consent; cancel under automation would block the whole export over an externally-installed skill the user did not author. Preservation matches the prior-attentive-operator convention captured in `skills/export-skill-result-latest.json` deviations.
-
-This detection runs once per export run (not per target context file) — orphan rows are inherent to the prior state of the first context file and the choice is global.
+**Scope note:** the pre-check above reads only `target_context_files[0]` — asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, when the first target is `CLAUDE.md`) are not detected. Tracked as Workstream B1 in issue #331 for a multi-file iteration with deduplication by `(skill_name, version)`.
 
 #### 4d. Rewrite Root Paths for Target Context File
 

--- a/src/skf-rename-skill/references/execute.md
+++ b/src/skf-rename-skill/references/execute.md
@@ -227,75 +227,16 @@ Report: "**Manifest updated** — re-keyed `exports.{old_name}` → `exports.{ne
 
 ### 7. Rebuild Context Files
 
-Load the `ides` list from `config.yaml`. The installer writes IDE identifiers — these must be mapped to context files and skill roots using the "IDE → Context File Mapping" table in `{managedSectionLogic}`.
+Load `references/rebuild-context.md` and follow its per-IDE managed-section sweep. The reference resolves `target_context_files` from `config.yaml.ides` (via `{managedSectionLogic}`'s mapping table), iterates each context file, builds the exported skill set (version-aware, deprecated-excluded — the manifest re-key from §6 is already in effect so `{new_name}` is present and `{old_name}` is absent), rewrites root paths via the §4d algorithm, assembles the new managed section, and invokes `{rebuildManagedSectionsHelper}` for the surgical between-marker swap.
 
-**Resolve `target_context_files`** using the canonical mapping table in `{managedSectionLogic}`:
+After the loop returns, the workflow context contains:
 
-1. For each entry in `config.yaml.ides`, look up its `context_file` and `skill_root` from the mapping table
-2. For any entry not found in the table, default to AGENTS.md / `.agents/skills/` and emit a warning: "Unknown IDE '{value}' in config.yaml — defaulting to AGENTS.md"
-3. Deduplicate by `context_file` — when multiple IDEs map to the same context file, use the first configured IDE's `skill_root`
-4. If `config.yaml.ides` is absent or the mapping yields an empty list, fall back to `[{context_file: "AGENTS.md", skill_root: ".agents/skills/"}]` and emit a note: "No IDEs configured in config.yaml — defaulting to AGENTS.md"
+- `context_files_updated` — list of files successfully rewritten
+- `context_files_failed` — list of any that failed (per-file failures do not halt the rename — the manifest and filesystem are already canonical state, so context files can be re-rebuilt later via `[EX] Export Skill`)
 
-Store the result as `target_context_files` for this section.
+Report per the reference's after-loop block, then proceed to §8.
 
-For each entry in `target_context_files`:
-
-1. **Resolve target file** at `{context_file}`.
-
-2. **Read the current file.**
-   - If the file does not exist, skip this context file (nothing to rebuild — the file will be re-created next time export-skill runs)
-   - If the file exists but contains no `<!-- SKF:BEGIN -->` marker, skip this context file (no managed section to rewrite)
-   - If the file contains `<!-- SKF:BEGIN -->` but no matching `<!-- SKF:END -->`, record the error against that context file and continue to the next entry — do not halt the entire rename on a malformed context file
-
-3. **Build the exported skill set (version-aware, deprecated-excluded)** using the same logic as export-skill step 4 section 4b and the snippet resolution logic from section 4c:
-   - Read the manifest's `exports` object (already updated in section 6, so `{new_name}` is present and `{old_name}` is absent)
-   - For each skill, resolve its `active_version`
-   - If `versions.{active_version}.status == "deprecated"`, skip that skill entirely
-   - For each remaining `{skill-name, active_version}` pair, read `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/context-snippet.md`
-   - If missing, fall back to the `active` symlink path; if still missing, skip with a warning
-
-4. **Rewrite root paths for the current context file** using the generic rewrite algorithm from export-skill step 4 section 4d:
-
-   For each snippet, parse the `root:` line (`root: {prefix}{skill-name}/`), strip the trailing `{skill-name}/` to extract the current prefix, and replace it with the **effective target prefix** if different. The effective target prefix is `snippet_skill_root_override` when that key is set in config.yaml — applied uniformly to every snippet so the managed section references the real on-disk location and never mixes override and per-IDE paths — otherwise the current entry's `skill_root`. See `skf-export-skill/references/update-context.md` §4d for full semantics.
-
-5. **Sort skills alphabetically by name.** Count totals (skills, stack skills).
-
-6. **Assemble the new managed section** using the format from `{managedSectionLogic}`:
-
-   ```markdown
-   <!-- SKF:BEGIN updated:{current-date} -->
-   [SKF Skills]|{n} skills|{m} stack
-   |IMPORTANT: Prefer documented APIs over training data.
-   |When using a listed library, read its SKILL.md before writing code.
-   |
-   |{skill-snippet-1}
-   |
-   |{skill-snippet-2}
-   |
-   |{skill-snippet-N}
-   <!-- SKF:END -->
-   ```
-
-7. **Surgical replacement — atomic, deterministic.** Invoke `{rebuildManagedSectionsHelper}` for the surgical between-marker swap:
-
-   ```bash
-   python3 {rebuildManagedSectionsHelper} {context_file} replace --content "{new_managed_section_text}"
-   ```
-
-   The helper handles marker location, between-marker swap, atomic temp-file + rename, and post-write verification (markers preserved, content outside markers byte-identical). It exits non-zero on any failure with a clear `stderr` reason.
-
-8. **Verify (deferred to helper).** The `replace` action above performs verification internally. Treat any non-zero exit code as a per-file failure (next bullet).
-
-9. **On per-file failure:** record the error against that context file and continue to the next entry. Do not halt the rename on a recoverable per-context-file error — the manifest and filesystem are already consistent; context files can be re-rebuilt later via `[EX] Export Skill`.
-
-**After the loop:**
-
-- Record `context_files_updated` as the list of files that were successfully rewritten
-- Record `context_files_failed` as the list of any that failed
-
-Report: "**Rebuilt managed sections in:** {list of updated files}. {if any failed: 'Failed: {list} — re-run `[EX] Export Skill` to retry.'}"
-
-**Note:** Section 7 failures do not trigger a rollback because the manifest and filesystem are the canonical state. Platform context files are derived artifacts that can be regenerated at any time.
+**Note:** §7 failures do not trigger a rollback. Platform context files are derived artifacts; the manifest and on-disk skill directories are the canonical state.
 
 ### 8. Delete Old Directories (Point of No Return)
 

--- a/src/skf-rename-skill/references/rebuild-context.md
+++ b/src/skf-rename-skill/references/rebuild-context.md
@@ -1,0 +1,110 @@
+---
+# Static reference loaded by execute.md §7. The carve removes ~70
+# lines of context-rebuild loop logic from the main execute.md so
+# the §1–§6 + §8–§10 critical-path stays tight; §7 itself is always
+# reached on the success path so this file loads on every successful
+# rename, but the rollback paths (§4–§6 failure jumps) skip §7
+# entirely and never load this reference.
+---
+
+<!-- Config: communicate in {communication_language}. Render the rebuilt-files report in {document_output_language}. -->
+
+# Rename: Rebuild Context Files (per-IDE managed-section sweep)
+
+## Purpose
+
+After §6 re-keys the manifest from `{old_name}` to `{new_name}`, every IDE's context file (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, etc.) still contains the old name in its managed-section snippet rows. This step rewrites each one in-place via the surgical between-marker swap so the on-disk managed sections reflect the new name.
+
+Loaded by `execute.md` §7 once `manifest_updated == true` (§6 succeeded) and the rollback paths in §4–§6 were not taken.
+
+## Resolve target_context_files
+
+Load the `ides` list from `config.yaml`. The installer writes IDE identifiers — these must be mapped to context files and skill roots using the "IDE → Context File Mapping" table in `{managedSectionLogic}`:
+
+1. For each entry in `config.yaml.ides`, look up its `context_file` and `skill_root` from the mapping table.
+2. For any entry not found in the table, default to AGENTS.md / `.agents/skills/` and emit a warning: `Unknown IDE '{value}' in config.yaml — defaulting to AGENTS.md`.
+3. Deduplicate by `context_file` — when multiple IDEs map to the same context file, use the first configured IDE's `skill_root`.
+4. If `config.yaml.ides` is absent or the mapping yields an empty list, fall back to `[{context_file: "AGENTS.md", skill_root: ".agents/skills/"}]` and emit a note: `No IDEs configured in config.yaml — defaulting to AGENTS.md`.
+
+Store the result as `target_context_files`.
+
+## Per-file loop
+
+For each entry in `target_context_files`:
+
+### 1. Resolve target file
+
+Resolve the absolute path at `{context_file}`.
+
+### 2. Read the current file
+
+- If the file does not exist, skip this context file (nothing to rebuild — the file will be re-created the next time export-skill runs).
+- If the file exists but contains no `<!-- SKF:BEGIN -->` marker, skip this context file (no managed section to rewrite).
+- If the file contains `<!-- SKF:BEGIN -->` but no matching `<!-- SKF:END -->`, record the error against that context file and continue to the next entry — do not halt the entire rename on a malformed context file.
+
+### 3. Build the exported skill set (version-aware, deprecated-excluded)
+
+Use the same logic as `skf-export-skill/references/update-context.md` §4b and the snippet resolution from §4c:
+
+- Read the manifest's `exports` object (already updated in §6, so `{new_name}` is present and `{old_name}` is absent).
+- For each skill, resolve its `active_version`.
+- If `versions.{active_version}.status == "deprecated"`, skip that skill entirely.
+- For each remaining `{skill-name, active_version}` pair, read `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/context-snippet.md`.
+- If missing, fall back to the `active` symlink path; if still missing, skip with a warning.
+
+### 4. Rewrite root paths for the current context file
+
+Use the generic rewrite algorithm from `skf-export-skill/references/update-context.md` §4d:
+
+For each snippet, parse the `root:` line (`root: {prefix}{skill-name}/`), strip the trailing `{skill-name}/` to extract the current prefix, and replace it with the **effective target prefix** if different. The effective target prefix is `snippet_skill_root_override` when that key is set in `config.yaml` — applied uniformly to every snippet so the managed section references the real on-disk location and never mixes override and per-IDE paths — otherwise the current entry's `skill_root`. See `skf-export-skill/references/update-context.md` §4d for full semantics.
+
+### 5. Sort and count
+
+Sort skills alphabetically by name. Count totals (skills, stack skills).
+
+### 6. Assemble the new managed section
+
+Use the format from `{managedSectionLogic}`:
+
+```markdown
+<!-- SKF:BEGIN updated:{current-date} -->
+[SKF Skills]|{n} skills|{m} stack
+|IMPORTANT: Prefer documented APIs over training data.
+|When using a listed library, read its SKILL.md before writing code.
+|
+|{skill-snippet-1}
+|
+|{skill-snippet-2}
+|
+|{skill-snippet-N}
+<!-- SKF:END -->
+```
+
+### 7. Surgical replacement — atomic, deterministic
+
+Invoke `{rebuildManagedSectionsHelper}` (resolved from `{rebuildManagedSectionsProbeOrder}` in `execute.md` frontmatter) for the surgical between-marker swap:
+
+```bash
+python3 {rebuildManagedSectionsHelper} {context_file} replace --content "{new_managed_section_text}"
+```
+
+The helper handles marker location, between-marker swap, atomic temp-file + rename, and post-write verification (markers preserved, content outside markers byte-identical). It exits non-zero on any failure with a clear `stderr` reason.
+
+### 8. Verify (deferred to helper)
+
+The `replace` action above performs verification internally. Treat any non-zero exit code as a per-file failure (next bullet).
+
+### 9. On per-file failure
+
+Record the error against that context file and continue to the next entry. Do not halt the rename on a recoverable per-context-file error — the manifest and filesystem are already consistent; context files can be re-rebuilt later via `[EX] Export Skill`.
+
+## After the loop
+
+- Record `context_files_updated` as the list of files that were successfully rewritten.
+- Record `context_files_failed` as the list of any that failed.
+
+Report: `**Rebuilt managed sections in:** {list of updated files}. {if any failed: 'Failed: {list} — re-run [EX] Export Skill to retry.'}`
+
+## Rollback semantics
+
+§7 failures **do not** trigger a rollback. The manifest and filesystem are the canonical state — context files are derived artifacts that can be regenerated at any time via `[EX] Export Skill`. The rename is considered successful as soon as §6 lands, even if §7 partially or fully fails to rewrite context files.


### PR DESCRIPTION
## Summary

Workstream A (structural carves) from issue #331. Three independent carves moving conditional protocols from inline prose into dedicated `references/*.md` files with explicit load triggers.

| Commit | Carve | Main file Δ | New reference files |
|---|---|---|---|
| `05563314` | EX `update-context.md` §3b + §4c.1 | 383 → 348 (−35) | `orphan-context-detection.md` (75), `orphan-row-detection.md` (98) |
| `733bf2df` | EX `load-skill.md` §1b + §1c | 258 → 219 (−39) | `preflight-snippet-root-probe.md` (74), `multi-skill-mode.md` (38) |
| `45ee6e27` | RS `execute.md` §7 | 364 → 305 (−59) | `rebuild-context.md` (110) |

**Total main-file reduction: 133 lines.** Each carve preserves a cheap pre-check inline so the trigger condition stays observable without loading the reference; the heavier gate-handling / iteration logic is lazy-loaded only when the trigger fires.

## Carves and triggers

- **A1 §3b** loads `orphan-context-detection.md` only when a known context file (`CLAUDE.md`/`.cursorrules`/`AGENTS.md`) exists on disk with an SKF marker but is not in `target_context_files`.
- **A1 §4c.1** loads `orphan-row-detection.md` only when the prior managed section in the first target context file contains rows for skills absent from the manifest-driven exported skill set.
- **A2 §1b** loads `preflight-snippet-root-probe.md` only when `snippet_skill_root_override` is unset in `config.yaml`.
- **A2 §1c** loads `multi-skill-mode.md` only when `len(skill_batch) > 1` (skipped entirely in the common single-skill case).
- **A3 §7** loads `rebuild-context.md` on the success path after §6 manifest re-key (rollback paths in §4–§6 skip §7 entirely).

## Scope-shift note (A4 dropped)

Issue #331 also listed Workstream A4 (`skf-verify-stack/references/init.md` §2 carve). Verification before this PR found that A4 has been superseded — `skf-enumerate-stack-skills.py` is already the primary path, and orphan detection has moved into the helper's `warnings[]` array rather than living as a standalone §2 prose section. A4 will be marked superseded in the #331 closeout, not addressed here.

## Behavior preserved

No semantic changes. Workflow-context contracts (`orphans_cleared`, `orphans_rewritten`, `rewrite_context_files`, `orphan_managed_rows`, `orphans_dropped`, `deviations[]`, `observed_prefixes`, `skill_batch`, `target_context_files`, `context_files_updated`, `context_files_failed`, `manifest_updated`) preserved verbatim so downstream sections continue to resolve.

The §4c.1 stub explicitly notes its `target_context_files[0]`-only scope as a known limitation tracked under Workstream B1 (PR to follow).

## Test plan

- [x] Pre-commit hooks (`markdownlint-cli2` + full `npm test` suite) passed on each of the 3 commits
- [x] Manual end-to-end smoke: run `[EX] Export Skill` against a single skill in single-skill mode (exercises the no-mismatch + no-orphan fast paths — the carved files should NOT be loaded)
- [x] Manual end-to-end smoke: run `[EX] Export Skill --all` (exercises `multi-skill-mode.md` load)
- [x] Manual smoke: rename a skill (exercises `rebuild-context.md` load on the success path)

Refs #331 — Workstream A (A1, A2, A3). A4 superseded; B1, C3 follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)