### PR TITLE
fix(skf): bound detect-tools probes so a hung daemon can't stall the detector

### DIFF
--- a/src/shared/scripts/skf-detect-tools.py
+++ b/src/shared/scripts/skf-detect-tools.py
@@ -102,9 +102,12 @@ PROBE_TIMEOUT_SEC = 8  # per-tool subprocess.run timeout
 # its daemon; `subprocess.run`'s own post-timeout `process.wait()` is
 # unbounded and never returns in that case, hanging the whole detector.
 # `timeout --kill-after` reaps the child (and its session) at the OS level,
-# so Python's wait always returns. None on platforms without it (then we
-# fall back to subprocess.run's own timeout, accepting the rare hang).
-_TIMEOUT_BIN = shutil.which("timeout")
+# so Python's wait always returns. POSIX-only: Windows' `timeout.exe` is an
+# unrelated builtin (waits for input; cannot run a command), and the
+# uninterruptible-wait hang is itself POSIX-specific (Windows uses a
+# forcible TerminateProcess), so on Windows we fall back to subprocess.run's
+# own timeout. None when unavailable.
+_TIMEOUT_BIN = shutil.which("timeout") if os.name == "posix" else None
 CCC_IDENTITY_MARKER = "cocoindex code"  # case-insensitive substring
 
 

--- a/src/shared/scripts/skf-detect-tools.py
+++ b/src/shared/scripts/skf-detect-tools.py
@@ -88,13 +88,23 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
 
 VALID_TIERS = ("Quick", "Forge", "Forge+", "Deep")
 PROBE_TIMEOUT_SEC = 8  # per-tool subprocess.run timeout
+# Prefer the OS `timeout(1)` utility to bound each probe. A daemon-backed
+# tool (e.g. `qmd status`) can block in an uninterruptible syscall against
+# its daemon; `subprocess.run`'s own post-timeout `process.wait()` is
+# unbounded and never returns in that case, hanging the whole detector.
+# `timeout --kill-after` reaps the child (and its session) at the OS level,
+# so Python's wait always returns. None on platforms without it (then we
+# fall back to subprocess.run's own timeout, accepting the rare hang).
+_TIMEOUT_BIN = shutil.which("timeout")
 CCC_IDENTITY_MARKER = "cocoindex code"  # case-insensitive substring
 
 
@@ -115,16 +125,45 @@ def _run(cmd: list[str], timeout: int = PROBE_TIMEOUT_SEC) -> tuple[int, str, st
     Treats every failure mode (FileNotFoundError, TimeoutExpired, OSError,
     CalledProcessError) as a failed probe — returns rc=127 and an empty
     stdout/stderr. Tool detection should never crash the workflow.
+
+    The child is wrapped in the OS `timeout(1)` utility (when available) so a
+    daemon-backed probe blocked in an uninterruptible syscall (e.g.
+    `qmd status` waiting on its daemon socket) is reaped at the OS level —
+    `subprocess.run`'s own post-timeout `process.wait()` is unbounded and
+    would otherwise never return, hanging the whole detector. Child
+    stdout/stderr are redirected to temp files (no pipe to drain), and
+    `start_new_session=True` isolates the child's process group; the
+    Python-level timeout is a secondary net set slightly above the OS one.
     """
+    if _TIMEOUT_BIN:
+        run_cmd = [_TIMEOUT_BIN, "--kill-after=2", str(timeout), *cmd]
+        py_timeout = timeout + 5
+    else:
+        run_cmd = cmd
+        py_timeout = timeout
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
-        return result.returncode, result.stdout or "", result.stderr or ""
+        with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
+            result = subprocess.run(
+                run_cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=out_f,
+                stderr=err_f,
+                timeout=py_timeout,
+                check=False,
+                start_new_session=True,
+            )
+            # Mocked unit tests patch `subprocess.run` to return a fake with
+            # `.stdout`/`.stderr` strings set; real runs redirect to the temp
+            # files (so `result.stdout` is None — read the files instead).
+            stdout = result.stdout
+            if stdout is None:
+                out_f.seek(0)
+                stdout = out_f.read().decode("utf-8", "replace")
+            stderr = result.stderr
+            if stderr is None:
+                err_f.seek(0)
+                stderr = err_f.read().decode("utf-8", "replace")
+            return result.returncode, stdout or "", stderr or ""
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return 127, "", ""
 

--- a/test/test-skf-detect-tools.py
+++ b/test/test-skf-detect-tools.py
@@ -135,6 +135,19 @@ def _fake_run(rc: int = 0, stdout: str = "", stderr: str = ""):
     return _Result()
 
 
+def _logical(cmd):
+    """Strip the OS `timeout(1)` wrapper `_run()` prepends, returning the
+    underlying tool argv so probe `side_effect`s can match on the logical
+    command regardless of whether the host has `timeout` available.
+    """
+    if cmd and os.path.basename(str(cmd[0])) == "timeout":
+        rest = list(cmd[1:])
+        while rest and (rest[0].startswith("-") or rest[0].replace(".", "", 1).isdigit()):
+            rest.pop(0)
+        return rest
+    return list(cmd)
+
+
 def test_probe_ast_grep_success():
     with patch.object(mod.subprocess, "run", return_value=_fake_run(0, "ast-grep 0.39.5\n")):
         result = mod.probe_ast_grep()
@@ -156,6 +169,7 @@ def test_probe_ccc_identity_marker_present():
     doctor_output = "All systems operational\n"
 
     def _side_effect(cmd, **kwargs):
+        cmd = _logical(cmd)
         if cmd == ["ccc", "--help"]:
             return _fake_run(0, help_output)
         if cmd == ["ccc", "doctor"]:
@@ -174,6 +188,7 @@ def test_probe_ccc_identity_marker_absent_rejects_alias():
     foreign_help = "Usage: ccc [OPTIONS]\n\nA generic tool that happens to use ccc as its name.\n"
 
     def _side_effect(cmd, **kwargs):
+        cmd = _logical(cmd)
         if cmd == ["ccc", "--help"]:
             return _fake_run(0, foreign_help)
         raise AssertionError(
@@ -188,6 +203,7 @@ def test_probe_ccc_identity_marker_absent_rejects_alias():
 
 def test_probe_qmd_binary_present_daemon_stopped():
     def _side_effect(cmd, **kwargs):
+        cmd = _logical(cmd)
         if cmd == ["qmd", "--version"]:
             return _fake_run(0, "qmd 1.2.3\n")
         if cmd == ["qmd", "status"]:
@@ -202,6 +218,7 @@ def test_probe_qmd_binary_present_daemon_stopped():
 def test_probe_qmd_falls_back_to_help_when_version_unsupported():
     """Some qmd builds reject --version; fall back to --help for identity check."""
     def _side_effect(cmd, **kwargs):
+        cmd = _logical(cmd)
         if cmd == ["qmd", "--version"]:
             return _fake_run(2, "", "unknown option --version\n")
         if cmd == ["qmd", "--help"]:

--- a/test/test-skf-detect-tools.py
+++ b/test/test-skf-detect-tools.py
@@ -140,7 +140,7 @@ def _logical(cmd):
     underlying tool argv so probe `side_effect`s can match on the logical
     command regardless of whether the host has `timeout` available.
     """
-    if cmd and os.path.basename(str(cmd[0])) == "timeout":
+    if cmd and os.path.splitext(os.path.basename(str(cmd[0])))[0].lower() == "timeout":
         rest = list(cmd[1:])
         while rest and (rest[0].startswith("-") or rest[0].replace(".", "", 1).isdigit()):
             rest.pop(0)


### PR DESCRIPTION
## Problem

`skf-detect-tools.py` could hang far beyond its per-probe timeout (observed >90s). A daemon-backed probe such as `qmd status` blocks in an uninterruptible syscall against its daemon; `subprocess.run`'s own post-timeout `process.wait()` is unbounded, so the SIGKILL is never reaped and the probe thread — and the whole detector — stalls. This made the CLI tests that bound the script at 30s fail.

Diagnosed with `faulthandler`: the hung frame is `subprocess.run` → `process.wait()` → `os.waitpid` inside `probe_qmd`, not a pipe-drain.

## Fix

- Wrap each probe in the OS `timeout(1)` utility (when available, with `--kill-after`) so the child **and its session** are reaped at the OS level regardless of Python's reaping behaviour.
- Redirect child stdio to temp files (no pipe to drain) and start a new session.
- Fall back to `subprocess.run`'s own timeout where `timeout` is absent.
- Probe `side_effect`s in the tests now match the logical tool argv via a shared wrapper-stripping helper (production command is legitimately wrapped).

## Verification

Detector now completes in ~12s with all tools present (was an effective hang). Full `npm test` suite green: **1414 passed, 0 failed**, lint/format/validators all clean. This eliminates the only pre-existing test failures on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)