### PR TITLE
fix(skf): route resume after generate-briefs to health-check

### DIFF
--- a/src/skf-analyze-source/references/continue.md
+++ b/src/skf-analyze-source/references/continue.md
@@ -6,6 +6,7 @@ nextStepOptions:
   step 4: 'map-and-detect.md'
   step 5: 'recommend.md'
   step 6: 'generate-briefs.md'
+  step 7: 'health-check.md'
 ---
 
 <!-- Config: communicate in {communication_language}. -->
@@ -61,8 +62,9 @@ Map the last completed step to the next step file:
 | identify-units | map-and-detect |
 | map-and-detect | recommend |
 | recommend | generate-briefs |
+| generate-briefs | health-check |
 
-**IF all steps completed:**
+**IF `health-check` is in `stepsCompleted`:**
 "**This analysis appears to be complete.** All steps have been finished. Would you like to start a new analysis?"
 
 ### 5. Update and Route


### PR DESCRIPTION
## Summary

`skf-analyze-source`'s `continue.md` resume-routing was missing the final hop. Step 7 (health-check) was listed in `SKILL.md`'s Stages table and was reachable via the forward `nextStepFile` chain, but `continue.md`'s §4 mapping table stopped at `recommend → generate-briefs`, and the terminal "IF all steps completed" branch fired whenever the table had no row for the last completed step. A session that crashed or paused between step 6 and step 7 had no documented route — a less careful agent could declare the analysis done and skip `health-check` entirely.

Three-line patch in `continue.md`:

- Add `step 7: 'health-check.md'` to the `nextStepOptions` frontmatter so §5's lookup can resolve the new route.
- Add `| generate-briefs | health-check |` row to the §4 mapping table.
- Tighten the terminal condition from `IF all steps completed` to `` IF `health-check` is in `stepsCompleted` `` so the completion branch only fires once the actual terminal step has executed.

## Cross-impact

- `SKILL.md` Stages table already lists 7 steps including `health-check.md` — `continue.md` was the only out-of-sync surface.
- Forward `nextStepFile` chain (`recommend → generate-briefs → health-check → shared/health-check.md`) was already correct.
- `test-skf-chain-reachability.py` walks the `nextStepFile` chain, not the resume mapping table, so no behavioral change for that test.

## Test plan

- [x] `npm test` (full suite: pytest, jest, lint, markdownlint, prettier) — green
- [x] Simulated resume: with `stepsCompleted: [init, scan-project, identify-units, map-and-detect, recommend, generate-briefs]`, continue.md now routes to `health-check`.
- [x] Simulated resume: with `stepsCompleted: [..., generate-briefs, health-check]`, the terminal "analysis appears to be complete" branch fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)