### PR TITLE
chore(skf): propagate v2 Workflow Rules trim across skf-* skills

### DIFF
--- a/src/skf-analyze-source/SKILL.md
+++ b/src/skf-analyze-source/SKILL.md
@@ -25,8 +25,6 @@ You are a source code analyst and decomposition architect collaborating with a d
 
 These rules apply to every step in this workflow:
 
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}` (the language for user-facing prose). Written artifact text — the per-unit recommendation `description` and `scope.notes` persisted into `skill-brief.yaml` — is in `{document_output_language}`; per-step rules call this out where it applies. The two values may be the same.
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision

--- a/src/skf-analyze-source/references/continue.md
+++ b/src/skf-analyze-source/references/continue.md
@@ -24,8 +24,6 @@ To resume the analyze-source workflow from where it was left off in a previous s
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Welcome Back
 
 "**Welcome back!** Let me check where we left off with the source analysis..."

--- a/src/skf-analyze-source/references/generate-briefs.md
+++ b/src/skf-analyze-source/references/generate-briefs.md
@@ -21,8 +21,6 @@ To generate a valid skill-brief.yaml file for each confirmed unit using the sche
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Context
 
 Read {outputFile} completely to obtain:

--- a/src/skf-analyze-source/references/identify-units.md
+++ b/src/skf-analyze-source/references/identify-units.md
@@ -21,8 +21,6 @@ To classify each detected boundary from the project scan into discrete skillable
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Context
 
 Read {outputFile} to obtain:

--- a/src/skf-analyze-source/references/init.md
+++ b/src/skf-analyze-source/references/init.md
@@ -21,8 +21,6 @@ To initialize the analyze-source workflow by loading configuration, detecting co
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Check for Existing Report (Continuation Detection)
 
 Look for {outputFile}.

--- a/src/skf-analyze-source/references/map-and-detect.md
+++ b/src/skf-analyze-source/references/map-and-detect.md
@@ -21,8 +21,6 @@ To analyze each qualifying unit's export surface and import graph, detect cross-
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Context
 
 Read {outputFile} to obtain:

--- a/src/skf-analyze-source/references/recommend.md
+++ b/src/skf-analyze-source/references/recommend.md
@@ -22,8 +22,6 @@ To present each qualifying unit as a recommendation with evidence-based rational
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Context
 
 Read {outputFile} completely to obtain:

--- a/src/skf-analyze-source/references/scan-project.md
+++ b/src/skf-analyze-source/references/scan-project.md
@@ -22,8 +22,6 @@ To map the complete project structure by scanning directory trees, detecting ser
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Context
 
 Read {outputFile} frontmatter to obtain:

--- a/src/skf-audit-skill/SKILL.md
+++ b/src/skf-audit-skill/SKILL.md
@@ -26,8 +26,6 @@ You are a skill auditor operating in Ferris Audit mode. This is a deterministic 
 These rules apply to every step in this workflow:
 
 - Never fabricate findings — all data must trace to source code with file:line citations
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Update `stepsCompleted` in output file frontmatter before loading next step
 - Always communicate in `{communication_language}`

--- a/src/skf-audit-skill/references/init.md
+++ b/src/skf-audit-skill/references/init.md
@@ -23,8 +23,6 @@ Load the existing skill artifacts, provenance map, and forge tier configuration 
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 **Initialize workflow context defaults.** Before entering §1, set `confidence_mode = "normal"` as the default. §4 may upgrade this to `"degraded — all findings T1-low"` if the operator opts into degraded mode. Downstream steps (report.md, drift-report-template.md) consume this variable directly — no conditional at the usage site.
 
 ### 1. Get Skill Path

--- a/src/skf-audit-skill/references/re-index.md
+++ b/src/skf-audit-skill/references/re-index.md
@@ -19,8 +19,6 @@ Re-scan the source code using the current forge tier tools to build a fresh extr
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Determine Extraction Strategy
 
 Based on forge tier detected in Step 01:

--- a/src/skf-audit-skill/references/report.md
+++ b/src/skf-audit-skill/references/report.md
@@ -20,8 +20,6 @@ Finalize the drift report by completing the Audit Summary with calculated metric
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Complete Audit Summary
 
 Update the ## Audit Summary section at the top of {outputFile} with final calculated values:

--- a/src/skf-audit-skill/references/semantic-diff.md
+++ b/src/skf-audit-skill/references/semantic-diff.md
@@ -20,8 +20,6 @@ Compare QMD knowledge context between the original skill creation and current st
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Check Forge Tier
 
 **IF forge tier is Quick, Forge, or Forge+:**

--- a/src/skf-audit-skill/references/severity-classify.md
+++ b/src/skf-audit-skill/references/severity-classify.md
@@ -20,8 +20,6 @@ Grade every drift finding from Steps 03 and 04 by severity level (CRITICAL/HIGH/
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Severity Rules
 
 Launch a subprocess (Pattern 3 — data operations) that:

--- a/src/skf-audit-skill/references/structural-diff.md
+++ b/src/skf-audit-skill/references/structural-diff.md
@@ -21,8 +21,6 @@ Compare the original provenance map extractions from create-skill against the cu
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Prepare Comparison Sets
 
 Load both datasets:

--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -29,8 +29,6 @@ You are a skill scoping architect collaborating with a developer who wants to cr
 
 These rules apply to every step in this workflow:
 
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - **Lazy-load references and assets:** `references/*.md` and `assets/*.md` files are loaded inside the section that needs them, not at step entry. If a section is skipped (e.g. `version-resolution.md` when `{extractPublicApiScript}` already returned a version, `scope-templates.md` for the `docs-only` branch that bypasses §2c), do not load that file. Each unnecessary load costs context (~5-10 KB per reference) and biases the LLM toward consulting material the current path does not need.
 - Always communicate in `{communication_language}` (the language for user-facing prose). Written artifact text — the `description`, `notes`, and other free-form fields persisted into `skill-brief.yaml` — is in `{document_output_language}`; per-step rules call this out where it applies (see step 5). The two values may be the same.

--- a/src/skf-brief-skill/references/analyze-target.md
+++ b/src/skf-brief-skill/references/analyze-target.md
@@ -23,8 +23,6 @@ To analyze the target repository by resolving its location, reading its structur
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Resolve Target Location
 
 **For GitHub URLs:**

--- a/src/skf-brief-skill/references/confirm-brief.md
+++ b/src/skf-brief-skill/references/confirm-brief.md
@@ -22,8 +22,6 @@ To present the complete skill brief in human-readable format, highlighting all f
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Assemble Complete Brief
 
 Use the values already accepted in steps 01-03 directly — do not re-load `{briefSchemaPath}` here. The 18 fields below are all in conversation; the schema is only consulted in §4 if an inline adjustment needs a specific field's validation rule cited.

--- a/src/skf-brief-skill/references/gather-intent.md
+++ b/src/skf-brief-skill/references/gather-intent.md
@@ -27,8 +27,6 @@ To initialize the brief-skill workflow by discovering the forge tier configurati
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Discover Forge Tier
 
 **Pre-flight write probe.** Before any conversational state accumulates, verify `{forge_data_folder}` is writable. A read-only mount, full disk, or permissions-denied path otherwise only surfaces at step 5's atomic write — by then the user has invested 5–15 minutes. Run a single-byte write-and-remove probe:

--- a/src/skf-brief-skill/references/scope-definition.md
+++ b/src/skf-brief-skill/references/scope-definition.md
@@ -24,8 +24,6 @@ To collaboratively define the skill's inclusion and exclusion boundaries using t
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Present Scope Context
 
 "**Let's define the scope for your skill.**

--- a/src/skf-brief-skill/references/write-brief.md
+++ b/src/skf-brief-skill/references/write-brief.md
@@ -28,8 +28,6 @@ To generate the complete skill-brief.yaml from the approved brief data and write
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Reference the Schema (LLM context only)
 
 `{briefSchemaPath}` and `{versionResolutionFile}` document the brief contract for human readers. The deterministic enforcement of that contract lives in `{writeSkillBriefScript}` and its JSON Schema artifact at `src/shared/scripts/schemas/skill-brief.v1.json`. Load `{briefSchemaPath}` only if you need to explain a specific field to the user during inline adjustments — otherwise skip the read; the script is the source of truth.

--- a/src/skf-create-skill/SKILL.md
+++ b/src/skf-create-skill/SKILL.md
@@ -26,8 +26,6 @@ You are operating in Ferris Architect mode — a skill compilation engine perfor
 These rules apply to every step in this workflow:
 
 - Never include content in SKILL.md that cannot be cited to source code
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}`
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision

--- a/src/skf-create-skill/references/compile.md
+++ b/src/skf-create-skill/references/compile.md
@@ -22,8 +22,6 @@ To assemble the complete skill content from the extraction inventory and enrichm
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Data Files
 
 Load `{skillSectionsData}` and `{assemblyRulesData}` completely. These define the agentskills.io-compliant format and detailed assembly rules for all output artifacts.

--- a/src/skf-create-skill/references/component-extraction.md
+++ b/src/skf-create-skill/references/component-extraction.md
@@ -19,8 +19,6 @@ When `scope.type: "component-library"`, perform specialized extraction that trea
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 **Prerequisite — §2a already ran.** Step-03 executes `§2a Discovered Authoritative Files Protocol` before delegating to this file. Any promoted authoritative files (`llms.txt`, `AGENTS.md`, etc.) are tracked in the `promoted_docs[]` context list and will be written to `file_entries[]` with `file_type: "doc"` by step 5 §6 — they do NOT appear in the filtered file list that was passed into this step, so Phase 1 demo exclusion below only operates on code files. No special handling is required in this file for promoted docs. See step 3 §2a for the full flow.
 
 ### Phase 1: Demo/Example Exclusion

--- a/src/skf-create-skill/references/ecosystem-check.md
+++ b/src/skf-create-skill/references/ecosystem-check.md
@@ -18,8 +18,6 @@ To search the agentskills.io ecosystem for an existing official skill matching t
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Ecosystem for Existing Skill
 
 **Note:** Ecosystem lookup requires the agentskills.io registry API, which is not yet available. The `skill-check` CLI validates local skills but does not query a remote registry.

--- a/src/skf-create-skill/references/enrich.md
+++ b/src/skf-create-skill/references/enrich.md
@@ -19,8 +19,6 @@ To enrich the extraction inventory with temporal context from QMD knowledge sear
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Tier Eligibility
 
 **If tier is Quick, Forge, or Forge+:**

--- a/src/skf-create-skill/references/extract.md
+++ b/src/skf-create-skill/references/extract.md
@@ -47,8 +47,6 @@ To extract all public exports, function signatures, type definitions, and co-imp
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Extraction Patterns
 
 Load `{extractionPatternsData}` completely. Identify the strategy for the current forge tier.

--- a/src/skf-create-skill/references/generate-artifacts.md
+++ b/src/skf-create-skill/references/generate-artifacts.md
@@ -26,8 +26,6 @@ To write all compiled content to disk — 4 deliverable files to `{skill_package
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Create Directory Structure
 
 Resolve `{version}` from the skill brief's `version` field. Create the following directories:

--- a/src/skf-create-skill/references/load-brief.md
+++ b/src/skf-create-skill/references/load-brief.md
@@ -27,8 +27,6 @@ To load and validate the skill-brief.yaml compilation config, resolve the source
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Forge Tier
 
 Load `{forgeTierFile}` completely.

--- a/src/skf-create-skill/references/report.md
+++ b/src/skf-create-skill/references/report.md
@@ -24,8 +24,6 @@ To display the final compilation summary — skill name, version, source, export
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Display Forge Completion Banner
 
 "**Skill forged: {name} v{version} — {export_count} functions, {primary_confidence} confidence.**"

--- a/src/skf-create-skill/references/sub/ccc-discover.md
+++ b/src/skf-create-skill/references/sub/ccc-discover.md
@@ -20,8 +20,6 @@ For Quick and Forge tiers, or when ccc is unavailable, skip silently and proceed
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Tier Eligibility
 
 **If tier is Quick or Forge:**

--- a/src/skf-create-skill/references/sub/fetch-docs.md
+++ b/src/skf-create-skill/references/sub/fetch-docs.md
@@ -25,8 +25,6 @@ Fetch remote documentation from brief-specified URLs using whatever web fetching
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Eligibility
 
 Evaluate the following conditions. **If the condition fails, skip silently to section 7 (auto-proceed) with no output:**

--- a/src/skf-create-skill/references/sub/fetch-temporal.md
+++ b/src/skf-create-skill/references/sub/fetch-temporal.md
@@ -25,8 +25,6 @@ To fetch temporal context (issues, PRs, changelogs, release notes) from the sour
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check Eligibility
 
 Evaluate the following conditions sequentially. **If ANY condition fails, skip silently to section 5 (auto-proceed) with no output:**

--- a/src/skf-create-skill/references/validate.md
+++ b/src/skf-create-skill/references/validate.md
@@ -37,8 +37,6 @@ To validate the compiled SKILL.md content against the agentskills.io specificati
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 0. Description Guard Protocol
 
 **Used by:** §2 (`skill-check check --fix`), §4 (`split-body`), and any future tool invocation that may modify SKILL.md.

--- a/src/skf-create-stack-skill/SKILL.md
+++ b/src/skf-create-stack-skill/SKILL.md
@@ -26,8 +26,6 @@ You are a dependency analyst and integration architect. You bring expertise in d
 These rules apply to every step in this workflow:
 
 - Zero hallucination — all extracted content must trace to actual source code (compose-mode inferences must be labeled)
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`

--- a/src/skf-create-stack-skill/references/compile-stack.md
+++ b/src/skf-create-stack-skill/references/compile-stack.md
@@ -19,8 +19,6 @@ Assemble the main SKILL.md by combining per-library extractions with the integra
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Template Structure
 
 Load `{stackSkillTemplate}` and prepare SKILL.md section structure.

--- a/src/skf-create-stack-skill/references/detect-integrations.md
+++ b/src/skf-create-stack-skill/references/detect-integrations.md
@@ -21,8 +21,6 @@ Analyze co-import patterns between confirmed libraries to identify integration p
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Generate Library Pairs
 
 From `confirmed_dependencies`, conceptually you have N*(N-1)/2 unordered pairs. Rather than enumerating and grep-testing each one, prune the matrix via a deterministic **file-list intersection fast path** (MANDATORY first pass, all N): pairs whose per-library file lists do not overlap cannot be integration candidates by construction — drop them. Subsequent grep passes (§2) run only against pairs with a non-empty intersection, and grep scope is restricted to those intersection files rather than the whole source tree. This is NOT a "subprocess-unavailable" fallback; it is the default strategy for every N. Rationale: at N≈21 this collapses 210 prescribed pair greps to ~12 non-empty-intersection pairs in typical codebases; at larger N the compression is even greater.

--- a/src/skf-create-stack-skill/references/detect-manifests.md
+++ b/src/skf-create-stack-skill/references/detect-manifests.md
@@ -20,8 +20,6 @@ Scan the project root for dependency manifest files, parse each to extract depen
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 0. Check Compose Mode
 
 **If `compose_mode` is true AND `explicit_deps` was provided in step 01:**

--- a/src/skf-create-stack-skill/references/generate-output.md
+++ b/src/skf-create-stack-skill/references/generate-output.md
@@ -27,8 +27,6 @@ Write all deliverable and workspace artifact files to their target directories.
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Resolve Paths and Stage Target Directory
 
 Resolve `{version}` from the primary library version or default to `1.0.0` (see S11 in "Primary library" note below). The final artifact paths are:

--- a/src/skf-create-stack-skill/references/init.md
+++ b/src/skf-create-stack-skill/references/init.md
@@ -17,8 +17,6 @@ Load forge tier configuration, validate prerequisites, and prepare the stack ski
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 0. Validate Project Config
 
 Before anything else, load `{project-root}/_bmad/skf/config.yaml`. If the file is missing OR fails YAML parse OR lacks the required top-level keys (`project_name`, `output_folder`, `skills_output_folder`, `forge_data_folder`, `sidecar_path`), HALT with:

--- a/src/skf-create-stack-skill/references/parallel-extract.md
+++ b/src/skf-create-stack-skill/references/parallel-extract.md
@@ -19,8 +19,6 @@ For each confirmed dependency, extract key exports, usage patterns, and API surf
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 0. Check Compose Mode
 
 **If `compose_mode` is true:**

--- a/src/skf-create-stack-skill/references/rank-and-confirm.md
+++ b/src/skf-create-stack-skill/references/rank-and-confirm.md
@@ -17,8 +17,6 @@ Count import frequency for each dependency across the codebase, rank by usage, a
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Count Import Frequency
 
 **If `compose_mode` is true:**

--- a/src/skf-create-stack-skill/references/report.md
+++ b/src/skf-create-stack-skill/references/report.md
@@ -25,8 +25,6 @@ Display the final summary of the forged stack skill with confidence distribution
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Display Stack Forged Banner
 
 "**Stack forged: {project_name}-stack — {lib_count} libraries, {integration_count} integration patterns**

--- a/src/skf-create-stack-skill/references/validate.md
+++ b/src/skf-create-stack-skill/references/validate.md
@@ -18,8 +18,6 @@ Validate all written output files against their expected structure and verify co
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Verify File Existence
 
 Check that all expected files exist from written_files[]:

--- a/src/skf-drop-skill/SKILL.md
+++ b/src/skf-drop-skill/SKILL.md
@@ -29,8 +29,6 @@ These rules apply to every step in this workflow:
 
 - Never delete files without explicit user confirmation in purge mode
 - Never drop an active version when other non-deprecated versions exist — enforce the active version guard
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`

--- a/src/skf-drop-skill/references/execute.md
+++ b/src/skf-drop-skill/references/execute.md
@@ -37,8 +37,6 @@ Execute the drop decisions recorded in step 1: update the export manifest, rebui
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Re-read Version-Paths Knowledge
 
 Read `{versionPathsKnowledge}` again and confirm the templates and management operations. This ensures the execution step uses the same rules as the selection step even when run in isolation.

--- a/src/skf-drop-skill/references/report.md
+++ b/src/skf-drop-skill/references/report.md
@@ -18,8 +18,6 @@ Present a clear, final summary of what the drop workflow changed — manifest st
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly.
-
 ### 1. Determine Remaining Versions
 
 **If `is_skill_level == true`:**

--- a/src/skf-drop-skill/references/select.md
+++ b/src/skf-drop-skill/references/select.md
@@ -20,8 +20,6 @@ Identify exactly what the user wants to drop — which skill, which version(s), 
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Knowledge
 
 Read `{versionPathsKnowledge}` completely and extract:

--- a/src/skf-export-skill/SKILL.md
+++ b/src/skf-export-skill/SKILL.md
@@ -26,8 +26,6 @@ You are a delivery and packaging specialist collaborating with a skill developer
 
 These rules apply to every step in this workflow:
 
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}`
 - At any interactive prompt, the inputs `cancel`, `exit`, `[X]`, `q`, or `:q` exit cleanly with exit code 6 (`halt_reason: "user-cancelled"`)

--- a/src/skf-export-skill/references/generate-snippet.md
+++ b/src/skf-export-skill/references/generate-snippet.md
@@ -19,8 +19,6 @@ To generate or update context-snippet.md for the skill in the Vercel-aligned ind
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Check Passive Context Setting
 
 **If `passive_context: false` was detected in step 1:**

--- a/src/skf-export-skill/references/load-skill.md
+++ b/src/skf-export-skill/references/load-skill.md
@@ -17,8 +17,6 @@ To load the target skill's artifacts, validate they meet agentskills.io spec com
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Parse Export Arguments
 
 "**Starting skill export...**"

--- a/src/skf-export-skill/references/package.md
+++ b/src/skf-export-skill/references/package.md
@@ -18,8 +18,6 @@ To assemble and validate an agentskills.io-compliant package structure from the 
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Validate Package Structure
 
 Verify the skill package at `{resolved_skill_package}` (resolved in step 1 via manifest or `active` symlink — see `knowledge/version-paths.md`) contains the expected agentskills.io package layout:

--- a/src/skf-export-skill/references/summary.md
+++ b/src/skf-export-skill/references/summary.md
@@ -18,8 +18,6 @@ To present a complete export summary showing all files written, token counts, an
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Compile Export Summary
 
 "**Export Complete{if dry-run: ' (Dry Run)'}**

--- a/src/skf-export-skill/references/token-report.md
+++ b/src/skf-export-skill/references/token-report.md
@@ -18,8 +18,6 @@ To calculate approximate token counts for all exported artifacts and present a c
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Calculate Token Counts
 
 For each artifact, estimate tokens using the heuristic: **words * 1.3** (approximate for GPT/Claude tokenizers). This same heuristic is used in step 3 for snippet token estimation.

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -43,8 +43,6 @@ To update the managed `<!-- SKF:BEGIN/END -->` section in the platform-appropria
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Check Passive Context Setting
 
 **If `passive_context: false` was detected in step 1:**

--- a/src/skf-quick-skill/SKILL.md
+++ b/src/skf-quick-skill/SKILL.md
@@ -26,6 +26,7 @@ You are a rapid skill compiler collaborating with a developer. You bring source 
 These rules apply to every step in this workflow:
 
 - Never fabricate content — all data must come from source extraction or user input
+- Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}`
 - **Universal cancel-line affordance** — at any interactive prompt the user may type `cancel`, `exit`, `:q`, or select the `[X] Cancel and exit` menu option (where surfaced) to leave cleanly. HARD HALT with **exit code 6 (user-cancelled)** and emit the error result contract per "Result Contract on HARD HALT" with `error.code: "user-cancelled"`. In step 4 §6 the equivalent affordance is `[Q] Quit without writing` — same exit code, same envelope contract.
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision

--- a/src/skf-refine-architecture/SKILL.md
+++ b/src/skf-refine-architecture/SKILL.md
@@ -26,8 +26,6 @@ You are an architecture refinement analyst operating in Ferris Architect mode. Y
 These rules apply to every step in this workflow:
 
 - Never speculate — every gap, issue, or improvement must cite specific APIs, types, or function signatures from the generated skills
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`

--- a/src/skf-refine-architecture/references/compile.md
+++ b/src/skf-refine-architecture/references/compile.md
@@ -19,8 +19,6 @@ Produce the refined architecture document by starting with the original as a bas
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Prepare the Original as Base
 
 Load the complete original architecture document.

--- a/src/skf-refine-architecture/references/gap-analysis.md
+++ b/src/skf-refine-architecture/references/gap-analysis.md
@@ -18,8 +18,6 @@ Find undocumented integration paths — library pairs that have compatible APIs 
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Reference Refinement Rules
 
 Use the refinement rules loaded in Step 01 from `{refinementRulesData}`. If not available in context, reload from `{refinementRulesData}`.

--- a/src/skf-refine-architecture/references/improvements.md
+++ b/src/skf-refine-architecture/references/improvements.md
@@ -19,8 +19,6 @@ Identify capability expansions — library features documented in the generated 
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Reference Refinement Rules
 
 Use the refinement rules loaded in Step 01 from `{refinementRulesData}`. If not available in context, reload from `{refinementRulesData}`.

--- a/src/skf-refine-architecture/references/init.md
+++ b/src/skf-refine-architecture/references/init.md
@@ -27,8 +27,6 @@ Load the architecture document (required), scan the skills folder to build a ski
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Accept Input Documents
 
 "**Refine Architecture — Evidence-Backed Refinement** (additive — never deletes original content).

--- a/src/skf-refine-architecture/references/issue-detection.md
+++ b/src/skf-refine-architecture/references/issue-detection.md
@@ -19,8 +19,6 @@ Find contradictions between what the architecture document claims and what the g
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Reference Refinement Rules
 
 Use the refinement rules loaded in Step 01 from `{refinementRulesData}`. If not available in context, reload from `{refinementRulesData}`.

--- a/src/skf-refine-architecture/references/report.md
+++ b/src/skf-refine-architecture/references/report.md
@@ -22,8 +22,6 @@ Present the complete refinement summary to the user. Display counts of gaps fill
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Refined Document
 
 Read the `{outputFile}` to have all data available for presentation.

--- a/src/skf-rename-skill/SKILL.md
+++ b/src/skf-rename-skill/SKILL.md
@@ -30,8 +30,6 @@ These rules apply to every step in this workflow:
 - Never delete the old skill directories until the new name has been fully materialized and verified
 - Never proceed past a verification failure — roll back (delete new directories) and halt
 - Never allow a rename to collide with an existing skill name
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`

--- a/src/skf-rename-skill/references/report.md
+++ b/src/skf-rename-skill/references/report.md
@@ -19,8 +19,6 @@ Present a clear, final summary of what the rename workflow changed — old and n
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly.
-
 ### 1. Render the Report
 
 Display the following block, filling in values from context:

--- a/src/skf-rename-skill/references/select.md
+++ b/src/skf-rename-skill/references/select.md
@@ -20,8 +20,6 @@ Identify the skill the user wants to rename, validate the new name against the a
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Knowledge
 
 Read `{versionPathsKnowledge}` completely and extract:

--- a/src/skf-test-skill/SKILL.md
+++ b/src/skf-test-skill/SKILL.md
@@ -16,6 +16,7 @@ Verifies that a skill is complete enough to be useful to an AI agent by checking
 - `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives, if present).
 - `{project-root}`-prefixed paths resolve from the project working directory.
 - `{skill-name}` resolves to the skill directory's basename.
+- Step files use `## STEP GOAL:` headings rather than the `## MANDATORY SEQUENCE` + `## CRITICAL STEP COMPLETION NOTE` pattern used by generate-driven SKF workflows — this skill is a validation harness with score-driven step semantics, not a chain that produces new artifacts.
 
 ## Role
 
@@ -26,8 +27,6 @@ You are a skill auditor and completeness analyst operating in Ferris's Audit mod
 These rules apply to every step in this workflow:
 
 - Zero hallucination — every finding must trace to actual code with file:line citations
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Update `stepsCompleted` in output file frontmatter before loading next step
 - Always communicate in `{communication_language}`

--- a/src/skf-update-skill/SKILL.md
+++ b/src/skf-update-skill/SKILL.md
@@ -28,8 +28,6 @@ These rules apply to every step in this workflow:
 
 - Never hallucinate — every statement must have AST provenance
 - [MANUAL] sections survive regeneration with zero content loss
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - Always communicate in `{communication_language}`
 - If `{headless_mode}` is true, auto-proceed through confirmation gates with their default action and log each auto-decision

--- a/src/skf-update-skill/references/detect-changes.md
+++ b/src/skf-update-skill/references/detect-changes.md
@@ -42,8 +42,6 @@ Compare current source code state against the provenance map to produce a comple
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 0. Check for Test Report Input (Gap-Driven Mode)
 
 **If `update_mode == "gap-driven"` (set in step 1 via `--from-test-report`):**

--- a/src/skf-update-skill/references/init.md
+++ b/src/skf-update-skill/references/init.md
@@ -18,8 +18,6 @@ Load the existing skill and all its provenance data, detect whether this is an i
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Request Skill Path
 
 "**Which skill would you like to update?**

--- a/src/skf-update-skill/references/merge.md
+++ b/src/skf-update-skill/references/merge.md
@@ -21,8 +21,6 @@ Merge freshly extracted export data into the existing SKILL.md content while pre
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Load Merge Rules
 
 Load {manualSectionRulesFile} for [MANUAL] detection and preservation patterns.

--- a/src/skf-update-skill/references/re-extract.md
+++ b/src/skf-update-skill/references/re-extract.md
@@ -30,8 +30,6 @@ Perform tier-aware extraction on only the changed files identified in step 02, p
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 0. Check for Gap-Driven Mode
 
 **If `update_mode == "gap-driven"` (set in step 1 via `--from-test-report`, confirmed in step 2 section 0):**

--- a/src/skf-update-skill/references/report.md
+++ b/src/skf-update-skill/references/report.md
@@ -18,8 +18,6 @@ Present a comprehensive change summary showing what was updated, [MANUAL] sectio
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Handle No-Change Shortcut
 
 **If routed here from step 02 with no changes detected:**

--- a/src/skf-update-skill/references/validate.md
+++ b/src/skf-update-skill/references/validate.md
@@ -18,8 +18,6 @@ Validate the merged skill content against the agentskills.io specification, veri
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 1. Check Tool Availability and Validation Timing
 
 Run: `npx skill-check -h`

--- a/src/skf-update-skill/references/write.md
+++ b/src/skf-update-skill/references/write.md
@@ -36,8 +36,6 @@ Verify the merged SKILL.md and stack reference files that step 4 section 6b wrot
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise unless user explicitly requests a change.
-
 ### 0. Description Guard Protocol
 
 **Used by:** §7 (`skill-check check --fix` and `skill-check split-body --write`), and any future tool invocation that may modify SKILL.md's frontmatter on disk.

--- a/src/skf-verify-stack/SKILL.md
+++ b/src/skf-verify-stack/SKILL.md
@@ -29,8 +29,6 @@ These rules apply to every step in this workflow:
 
 - Read-only — never modify skills, architecture docs, or PRD files
 - Every verdict must cite evidence from the generated skills
-- Read each step file completely before taking any action
-- Follow the mandatory sequence in each step exactly — do not skip, reorder, or optimize
 - Only load one step file at a time — never preload future steps
 - If any instruction references a subprocess or tool you lack, achieve the outcome in your main context thread
 - Always communicate in `{communication_language}`

--- a/src/skf-verify-stack/references/coverage.md
+++ b/src/skf-verify-stack/references/coverage.md
@@ -22,8 +22,6 @@ Verify that a generated skill exists for every technology, library, or framework
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Coverage Patterns
 
 Load `{coveragePatternsData}` for detection rules.

--- a/src/skf-verify-stack/references/init.md
+++ b/src/skf-verify-stack/references/init.md
@@ -36,8 +36,6 @@ Load all generated skills from the skills output folder, accept the architecture
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Accept Input Documents
 
 "**Verify Stack — Feasibility Analysis** (read-only — never modifies your skills, architecture doc, or PRD).

--- a/src/skf-verify-stack/references/integrations.md
+++ b/src/skf-verify-stack/references/integrations.md
@@ -24,8 +24,6 @@ Cross-reference API surfaces between library pairs that the architecture documen
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Integration Verification Rules
 
 Load `{integrationRulesData}` for the cross-reference verification protocol.

--- a/src/skf-verify-stack/references/report.md
+++ b/src/skf-verify-stack/references/report.md
@@ -25,8 +25,6 @@ Present the complete feasibility report to the user. Display the overall verdict
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Load Complete Report
 
 Read the entire `{outputFile}` to have all data available for presentation.

--- a/src/skf-verify-stack/references/requirements.md
+++ b/src/skf-verify-stack/references/requirements.md
@@ -22,8 +22,6 @@ If a PRD or vision document was provided in Step 01, verify that the combined ca
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Check PRD Availability
 
 **Read `prdAvailable` from `{outputFile}` frontmatter (set in Step 01). If `prdAvailable` is false (no PRD/vision document was provided):**

--- a/src/skf-verify-stack/references/synthesize.md
+++ b/src/skf-verify-stack/references/synthesize.md
@@ -21,8 +21,6 @@ Calculate the overall feasibility verdict based on all three analysis passes, ge
 
 ## MANDATORY SEQUENCE
 
-**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise.
-
 ### 1. Calculate Overall Verdict
 
 **Zero-coverage short-circuit (evaluate before anything else):** Read `coveragePercentage` from `{outputFile}` frontmatter. If `coveragePercentage == 0`, force `overallVerdict: NOT_FEASIBLE` with rationale "no coverage — analysis vacuous: zero generated skills match the architecture's referenced technologies, so integration and requirements verdicts cannot produce meaningful evidence." Skip the remainder of the verdict ladder; proceed directly to section 2 to generate recommendations for the Missing skills surfaced by Step 02.


### PR DESCRIPTION
## Summary

- Propagates the per-rule Workflow Rules trim from skf-setup's v2 quality pass (commit 3dd864cd) across all 13 SKF workflow skills, plus drops the restated `**CRITICAL:** Follow this sequence exactly...` ritual line from step files.
- Surfaces and fixes two drifts during the audit: missing Rule 3 in `skf-quick-skill`, and undocumented alternative step heading convention in `skf-test-skill`.
- Load-bearing content preserved: 94 `## MANDATORY SEQUENCE` headings, 52 `## CRITICAL STEP COMPLETION NOTE` blocks, and all `Auto-Proceed` inline behavioral instructions remain intact.

## What changed

### SKILL.md Workflow Rules — per-rule decision (13 files)

- **Drop** "Read each step file completely..." — restated baseline
- **Drop** "Follow the mandatory sequence in each step exactly..." — restated by the chain mechanism + Stages table
- **Keep** "Only load one step file at a time — never preload future steps" — context-window management; not restated elsewhere. This is the deliberate keep from the v2 skf-setup pass; this PR brings the other 12 workflow skills into alignment.

### Drift fixes surfaced by the audit

- `skf-quick-skill`: was missing Rule 3 entirely (drift from before the v2 trim convention existed) — Rule 3 added.
- `skf-test-skill`: documents its alternative step heading convention. Step files use `## STEP GOAL:` instead of `## MANDATORY SEQUENCE` because this skill is a validation harness with score-driven semantics, not a generate-driven chain. The note prevents future contributors from "fixing" the intentional deviation.

### Step files (69 files across 13 skills)

- **Drop** the restated `**CRITICAL:** Follow this sequence exactly. Do not skip, reorder, or improvise...` ritual line. The information is restated by the `## MANDATORY SEQUENCE` heading + the Stages table + the `nextStepFile` chain mechanism — three independent mechanical enforcement paths.

### What this PR does NOT change

- `## MANDATORY SEQUENCE` headings (structural — they organize numbered substeps)
- `## CRITICAL STEP COMPLETION NOTE` blocks (load-bearing — these are the step-transition gates declaring "ONLY WHEN X has happened will you load `{nextStepFile}`")
- `Auto-Proceed` mentions (inline behavioral instructions for headless mode)
- `skf-setup` SKILL.md (already correct per v2 commit 3dd864cd)
- `skf-forger` SKILL.md (non-workflow agent persona — correctly excluded)

## Diff stats

82 files changed, 2 insertions(+), 162 deletions(-)

## Test plan

- [x] All 1346 Python tests pass
- [x] 0 broken file references
- [x] 0 absolute path leaks
- [x] ESLint clean
- [x] markdownlint clean across 224 markdown files
- [x] Prettier formatting clean
- [x] Sanity-check: open `skf-drop-skill/SKILL.md` and confirm the Workflow Rules section now lists Rule 3 alongside skill-specific rules, with no Rule 1/Rule 2 residue
- [x] Sanity-check: open `skf-drop-skill/references/select.md` and confirm `## MANDATORY SEQUENCE` heading remains, the `**CRITICAL:** Follow this sequence...` ritual line is gone, and `## CRITICAL STEP COMPLETION NOTE` body is intact

Refs #335 — addresses A4 (already superseded), D1 (Workflow Rules trim), D2 (step-file CRITICAL ritual line), and the `skf-test-skill` documentation item. C1, C2, C4 remain open per their per-workstream demand-gated triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)