### PR TITLE
feat(skf-brief-skill): capture authoring-time scope.rationale

### DIFF
--- a/src/shared/scripts/schemas/skill-brief.v1.json
+++ b/src/shared/scripts/schemas/skill-brief.v1.json
@@ -70,7 +70,27 @@
         },
         "include": { "type": "array", "items": { "type": "string" } },
         "exclude": { "type": "array", "items": { "type": "string" } },
-        "notes": { "type": "string" }
+        "notes": { "type": "string" },
+        "rationale": {
+          "type": "object",
+          "description": "Optional authoring-time scope-type decision record written once by skf-brief-skill step 03. Absent on legacy briefs.",
+          "required": ["recommended", "chosen", "accepted_recommendation", "heuristic", "reason", "recorded"],
+          "additionalProperties": false,
+          "properties": {
+            "recommended": {
+              "type": "string",
+              "enum": ["full-library", "specific-modules", "public-api", "component-library", "reference-app", "docs-only"]
+            },
+            "chosen": {
+              "type": "string",
+              "enum": ["full-library", "specific-modules", "public-api", "component-library", "reference-app", "docs-only"]
+            },
+            "accepted_recommendation": { "type": "boolean" },
+            "heuristic": { "type": "string", "minLength": 1 },
+            "reason": { "type": "string", "minLength": 1 },
+            "recorded": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" }
+          }
+        }
       }
     }
   }

--- a/src/shared/scripts/skf-write-skill-brief.py
+++ b/src/shared/scripts/skf-write-skill-brief.py
@@ -263,6 +263,36 @@ def validate_context(ctx: dict[str, Any]) -> list[str]:
     if not isinstance(scope["notes"], str):
         _die("scope.notes must be a string (use empty string when no notes)", field="scope.notes")
 
+    # scope.rationale — optional authoring-time scope-type decision record.
+    # Absent/None → field is simply not present (same null-drop path as
+    # doc_urls). When present it must be a complete six-subkey object.
+    rationale = scope.get("rationale")
+    if rationale is not None:
+        if not isinstance(rationale, dict):
+            _die("scope.rationale must be an object when present", field="scope.rationale")
+        _RATIONALE_STR_KEYS = ("recommended", "chosen", "heuristic", "reason", "recorded")
+        for rk in (*_RATIONALE_STR_KEYS, "accepted_recommendation"):
+            if rk not in rationale:
+                _die(f"scope.rationale.{rk} is required", field=f"scope.rationale.{rk}")
+        for rk in _RATIONALE_STR_KEYS:
+            if not isinstance(rationale[rk], str) or not rationale[rk]:
+                _die(
+                    f"scope.rationale.{rk} must be a non-empty string",
+                    field=f"scope.rationale.{rk}",
+                )
+        if not isinstance(rationale["accepted_recommendation"], bool):
+            _die(
+                "scope.rationale.accepted_recommendation must be a boolean",
+                field="scope.rationale.accepted_recommendation",
+            )
+        for rk in ("recommended", "chosen"):
+            if rationale[rk] not in VALID_SCOPE_TYPES:
+                _die(
+                    f"scope.rationale.{rk} must be one of {sorted(VALID_SCOPE_TYPES)}. "
+                    f"Got: {rationale[rk]!r}",
+                    field=f"scope.rationale.{rk}",
+                )
+
     # target_version semver shape (when present)
     tv = ctx.get("target_version")
     if tv is not None:
@@ -307,6 +337,21 @@ def assemble_brief(ctx: dict[str, Any], resolved_version: str) -> dict[str, Any]
             "notes": ctx["scope"]["notes"],
         },
     }
+
+    # Conditional: scope.rationale — canonical position is after `notes` and
+    # before `amendments` (amendments is appended post-authoring by other
+    # workflows and is never emitted here, so appending after notes yields the
+    # canonical order). Absent → key omitted, matching the legacy-brief default.
+    scope_rationale = ctx["scope"].get("rationale")
+    if scope_rationale is not None:
+        brief["scope"]["rationale"] = {
+            "recommended": scope_rationale["recommended"],
+            "chosen": scope_rationale["chosen"],
+            "accepted_recommendation": scope_rationale["accepted_recommendation"],
+            "heuristic": scope_rationale["heuristic"],
+            "reason": scope_rationale["reason"],
+            "recorded": scope_rationale["recorded"],
+        }
 
     # Conditional: target_version (must equal version)
     tv = ctx.get("target_version")
@@ -388,7 +433,13 @@ def atomic_write(target: Path, content: str) -> int:
 # Top-level keys that get folded into the nested `scope` sub-object — every
 # other top-level key passes through unchanged so future additions to the
 # schema don't require a translator update.
-_FLAT_SCOPE_KEYS = ("scope_type", "scope_include", "scope_exclude", "scope_notes")
+_FLAT_SCOPE_KEYS = (
+    "scope_type",
+    "scope_include",
+    "scope_exclude",
+    "scope_notes",
+    "scope_rationale",
+)
 
 
 def flat_to_nested(flat: dict[str, Any]) -> dict[str, Any]:
@@ -437,6 +488,11 @@ def flat_to_nested(flat: dict[str, Any]) -> dict[str, Any]:
             scope["exclude"] = flat["scope_exclude"]
         if "scope_notes" in flat and flat["scope_notes"] is not None:
             scope["notes"] = flat["scope_notes"]
+        # Optional authoring-time rationale. Null/absent → key dropped (same
+        # null-drop semantics as doc_urls); when present it carries the full
+        # six-subkey object validated by validate_context.
+        if "scope_rationale" in flat and flat["scope_rationale"] is not None:
+            scope["rationale"] = flat["scope_rationale"]
         nested["scope"] = scope
     return nested
 

--- a/src/skf-brief-skill/assets/skill-brief-schema.md
+++ b/src/skf-brief-skill/assets/skill-brief-schema.md
@@ -67,6 +67,14 @@ scope:
   #   - "code/core/src/manager-api/**"
   #   - "code/core/src/preview-api/**"
   notes: "Optional notes about scope decisions"
+  # Optional: authoring-time scope-type rationale (written once by brief-skill 2c)
+  # rationale:
+  #   recommended: full-library
+  #   chosen: public-api
+  #   accepted_recommendation: false
+  #   heuristic: narrow-public-api
+  #   reason: "user overrode full-library->public-api: only documented API ships"
+  #   recorded: "2026-05-18"
   # Optional: amendment log for scope decisions made during create-skill §2a,
   # update-skill §1b (auth-doc), and update-skill §1c (scope-expansion).
   # amendments:
@@ -93,6 +101,28 @@ scope:
   #   - "**/demo/**"
   #   - "**/*.stories.*"
 ```
+
+### Scope Rationale (Optional)
+
+`scope.rationale` is a single optional object recording **why the scope type was chosen at authoring time**. Unlike `scope.amendments[]` (an additive log that accumulates post-authoring decisions across workflow runs), `scope.rationale` is one decision, written once by `skf-brief-skill` step 03 §2c and revised in place on a step-4 `[R]` re-entry. It sits structurally beside `scope.amendments`, reusing the same structured / script-readable / human-auditable ethos rather than a prose decision log.
+
+**Fields:**
+
+| Field | Type | Required | Source |
+|---|---|---|---|
+| `recommended` | string (one of the six `scope.type` values) | yes | `skf-recommend-scope-type.py` → `scope_type` |
+| `chosen` | string (one of the six) | yes | final `scope.type` |
+| `accepted_recommendation` | bool | yes | `chosen == recommended` |
+| `heuristic` | string | yes | script `matched_heuristic` |
+| `reason` | string | yes | accepted → script `rationale` verbatim; overridden → user's stated reason, or `"user overrode {recommended}->{chosen}; reason not stated"` |
+| `recorded` | string (ISO date `YYYY-MM-DD`) | yes | current date — mirrors `amendments[].date` |
+
+**Who reads `scope.rationale`:**
+
+- Humans reviewing the brief — it records why the boundary was drawn the way it was.
+- `skf-update-skill` Update intent MAY later surface conflicts against it (e.g., a scope change that contradicts the original authoring decision). **Not implemented now — deferred.** The field is forward-compatible; the reader is wired later.
+
+**Backward compatibility:** `scope.rationale` is optional. Briefs without this field validate unchanged — treat missing as absent (null). Mirrors the `scope.amendments` backward-compat rule.
 
 ### Scope Amendments (Optional)
 

--- a/src/skf-brief-skill/references/confirm-brief.md
+++ b/src/skf-brief-skill/references/confirm-brief.md
@@ -41,6 +41,7 @@ Compile all gathered data from steps 01-03 into the complete brief:
 - **scope.include:** {include patterns from step 03}
 - **scope.exclude:** {exclude patterns from step 03}
 - **scope.notes:** {any scope notes from step 03}
+- **scope.rationale:** {recommended -> chosen, reason — from step 03}
 - **source_type:** {source or docs-only, from step 01}
 - **doc_urls:** {collected documentation URLs with labels, from steps 01/03 — include if source_type is "docs-only" or supplemental URLs were collected}
 - **scripts_intent:** {detect/none/description from step 03, or "detect" if not explicitly set}
@@ -68,6 +69,8 @@ Scope: {scope.type}
   Include: {scope.include patterns, one per line}
   Exclude: {scope.exclude patterns, one per line}
   Notes:   {scope.notes}
+  Rationale: {chosen} chosen over {recommended} — {reason}
+             {omit this line entirely if scope.rationale absent}
 
 {If source_type is "docs-only":}
 Source Type: docs-only

--- a/src/skf-brief-skill/references/scope-definition.md
+++ b/src/skf-brief-skill/references/scope-definition.md
@@ -20,7 +20,7 @@ To collaboratively define the skill's inclusion and exclusion boundaries using t
 - Do not make scope decisions unilaterally — user drives all scope choices
 - Produce: scope type, include patterns, exclude patterns
 - All user-facing output in `{communication_language}`
-- **Re-entry from step 4 [R] revise:** prior selections (`scope.type`, `scope.include`, `scope.exclude`, `scope.notes`, `scripts_intent`, `assets_intent`, supplemental `doc_urls`) are preserved as the current state. Re-present them at each section as the existing answer; the user only re-confirms or overrides. Do not reset to the §2c template menu unless the user explicitly asks to start scope over.
+- **Re-entry from step 4 [R] revise:** prior selections (`scope.type`, `scope.include`, `scope.exclude`, `scope.notes`, `scope.rationale`, `scripts_intent`, `assets_intent`, supplemental `doc_urls`) are preserved as the current state. Re-present them at each section as the existing answer; the user only re-confirms or overrides. Do not reset to the §2c template menu unless the user explicitly asks to start scope over. When `scope.rationale` is preserved and the user changes `chosen` (the scope type) on this pass, recompute `accepted_recommendation` (`chosen == recommended`) and refresh `reason` and `recorded` per the §2c capture rules — revise in place, do not append.
 
 ## MANDATORY SEQUENCE
 
@@ -104,6 +104,8 @@ echo '{
 
 The script returns `{scope_type, matched_heuristic, signals, rationale}`. Use `rationale` directly — it already names the specific signals that fired.
 
+**Persist the rationale — do not discard it.** Hold `scope_type` as `rationale.recommended` and `matched_heuristic` as `rationale.heuristic` in conversation state. After the user's §2c selection: if they accept the recommendation, set `rationale.chosen = recommended`, `accepted_recommendation = true`, `reason = <script rationale verbatim>`. If they override, set `chosen = <selected type>`, `accepted_recommendation = false`, and ask one line — *"In a sentence, why {chosen} over the recommended {recommended}?"* — storing the answer as `reason` (or `"user overrode {recommended}->{chosen}; reason not stated"` if skipped). Set `recorded = {current ISO date}`. This object becomes `scope.rationale`.
+
 Present:
 
 "**Recommended scope type: [{letter}] {Name}** — {rationale from the script}.
@@ -183,6 +185,7 @@ Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Conti
   - Otherwise auto-select via `{recommendScopeTypeScript}` — invoke the script with the **same payload shape** documented in §2c but with `mode: "headless"` (presence-only matching for the component-registry rule, since `entry_files` may not be available without an interactive context). Use the returned `scope_type` and log `"headless: scope_type={value} from heuristic={matched_heuristic}"`. The script's docs-only short-circuit handles `source_type=docs-only` automatically.
   - If `include`/`exclude` were supplied, use them verbatim (split on comma) instead of running the boundary prompts in §3.
   - If `scripts_intent`/`assets_intent` were supplied, record them and skip §5b; otherwise default to `detect`.
+  - Set `scope.rationale`: `recommended`/`heuristic` from the script (or `recommended = scope_type` arg, `heuristic = "user-supplied-arg"` when `scope_type` was passed); `chosen = <resolved type>`; `accepted_recommendation = (no scope_type arg)`; `reason = "<script rationale>"` (auto path) or `"headless: scope_type supplied as argument"` (arg path); `recorded = {date}`. No prompt — headless never asks "why".
   - Log: `"headless: scope_type={value} include={n} exclude={n} scripts_intent={value} assets_intent={value}"`.
 - ONLY proceed to next step when user selects 'C'
 - After other menu items execution, return to this menu

--- a/src/skf-brief-skill/references/write-brief.md
+++ b/src/skf-brief-skill/references/write-brief.md
@@ -83,6 +83,7 @@ Assemble the brief context as a **flat** JSON object — every approved value is
   "scope_include":    ["{approved include patterns}"],
   "scope_exclude":    ["{approved exclude patterns}"],
   "scope_notes":      "{approved scope notes or empty string}",
+  "scope_rationale":  null | {"recommended":"...","chosen":"...","accepted_recommendation":true|false,"heuristic":"...","reason":"...","recorded":"YYYY-MM-DD"},
   "doc_urls":         null | [{"url": "...", "label": "..."}],
   "scripts_intent":   null | "{detect|none|free-text}",
   "assets_intent":    null | "{detect|none|free-text}",

--- a/test/test-skf-validate-brief-schema.py
+++ b/test/test-skf-validate-brief-schema.py
@@ -315,3 +315,69 @@ class TestCli:
         # argparse missing-required exits 2
         result = _run_cli()
         assert result.returncode == 2
+
+
+# --------------------------------------------------------------------------
+# scope.rationale — optional authoring-time decision record
+# --------------------------------------------------------------------------
+
+
+def _rationale() -> dict:
+    return {
+        "recommended": "full-library",
+        "chosen": "public-api",
+        "accepted_recommendation": False,
+        "heuristic": "narrow-public-api",
+        "reason": "user overrode full-library->public-api: only documented API ships",
+        "recorded": "2026-05-18",
+    }
+
+
+class TestScopeRationaleSchema:
+    """skill-brief.v1.json: rationale is optional but fully constrained when present."""
+
+    def test_legacy_brief_without_rationale_validates(self) -> None:
+        brief = _valid_brief()
+        assert "rationale" not in brief["scope"]
+        result = mod.validate_brief(brief)
+        assert result["valid"] is True
+        assert result["errors"] == []
+
+    def test_brief_with_rationale_validates(self) -> None:
+        brief = _valid_brief()
+        brief["scope"]["rationale"] = _rationale()
+        result = mod.validate_brief(brief)
+        assert result["valid"] is True, result["errors"]
+        assert result["errors"] == []
+
+    def test_rationale_missing_required_subkey_fails(self) -> None:
+        brief = _valid_brief()
+        r = _rationale()
+        del r["reason"]
+        brief["scope"]["rationale"] = r
+        result = mod.validate_brief(brief)
+        assert result["valid"] is False
+
+    def test_rationale_bad_scope_type_enum_fails(self) -> None:
+        brief = _valid_brief()
+        r = _rationale()
+        r["chosen"] = "made-up"
+        brief["scope"]["rationale"] = r
+        result = mod.validate_brief(brief)
+        assert result["valid"] is False
+
+    def test_rationale_rejects_additional_properties(self) -> None:
+        brief = _valid_brief()
+        r = _rationale()
+        r["extra"] = "nope"
+        brief["scope"]["rationale"] = r
+        result = mod.validate_brief(brief)
+        assert result["valid"] is False
+
+    def test_rationale_recorded_must_be_iso_date(self) -> None:
+        brief = _valid_brief()
+        r = _rationale()
+        r["recorded"] = "May 18 2026"
+        brief["scope"]["rationale"] = r
+        result = mod.validate_brief(brief)
+        assert result["valid"] is False

--- a/test/test-skf-write-skill-brief.py
+++ b/test/test-skf-write-skill-brief.py
@@ -571,3 +571,156 @@ class TestCLIWriteFlat:
         body = tmp_target.read_text()
         assert "doc_urls:" in body
         assert "https://docs.example.com" in body
+
+
+# --------------------------------------------------------------------------
+# scope.rationale — authoring-time scope-type decision record (optional)
+# --------------------------------------------------------------------------
+
+
+def _rationale(**overrides) -> dict:
+    """A complete, valid scope.rationale object (override individual subkeys)."""
+    base = {
+        "recommended": "full-library",
+        "chosen": "public-api",
+        "accepted_recommendation": False,
+        "heuristic": "narrow-public-api",
+        "reason": "user overrode full-library->public-api: only documented API ships",
+        "recorded": "2026-05-18",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestScopeRationaleValidation:
+    """validate_context — rationale is optional, but complete when present."""
+
+    def test_absent_rationale_validates(self):
+        # Legacy briefs have no scope.rationale and must still pass.
+        ctx = _baseline_ctx()
+        assert "rationale" not in ctx["scope"]
+        mod.validate_context(ctx)  # no raise
+
+    def test_present_valid_rationale_validates(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = _rationale()
+        mod.validate_context(ctx)  # no raise
+
+    def test_rationale_must_be_object(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = "not-an-object"
+        with pytest.raises(SystemExit):
+            mod.validate_context(ctx)
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["recommended", "chosen", "accepted_recommendation", "heuristic", "reason", "recorded"],
+    )
+    def test_rationale_missing_subkey_fails(self, missing):
+        ctx = _baseline_ctx()
+        r = _rationale()
+        del r[missing]
+        ctx["scope"]["rationale"] = r
+        with pytest.raises(SystemExit):
+            mod.validate_context(ctx)
+
+    def test_rationale_accepted_recommendation_must_be_bool(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = _rationale(accepted_recommendation="false")
+        with pytest.raises(SystemExit):
+            mod.validate_context(ctx)
+
+    def test_rationale_recommended_must_be_valid_scope_type(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = _rationale(recommended="bogus-type")
+        with pytest.raises(SystemExit):
+            mod.validate_context(ctx)
+
+    def test_rationale_empty_reason_fails(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = _rationale(reason="")
+        with pytest.raises(SystemExit):
+            mod.validate_context(ctx)
+
+
+class TestScopeRationaleAssembly:
+    """assemble_brief — rationale sits after notes; omitted when absent."""
+
+    def test_rationale_absent_when_not_supplied(self):
+        brief = mod.assemble_brief(_baseline_ctx(), "1.0.0")
+        assert "rationale" not in brief["scope"]
+
+    def test_rationale_emitted_after_notes(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = _rationale()
+        brief = mod.assemble_brief(ctx, "1.0.0")
+        scope_keys = list(brief["scope"].keys())
+        assert scope_keys == ["type", "include", "exclude", "notes", "rationale"]
+        assert brief["scope"]["rationale"]["chosen"] == "public-api"
+        # Subkeys emitted in canonical order
+        assert list(brief["scope"]["rationale"].keys()) == [
+            "recommended", "chosen", "accepted_recommendation",
+            "heuristic", "reason", "recorded",
+        ]
+
+    def test_rationale_round_trips_through_yaml(self):
+        ctx = _baseline_ctx()
+        ctx["scope"]["rationale"] = _rationale()
+        rendered = mod.render_yaml(mod.assemble_brief(ctx, "1.0.0"))
+        parsed = yaml.safe_load(rendered)
+        assert parsed["scope"]["rationale"] == _rationale()
+
+
+class TestScopeRationaleFlatTranslation:
+    """flat_to_nested — scope_rationale maps in; null drops out."""
+
+    def test_flat_scope_rationale_mapped_into_scope(self):
+        flat = _baseline_flat()
+        flat["scope_rationale"] = _rationale()
+        nested = mod.flat_to_nested(flat)
+        assert nested["scope"]["rationale"] == _rationale()
+        # Does not leak as a top-level key
+        assert "scope_rationale" not in nested
+
+    def test_flat_scope_rationale_null_drops_key(self):
+        flat = _baseline_flat()
+        flat["scope_rationale"] = None
+        nested = mod.flat_to_nested(flat)
+        assert "rationale" not in nested["scope"]
+        assert "scope_rationale" not in nested
+
+    def test_flat_scope_rationale_absent_drops_key(self):
+        nested = mod.flat_to_nested(_baseline_flat())
+        assert "rationale" not in nested["scope"]
+
+
+class TestCLIWriteFlatScopeRationale:
+    """End-to-end flat CLI write with scope_rationale."""
+
+    def _write_flat(self, target: Path, flat: dict):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "write", "--target", str(target), "--from-flat"],
+            input=json.dumps(flat),
+            capture_output=True,
+            text=True,
+        )
+        out = json.loads(proc.stdout) if proc.stdout.strip() else {}
+        return proc.returncode, out, proc.stderr
+
+    def test_flat_write_with_rationale_object(self, tmp_target):
+        flat = _baseline_flat()
+        flat["scope_rationale"] = _rationale()
+        code, response, stderr = self._write_flat(tmp_target, flat)
+        assert code == 0, stderr
+        parsed = yaml.safe_load(tmp_target.read_text())
+        assert parsed["scope"]["rationale"] == _rationale()
+
+    def test_flat_write_with_null_rationale_omits_key(self, tmp_target):
+        flat = _baseline_flat()
+        flat["scope_rationale"] = None
+        code, response, stderr = self._write_flat(tmp_target, flat)
+        assert code == 0, stderr
+        body = tmp_target.read_text()
+        assert "rationale:" not in body
+        parsed = yaml.safe_load(body)
+        assert "rationale" not in parsed["scope"]


### PR DESCRIPTION
## What

Adds an optional **`scope.rationale`** object to the skill brief, capturing *authoring-time* scope-type rationale — which scope type the heuristic recommended, which was actually chosen, and why. It sits structurally beside the existing post-authoring `scope.amendments[]`, reusing the same structured / script-readable / human-auditable ethos rather than a prose decision log.

Optional and backward-compatible: legacy briefs without the field validate unchanged.

## Changes

| Area | File | Change |
|---|---|---|
| Field design + schema | `assets/skill-brief-schema.md`, `schemas/skill-brief.v1.json` | `scope.rationale` — 6 required subkeys, `additionalProperties:false`, **not** in `scope.required` |
| Capture rule | `references/scope-definition.md` | §2c persist rule, §6 headless GATE bullet, `[R]` re-entry in-place revision |
| Review surface | `references/confirm-brief.md`, `references/write-brief.md` | §1/§2 review lines (omit-if-absent), flat-context JSON key |
| Writer | `src/shared/scripts/skf-write-skill-brief.py` | `_FLAT_SCOPE_KEYS` + flat→nested mapping, optional validator block, canonical YAML order (after `notes`) |
| Tests | `test/test-skf-write-skill-brief.py`, `test/test-skf-validate-brief-schema.py` | 24 new tests: validator, assembly order, flat round-trip + null-drop, JSON-schema fixture with/without rationale |

## Verification

- Full `npm test` gate green (pre-commit hook): `test:python` **1414 passed**, knowledge base 95 passed, `validate:schemas`/`validate:skills`/`validate:refs` 0 findings, lint/format clean
- `skill-brief.v1.json` meta-validates as draft-2020-12
- Backward-compat confirmed by test: legacy briefs (no `rationale`) validate unchanged

## Deliberate deviation

The build spec's test bullet referencing an `evals.json` override scenario was **not** implemented: no `evals/` directory or `evals.json` exists anywhere in this repo, and eval suites are an opt-in `--evals-file` artifact never created for this skill. Authoring a brand-new eval harness is outside this minimal slice. Override behaviour is still covered by the JSON-schema fixture test and writer round-trip test.

Out of scope (deferred, forward-compatible): `skf-update-skill` reading `scope.rationale` to surface authoring-decision conflicts during the Update intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)