### PR TITLE
fix(skf-export-skill): multi-file orphan-row probe with (skill, version) dedup

### DIFF
--- a/src/skf-export-skill/references/orphan-row-detection.md
+++ b/src/skf-export-skill/references/orphan-row-detection.md
@@ -21,23 +21,23 @@ Strict ADR-K would silently drop such rows, but the user's managed section is lo
 
 ## Inputs
 
-- `orphan_managed_rows` — list of `{skill_name, version, snippet_text}` entries built by §4c.1's pre-check (each `snippet_text` is the original snippet line(s) captured verbatim from the prior section, so they can be re-emitted unchanged if (b) is chosen)
-- `target_context_files[0].context_file` — the file the orphans were detected in (used in the gate prompt for traceability)
+- `orphan_managed_rows` — list of `{skill_name, version, snippet_text, source_files: []}` entries built by §4c.1's pre-check across **every** target context file, deduplicated by `(skill_name, version)`. `source_files` carries the file paths the orphan appeared in (one entry per file in which the row was found). `snippet_text` is the original snippet line(s) captured verbatim from the first encountered occurrence, used for re-emission if (b) is chosen.
+- `target_context_files` — the full IDE → context-file list (referenced in the gate's framing copy so the user understands the consolidation scope)
 - `{headless_mode}` — boolean flag from workflow context
 
 ## Gate Protocol
 
 Emit the gate:
 
-> **Managed-section rows present but absent from manifest:**
+> **Managed-section rows present but absent from manifest** (consolidated across {len(target_context_files)} target context file(s)):
 >
-> {list each as `- {skill_name} v{version}`}
+> {list each as `- {skill_name} v{version} (in: {comma-separated source_files})`}
 >
-> These skills appear in the existing managed section in `{first-context-file}` but no entry exists in `.export-manifest.json` and no source draft exists under `{skills_output_folder}/{skill_name}/`. They were likely installed from a different repo and never run through export-skill in this project. Options:
+> These skills appear in one or more existing managed sections but no entry exists in `.export-manifest.json` and no source draft exists under `{skills_output_folder}/{skill_name}/`. They were likely installed from a different repo and never run through export-skill in this project. Options:
 >
-> - **(a) Drop** — remove these rows from the rebuilt managed section (strict ADR-K behavior). The skills' on-disk files are not touched, but they will no longer appear in any context file's managed index.
-> - **(b) Preserve verbatim** — copy each orphan's existing snippet line(s) into the rebuilt managed section unchanged. Records `deviations[].kind = "preserve_external_skills"` with the affected skill names and versions in the result contract for audit.
-> - **(c) Cancel** — abort export. Run export-skill against each external skill (or remove the orphan rows from the context file manually) before re-running.
+> - **(a) Drop** — remove these rows from the rebuilt managed section across **all** target context files (strict ADR-K behavior). The skills' on-disk files are not touched, but they will no longer appear in any context file's managed index.
+> - **(b) Preserve verbatim** — copy each orphan's existing snippet line(s) into the rebuilt managed section across **all** target context files unchanged (one canonical row per `(skill, version)` written everywhere — orphans become symmetric across IDEs as a side effect, which is the correct outcome since the user's intent is "these external skills should appear in my managed index"). Records `deviations[].kind = "preserve_external_skills"` with the affected skill names, versions, and `source_files` in the result contract for audit.
+> - **(c) Cancel** — abort export. Run export-skill against each external skill (or remove the orphan rows from the context files manually) before re-running.
 
 Wait for user choice.
 
@@ -61,19 +61,23 @@ in workflow context for the §6 result contract.
 
 ### (b) Preserve verbatim
 
-Append each captured `snippet_text` to the assembled section after the manifest-driven entries, preserving alphabetical order in the merged list (sort the combined set of `manifest-driven` + `orphan` snippets by `skill_name`).
+Append each captured `snippet_text` to the assembled section after the manifest-driven entries, preserving alphabetical order in the merged list (sort the combined set of `manifest-driven` + `orphan` snippets by `skill_name`). Each `(skill, version)` is written **once** per rebuilt managed section — the deduplication done by §4c.1 means there is no per-file divergence to reconcile here.
 
 Append the following entry to the `deviations[]` array in the §6 result contract:
 
 ```json
 {
   "kind": "preserve_external_skills",
-  "skills": [{"name": "...", "version": "..."}, …],
+  "skills": [
+    {"name": "...", "version": "...", "source_files": ["..."]}
+  ],
   "rationale": "managed-section row exists but no manifest entry / no source draft"
 }
 ```
 
-The same orphans are written to **every** target context file in the §4–§9a loop, so all configured IDEs end up with consistent managed sections.
+`source_files` per skill records the prior context files the orphan was found in (asymmetric provenance preserved for audit) — useful when an operator later debugs which IDE's managed section originally carried the row.
+
+The same orphans are written to **every** target context file in the §4–§9a loop, so all configured IDEs end up with consistent managed sections (asymmetric prior orphans become symmetric — the correct outcome for the "preserve external skills" intent).
 
 ### (c) Cancel
 
@@ -95,4 +99,4 @@ After this protocol completes, §4c.1 returns control to §4d with these workflo
 
 ## Scope note
 
-This detection runs once per export run (not per target context file) — orphan rows are inherent to the prior state of the first context file and the choice is global. The §B1 multi-file fix (issue #331 — Workstream B1) tracks expanding this to iterate over every entry in `target_context_files`; until then, asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, when `target_context_files[0]` is `CLAUDE.md`) are not detected by this protocol.
+This detection runs once per export run (not per target context file) — the §4c.1 pre-check iterates **every** entry in `target_context_files` and deduplicates by `(skill_name, version)` before invoking this protocol, so the gate's choice applies globally and asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, or vice versa) are detected and surfaced with `source_files` provenance.

--- a/src/skf-export-skill/references/summary.md
+++ b/src/skf-export-skill/references/summary.md
@@ -147,10 +147,14 @@ Substitute `{skill_batch_names}`, `{context_files_updated}`, and `{headless_deci
 ```json
 {
   "kind": "preserve_external_skills",
-  "skills": [{"name": "skill-name", "version": "1.0.0"}, …],
+  "skills": [
+    {"name": "skill-name", "version": "1.0.0", "source_files": ["CLAUDE.md", ".cursorrules"]}
+  ],
   "rationale": "managed-section row exists but no manifest entry / no source draft"
 }
 ```
+
+`source_files` per skill records the prior context files the orphan was found in (the §4c.1 multi-file scan deduplicates by `(skill, version)` and tracks which target context files originally carried the row — useful when an operator later debugs which IDE's managed section first introduced the external skill).
 
 Other workflow choices that diverge from the strict spec path may add their own entries with a distinct `kind` value — auditors then have one place to look for "what did this run choose to do differently from the canonical flow." Omit the field when there are no deviations rather than writing an empty array, so the absence is readable as "ran the canonical path."
 

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -126,17 +126,21 @@ Instead of globbing `{skills_output_folder}/*/context-snippet.md`, resolve snipp
 
 A managed-section row becomes orphaned when a `[skill-name v...]` entry already exists in the prior managed section but the skill is not in the exported skill set built in 4b — typically an externally-installed skill authored in a different repo and dropped into `{skills_output_folder}` without going through export-skill. Strict ADR-K would silently drop such rows, but the user's managed section is load-bearing — silent removal is a regression.
 
-**Cheap pre-check (always run before §5 assembly):**
+**Cheap pre-check (always run before §5 assembly).** Scan **every** target context file (not just the first), deduplicate by `(skill_name, version)`, and present one consolidated gate. Asymmetric orphans — a row present in `.cursorrules` but absent from `CLAUDE.md`, or vice versa — must be detected; otherwise the §4 rebuild loop silently overwrites the orphan-bearing file's content (ADR-J violation: silent loss of user content).
 
-1. Read the prior managed section from the first target context file (`target_context_files[0].context_file`). If the file does not exist or has no `<!-- SKF:BEGIN -->` marker, set `orphan_managed_rows = []` and skip to §4d.
-2. Parse the `[skill-name v...]` rows between `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` into `prior_section_rows` — a list of `{skill_name, version, snippet_text}` triples (capture the original snippet line(s) verbatim so they can be re-emitted unchanged if (b) is chosen).
-3. Build `orphan_managed_rows` — every entry in `prior_section_rows` whose `skill_name` is NOT in the exported skill set built in 4b (manifest entries plus current-export targets).
+1. Initialize `orphan_managed_rows = []` (a list of `{skill_name, version, snippet_text, source_files: []}` entries — `source_files` carries provenance for the gate display and the audit `deviations[]` entry).
+2. **Iterate every entry in `target_context_files`:**
+   a. Read the prior managed section from `{entry.context_file}`. If the file does not exist or has no `<!-- SKF:BEGIN -->` marker, skip this entry — it has no orphans by definition.
+   b. Parse the `[skill-name v...]` rows between `<!-- SKF:BEGIN -->` and `<!-- SKF:END -->` into `file_rows` — a list of `{skill_name, version, snippet_text}` triples (capture the original snippet line(s) verbatim so they can be re-emitted unchanged if (b) is chosen).
+   c. For each `row` in `file_rows`:
+      - If `row.skill_name` is in the exported skill set built in 4b (manifest entries plus current-export targets), skip — not an orphan.
+      - Otherwise look up `(row.skill_name, row.version)` in `orphan_managed_rows`:
+        - If already present, append `entry.context_file` to that row's `source_files` list (deduplicated). Keep the first-encountered `snippet_text` — divergent snippets across files for the same `(skill, version)` are themselves a user-content asymmetry but the `(b) Preserve verbatim` semantic writes one canonical row to every target file, so picking the first is deterministic and avoids silently choosing.
+        - If new, append `{skill_name: row.skill_name, version: row.version, snippet_text: row.snippet_text, source_files: [entry.context_file]}`.
 
-**If `orphan_managed_rows` is non-empty:** load `references/orphan-row-detection.md` and follow its (a) Drop / (b) Preserve verbatim / (c) Cancel gate protocol. The reference handles user prompting, headless default (Preserve verbatim), `deviations[]` recording, and §6 result-contract integration.
+**If `orphan_managed_rows` is non-empty:** load `references/orphan-row-detection.md` and follow its (a) Drop / (b) Preserve verbatim / (c) Cancel gate protocol. The reference handles user prompting (with per-orphan `source_files` provenance), headless default (Preserve verbatim), `deviations[]` recording (including `source_files` per orphan for audit), and §6 result-contract integration.
 
 **If `orphan_managed_rows` is empty:** proceed to §4d.
-
-**Scope note:** the pre-check above reads only `target_context_files[0]` — asymmetric orphans (a row present in `.cursorrules` but not in `CLAUDE.md`, when the first target is `CLAUDE.md`) are not detected. Tracked as Workstream B1 in issue #331 for a multi-file iteration with deduplication by `(skill_name, version)`.
 
 #### 4d. Rewrite Root Paths for Target Context File
 


### PR DESCRIPTION
## Summary

Closes the silent-data-loss bug identified as Workstream B1 in issue #331. Stacked on #332 (which carved the orphan-row gate to `references/orphan-row-detection.md`); base will auto-rebase to `v2` once #332 merges.

## The bug

§4c.1's pre-check previously read only `target_context_files[0]` when scanning for managed-section rows absent from the manifest-driven exported skill set. If the first target was `CLAUDE.md` and an orphan-bearing row existed only in `.cursorrules` or `AGENTS.md`, the orphan went undetected and the §4–§9a rebuild loop **silently overwrote** the orphan-bearing file's content with the manifest-driven section.

**Severity:** silent loss of user-authored content — ADR-J violation. Low frequency (asymmetric orphans require a user to manually edit one IDE's managed section but not another) but high-correctness work.

## The fix

- Iterate the orphan probe across **every** entry in `target_context_files`
- Deduplicate by `(skill_name, version)`, tracking which file(s) each orphan appeared in via a new `source_files: []` field per row
- Present one consolidated gate listing each orphan with its source-file provenance: `- {skill} v{version} (in: CLAUDE.md, .cursorrules)`
- (b) Preserve verbatim semantic unchanged: write one canonical row per `(skill, version)` to every target context file (asymmetric prior orphans become symmetric — the correct outcome since the user's intent is "these external skills should appear in my managed index")
- Result-contract `deviations[].skills[]` entries now carry `source_files` per skill so an auditor can see which IDE's managed section first introduced each external skill

## Files changed

| File | Change |
|---|---|
| `update-context.md` §4c.1 | Multi-file iteration + `(skill, version)` dedup logic. Trigger remains observable (`orphan_managed_rows` non-empty after the multi-file scan). |
| `orphan-row-detection.md` | Gate copy reflects consolidation across all target files; `deviations[]` schema documents `source_files`; scope-note no longer flags single-file limitation. |
| `summary.md` | Result-contract example shows `source_files` in the `preserve_external_skills` deviation entry. |

## On test coverage

No automated test added. The §4c.1 protocol is LLM-interpreted prose, not a script. The codebase's tests cover shared Python helpers (`test-skf-rebuild-managed-sections.py` et al.); workflow-prose semantics rely on contract documentation + manual smoke validation.

The fix is small enough and the contract is explicit enough that prose review is the appropriate validation surface. If desired, a future work item could add a fixture-driven workflow integration test that constructs an asymmetric-orphan scenario and asserts the gate fires — but that requires test infrastructure that doesn't exist yet for prose protocols.

## Test plan

- [x] Pre-commit hooks (`markdownlint-cli2` + full `npm test` suite) passed
- [x] Manual smoke (post-#332-merge): construct a fixture with `CLAUDE.md` clean and `.cursorrules` carrying a stale `[external-lib v1.0.0]` row not in the manifest, then run `[EX] Export Skill --all`. Verify the gate fires and lists `external-lib v1.0.0 (in: .cursorrules)`.

Refs #331 — Workstream B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)