### PR TITLE
chore(readme): drop maintainer-only Versioning & Release Process sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Past releases are documented in [CHANGELOG.md](CHANGELOG.md).
 
-## Versioning & Stability
-
-The v1.0.0 public API contract is documented in [docs/_internal/STABILITY.md](docs/_internal/STABILITY.md).
-
-## Release Process
-
-Maintainers: see [docs/_internal/RELEASING.md](docs/_internal/RELEASING.md) for branch-protection rules, required status checks, the [`release` environment with required-reviewer gate](docs/_internal/RELEASING.md#release-environment), the [npm Trusted Publisher registration](docs/_internal/RELEASING.md#npm-trusted-publisher) (OIDC-backed publish, auto-provenance), and the [rollback playbook](docs/_internal/RELEASING.md#rollback-playbook) covering seven failure scenarios.
-
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

Removes two maintainer-only sections from the user-facing README:

- **Release Process** — duplicated `CONTRIBUTING.md` § Releasing (already linked from README), explicitly "Maintainers:"-scoped.
- **Versioning & Stability** — a one-line pointer into an internal doc with stale `v1.0.0` wording.

Both target files under `docs/_internal/` and **still ship in the npm tarball**, reachable via `CONTRIBUTING.md`. Net: a tighter, user-focused README with zero information loss for maintainers.

## Validation

prettier ✅ · markdownlint ✅ (0 errors) · doc-links ✅ (all valid) · full pre-push suite ✅

## Scope

Docs-only chore; no code or behavior change. `chore:` → no CHANGELOG Features/Fixes impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
