### PR TITLE
fix(skf): prevent npx install hint from being parsed as github org/repo

### DIFF
--- a/src/skf-export-skill/references/summary.md
+++ b/src/skf-export-skill/references/summary.md
@@ -89,17 +89,17 @@ Your skill is generated from an external dependency for local use.
 
 ### 3. Use It In This Project
 
-Always show this section (regardless of `source_authority`) so the author can install the skill they just forged into the current project and try it immediately:
+Always show this section (regardless of `source_authority`) so the author can install the skill they just forged into the current project and try it immediately.
+
+**Rendering rule for the command below — must be obeyed:** substitute `{resolved_skill_package}` with the actual resolved path before printing (do not leave the placeholder for the user to replace). The substituted path must be either absolute (starts with `/`) or `./`-prefixed. A bare relative path like `skills/foo/1.0.0/foo` is parsed by the `skills` CLI as `https://github.com/skills/foo.git` (org/repo GitHub lookup) and will fail with an authentication error. If `{resolved_skill_package}` resolves to a relative path, prefix it with `./` before emitting.
 
 "### Use It In This Project
 
-To install this skill into the current project right now:
+To install this skill into the current project right now, run:
 
 ```
 npx skills add {resolved_skill_package}
 ```
-
-Replace `{resolved_skill_package}` with the absolute path to the package folder shown above (from step 2), e.g. `{skills_output_folder}/{skill-name}/{version}/{skill-name}/`.
 
 For other source formats (registry name, git URL, tarball, etc.), see the **Installation → Source Formats** section at <https://www.npmjs.com/package/skills>.
 


### PR DESCRIPTION
## Summary

The `skf-export-skill` summary step printed `npx skills add {resolved_skill_package}` followed by prose telling the user to substitute the placeholder with an absolute path. In practice that left the door open to emitting a bare relative path like `skills/foo/1.0.0/foo/`, which the `skills` CLI parses as `https://github.com/skills/foo.git` (org/repo GitHub lookup) and fails with an authentication error instead of installing locally.

This PR adds an explicit rendering rule directing the LLM to substitute the placeholder itself and to prefix relative paths with `./` (or use an absolute path) so the CLI resolves them as local directories. The now-redundant "replace the placeholder" prose is dropped from the user-facing block — the substitution belongs to the workflow renderer, not the end user.

## Repro (against the upstream `skills` CLI)

```
$ npx --yes skills add skills/foo/1.0.0/foo --yes
◇  Source: https://github.com/skills/foo.git (1.0.0/foo)
■  Failed to clone repository
   Authentication failed for https://github.com/skills/foo.git.

$ npx --yes skills add ./skills/foo/1.0.0/foo --yes
◇  Source: /tmp/.../skills/foo/1.0.0/foo
◇  Local path validated
```

The CLI takes the first two segments of a bare path as `org/repo`. Absolute paths (start with `/`) and `./`-prefixed relative paths are unambiguous and resolve as local directories.

## Audit

I greped every `npx skills add` mention in the repo to confirm the trap only exists in one location. The other 12 mentions are conceptual references or describe registry-name installs (single-segment names, which is the intended path for published skills) — none emit a user-runnable command with a multi-segment path.

## Test plan

- [x] `npm test` passes locally on the branch
- [x] Verify summary step output of a real `skf-export-skill` run renders the install command with a safe path form (absolute or `./`-prefixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)