### PR TITLE
fix(skf): correct analyze-source roots and manifest IDE recording

### DIFF
--- a/src/shared/scripts/skf-manifest-ops.py
+++ b/src/shared/scripts/skf-manifest-ops.py
@@ -12,7 +12,10 @@ CLI: python3 skf-manifest-ops.py <skills-folder> <command> [args]
 Commands:
   read                          — Read entire manifest
   get <skill-name>              — Get a single skill entry
-  set <skill-name> <version>    — Add/update skill with active version
+  set <skill-name> <version> [--ides a,b]
+                                — Add/update skill with active version;
+                                  --ides unions a comma-separated IDE list
+                                  into the version entry (deduped, sorted)
   remove <skill-name>           — Remove skill from manifest
   deprecate <skill-name> [ver]  — Mark skill or version as deprecated
   rename <old-name> <new-name>  — Rename a skill entry
@@ -124,7 +127,7 @@ def cmd_get(manifest_path, skill_name):
     return {"status": "ok", "skill": skill_name, "entry": exports[skill_name]}
 
 
-def cmd_set(manifest_path, skill_name, version):
+def cmd_set(manifest_path, skill_name, version, ides=None):
     data, err = read_manifest(manifest_path)
     if err:
         return {"status": "error", "error": err}
@@ -140,10 +143,18 @@ def cmd_set(manifest_path, skill_name, version):
     if old_active and old_active in versions and old_active != version:
         versions[old_active]["status"] = "archived"
 
-    # Add or update the new active version
+    # Add or update the new active version. Absent --ides preserves the
+    # existing ides/platforms list verbatim (backward-compatible). When
+    # --ides is supplied, union it in (dedupe, keep sorted).
     existing_version = versions.get(version, {})
+    merged_ides = list(existing_version.get("ides", existing_version.get("platforms", [])))
+    if ides:
+        for ide in ides:
+            if ide not in merged_ides:
+                merged_ides.append(ide)
+        merged_ides = sorted(merged_ides)
     versions[version] = {
-        "ides": existing_version.get("ides", existing_version.get("platforms", [])),
+        "ides": merged_ides,
         "last_exported": today,
         "status": "active",
     }
@@ -205,7 +216,7 @@ def cmd_rename(manifest_path, old_name, new_name):
 def main():
     if len(sys.argv) < 3:
         print("Usage: python3 skf-manifest-ops.py <skills-folder> <command> [args]", file=sys.stderr)
-        print("Commands: read, get <name>, set <name> <version>, remove <name>, deprecate <name> [version], rename <old> <new>", file=sys.stderr)
+        print("Commands: read, get <name>, set <name> <version> [--ides a,b], remove <name>, deprecate <name> [version], rename <old> <new>", file=sys.stderr)
         sys.exit(1)
 
     skills_folder = Path(sys.argv[1])
@@ -217,7 +228,12 @@ def main():
     elif command == "get" and len(sys.argv) >= 4:
         result = cmd_get(manifest_path, sys.argv[3])
     elif command == "set" and len(sys.argv) >= 5:
-        result = cmd_set(manifest_path, sys.argv[3], sys.argv[4])
+        ides_arg = None
+        if "--ides" in sys.argv:
+            idx = sys.argv.index("--ides")
+            if idx + 1 < len(sys.argv):
+                ides_arg = [s for s in sys.argv[idx + 1].split(",") if s]
+        result = cmd_set(manifest_path, sys.argv[3], sys.argv[4], ides_arg)
     elif command == "remove" and len(sys.argv) >= 4:
         result = cmd_remove(manifest_path, sys.argv[3])
     elif command == "deprecate" and len(sys.argv) >= 4:

--- a/src/skf-analyze-source/references/identify-units.md
+++ b/src/skf-analyze-source/references/identify-units.md
@@ -58,16 +58,16 @@ Run the shared disqualification helper to apply the deterministic subset of the 
    ```json
    [
      {"name": "<unit-name>",
-      "path": "<rel-from-project-root>",
+      "path": "<rel-from-analyzed-source-root (project_paths[0])>",
       "files": ["<rel-path>", ...]},
      ...
    ]
    ```
 2. **Invoke the script** via stdin:
    ```bash
-   uv run {disqualifyCandidatesScript} filter --boundaries - --source-root {project-root}
+   uv run {disqualifyCandidatesScript} filter --boundaries - --source-root {project_paths[0]}
    ```
-   piping the boundaries JSON on stdin. The script emits:
+   piping the boundaries JSON on stdin. `--source-root` is the analyzed-source root (`project_paths[0]`) — the directory the boundaries/manifest scan ran against — not `{project-root}` (the forge workspace), which differs whenever the analyzed target lives outside the forge workspace. The script emits:
    ```json
    {
      "kept":    [{"name": "...", "path": "...", "files_count": N, "loc_total": L}, ...],

--- a/src/skf-analyze-source/references/init.md
+++ b/src/skf-analyze-source/references/init.md
@@ -26,9 +26,11 @@ To initialize the analyze-source workflow by loading configuration, detecting co
 Look for {outputFile}.
 
 **IF the file exists AND has `stepsCompleted` with entries:**
-- "**Found an existing analysis report. Resuming previous session...**"
-- Load, read entirely, then execute {continueFile}
-- **STOP HERE** — do not continue this sequence
+- The report filename is keyed to `{project_name}` (the forge workspace), not the analyzed target — so a report from a *different* target can collide here. Before resuming, establish the requested target and compare it to the existing report:
+  - Determine the requested target now: if `--project-path <path>` was passed at invocation, set `project_paths[]` from it (comma-split if multiple); otherwise collect the path(s) using the section-3 "Collect Project Path" prompt and store as `project_paths[]`. (Section 3 must NOT re-prompt when `project_paths[]` is already populated here.)
+  - Read the existing report's frontmatter `project_paths`.
+  - **IF the existing report's `project_paths` matches the requested target:** "**Found an existing analysis report. Resuming previous session...**" — Load, read entirely, then execute {continueFile}. **STOP HERE** — do not continue this sequence.
+  - **ELSE (different target — stale collision):** the existing report belongs to another analysis. Archive it by renaming to `{forge_data_folder}/analyze-source-report-{project_name}-<UTC-timestamp>.md`, announce "**Existing report belongs to a different target — archived as <name>; starting a fresh analysis.**", then continue to section 2 (skip re-collecting the path in section 3 — it is already set).
 
 **IF the file does not exist OR stepsCompleted is empty:**
 - Continue to section 2
@@ -46,7 +48,7 @@ Look for {outputFile}.
 
 ### 3. Collect Project Path
 
-**Headless flag consumption:** If `--project-path <path>` was passed at invocation, set `project_paths[]` directly from the flag value (comma-split if multiple paths were supplied), skip the prompt below, and proceed to validation. Otherwise prompt as today.
+**Headless flag consumption:** If `project_paths[]` is already populated (e.g. collected by the section-1 stale-collision guard) OR `--project-path <path>` was passed at invocation, set/keep `project_paths[]` (comma-split the flag value if multiple paths were supplied), skip the prompt below, and proceed to validation. Otherwise prompt as today.
 
 "**Welcome to Analyze Source — the SKF decomposition engine.**
 

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -335,10 +335,10 @@ On success per file, report: "**{target-file} updated successfully.** Verified b
 5. Write the updated manifest atomically via `{manifestOpsHelper}` after all skills in the batch have been applied. For each skill / version pair, invoke:
 
    ```bash
-   python3 {manifestOpsHelper} {skills_output_folder} set {skill-name} {version}
+   python3 {manifestOpsHelper} {skills_output_folder} set {skill-name} {version} --ides {ides_written}
    ```
 
-   The helper handles v2-schema validation, v1→v2 migration, and `platforms`→`ides` rename internally — no in-prompt JSON manipulation needed. Each `set` invocation merges the per-version `ides` and `last_exported` fields into the existing entry. After all skills have been set, re-read the manifest via `{manifestOpsHelper} {skills_output_folder} read` to confirm the final state matches expectations.
+   `{ides_written}` is the comma-joined sorted IDE set computed in step 3. The helper handles v2-schema validation, v1→v2 migration, and `platforms`→`ides` rename internally — no in-prompt JSON manipulation needed. Each `set` invocation unions the supplied `--ides` into the version entry's existing `ides` (deduplicated, sorted) server-side and refreshes `last_exported`. After all skills have been set, re-read the manifest via `{manifestOpsHelper} {skills_output_folder} read` to confirm the final state matches expectations.
 
 **Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name-list} — ides: {ides_written}.**" (list every skill in `skill_batch`)
 

--- a/test/test-skf-manifest-ops.py
+++ b/test/test-skf-manifest-ops.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -205,3 +206,34 @@ class TestManifestOps:
         entry = r["entry"]["versions"]["2.0.0"]
         assert entry["ides"] == ["cursor"]
         assert "platforms" not in entry
+
+    def test_set_with_ides_writes_sorted_deduped(self, manifest_path):
+        """S15: cmd_set(ides=...) on a new version records the deduped, sorted list."""
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0", ides=["cursor", "claude-code", "cursor"])
+        r = mod.cmd_get(manifest_path, "cocoindex")
+        entry = r["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["claude-code", "cursor"]
+
+    def test_set_with_ides_unions_existing(self, manifest_path):
+        """S16: cmd_set(ides=...) unions into the version's existing ides; absence preserves."""
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0", ides=["claude-code"])
+        # Re-set same version with a new IDE → union, deduped + sorted
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0", ides=["cursor", "claude-code"])
+        entry = mod.cmd_get(manifest_path, "cocoindex")["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["claude-code", "cursor"]
+        # Re-set with no --ides → existing list preserved verbatim (backward-compatible)
+        mod.cmd_set(manifest_path, "cocoindex", "2.0.0")
+        entry = mod.cmd_get(manifest_path, "cocoindex")["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["claude-code", "cursor"]
+
+    def test_cli_set_parses_ides_flag(self, manifest_path):
+        """S17: the `set ... --ides a,b` CLI dispatch path parses and unions the list."""
+        script = Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-manifest-ops.py"
+        proc = subprocess.run(
+            [sys.executable, str(script), str(manifest_path.parent),
+             "set", "cocoindex", "2.0.0", "--ides", "cursor,claude-code"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+        entry = mod.cmd_get(manifest_path, "cocoindex")["entry"]["versions"]["2.0.0"]
+        assert entry["ides"] == ["claude-code", "cursor"]


### PR DESCRIPTION
Three findings in skf-analyze-source / skf-export-skill, each ground-truthed against live source. Includes a script change with new test coverage.

- **shared/skf-manifest-ops**: `set` accepts an optional `--ides` comma-list and unions it into the version entry's `ides` (deduped, sorted). Absent `--ides` preserves prior behaviour verbatim, so existing callers are unaffected. Adds function- and CLI-level coverage for the new path.
- **skf-export-skill/update-context**: §9b now invokes `set` with `--ides {ides_written}`, so exported skills no longer persist an empty `ides` list (which broke orphan detection and managed-section rebuilds).
- **skf-analyze-source/identify-units**: pass the analyzed-source root (`project_paths[0]`) to the disqualification filter's `--source-root` instead of the forge workspace, which differ whenever the analyzed target lives outside the workspace.
- **skf-analyze-source/init**: the report filename is keyed to the workspace name, so a different target collided and falsely triggered resume. Added a stale-collision guard that compares the existing report's `project_paths` to the requested target and starts a fresh analysis (archiving the stale report) on mismatch.

Backward-compat: the optional `--ides` arg defaults to no-op; the existing `platforms`→`ides` preserve-on-set behaviour (test S13/S14) is intact. Verification: full suite 1415 passed (3 new tests), validators/lint clean.

Independent of #344/#345 (disjoint files). Note: shares `identify-units.md` with the later ProbeOrder-migration PR — merge that one last; the conflict is a documented one-line union (`{disqualifyCandidatesHelper}` token + `--source-root {project_paths[0]}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)