### PR TITLE
fix(shared): YAML round-trip in description-guard restore

### DIFF
--- a/src/shared/scripts/skf-description-guard.py
+++ b/src/shared/scripts/skf-description-guard.py
@@ -160,17 +160,45 @@ def is_diverged(diff_kind: str) -> bool:
 def restore_description(skill_md: Path, captured: str) -> None:
     """Atomically rewrite SKILL.md so its frontmatter `description` equals captured.
 
-    Preserves frontmatter key order and surrounding whitespace by doing a
-    line-level rewrite of just the `description:` value, not a full YAML
-    re-dump (which would re-order keys, change quoting style, and likely
-    fail roundtrip tests downstream).
+    Parses the entire frontmatter via PyYAML, replaces the top-level
+    `description` value, and re-emits the frontmatter via `yaml.safe_dump`.
+    This guarantees valid YAML output regardless of the source representation
+    (inline, double-quoted, single-quoted, folded `>`, literal `|`), and
+    avoids the line-level pitfalls a previous implementation had with folded
+    block scalars and nested `description:` keys in sibling mappings.
+
+    Key order is preserved (PyYAML's `safe_dump` honours dict insertion order;
+    this module's `requires-python = ">=3.10"` guarantees ordered dicts).
+    Quoting style of *other* fields may change to whatever `safe_dump`
+    chooses for each scalar — downstream readers parse YAML, so any valid
+    YAML emission is acceptable.
     """
     text = skill_md.read_text(encoding="utf-8")
     leading, fm_yaml, body = _split_frontmatter(text)
     if not fm_yaml:
         raise ValueError(f"cannot restore: no frontmatter in {skill_md}")
 
-    new_fm = _rewrite_description_line(fm_yaml, captured)
+    try:
+        fm = yaml.safe_load(fm_yaml)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"frontmatter in {skill_md} is not valid YAML: {exc}") from exc
+    if not isinstance(fm, dict):
+        raise ValueError(f"frontmatter in {skill_md} is not a mapping")
+    if "description" not in fm:
+        raise ValueError(f"frontmatter in {skill_md} has no `description` field")
+
+    fm["description"] = captured
+
+    # `width=10**9` keeps the description on one line regardless of length;
+    # PyYAML otherwise inserts line breaks at ~80 chars which would re-introduce
+    # folded-scalar continuation lines — the exact failure mode this rewrite fixes.
+    new_fm = yaml.safe_dump(
+        fm,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=10**9,
+    ).rstrip("\n")
     new_text = f"{leading}{new_fm}\n---\n{body}"
 
     # atomic: write to a sibling temp file, fsync, rename
@@ -189,81 +217,6 @@ def restore_description(skill_md: Path, captured: str) -> None:
         except FileNotFoundError:
             pass
         raise
-
-
-def _rewrite_description_line(fm_yaml: str, new_description: str) -> str:
-    """Replace the `description:` value in a YAML frontmatter block.
-
-    Preserves other keys verbatim. Handles three common shapes:
-      description: single-line value
-      description: "double-quoted value"
-      description: |     # block scalar (folded variant: >)
-        multi-line
-        value here
-    """
-    lines = fm_yaml.split("\n")
-    out: list[str] = []
-    i = 0
-    quoted = _yaml_quote_inline(new_description)
-    replaced = False
-    while i < len(lines):
-        line = lines[i]
-        if not replaced and _is_description_key_line(line):
-            stripped = line.lstrip()
-            indent = line[: len(line) - len(stripped)]
-            # detect block-scalar indicator (| or >)
-            after_key = stripped[len("description:") :].lstrip()
-            if after_key.startswith("|") or after_key.startswith(">"):
-                # skip block-scalar continuation lines (deeper indent than the key line)
-                key_indent = len(indent)
-                i += 1
-                while i < len(lines):
-                    nxt = lines[i]
-                    if nxt.strip() == "":
-                        # blank lines belong to the block scalar
-                        i += 1
-                        continue
-                    nxt_indent = len(nxt) - len(nxt.lstrip())
-                    if nxt_indent <= key_indent:
-                        break
-                    i += 1
-                out.append(f"{indent}description: {quoted}")
-                replaced = True
-                continue
-            out.append(f"{indent}description: {quoted}")
-            replaced = True
-            i += 1
-            continue
-        out.append(line)
-        i += 1
-    if not replaced:
-        raise ValueError("description key not found while rewriting frontmatter")
-    return "\n".join(out)
-
-
-def _is_description_key_line(line: str) -> bool:
-    stripped = line.lstrip()
-    return stripped.startswith("description:") and (
-        len(stripped) == len("description:") or stripped[len("description:")] in (" ", "\t", "")
-    )
-
-
-def _yaml_quote_inline(value: str) -> str:
-    """Emit a YAML scalar suitable as the inline value of `description: `.
-
-    Uses double-quoted form so control characters and embedded quotes are
-    safe. Block scalars (| / >) are not used — the description field is a
-    single semantic string and downstream readers (skill-check, agentskills)
-    expect inline form.
-    """
-    escaped = (
-        value.replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-    )
-    return f'"{escaped}"'
 
 
 # --------------------------------------------------------------------------

--- a/test/test-skf-description-guard.py
+++ b/test/test-skf-description-guard.py
@@ -17,6 +17,16 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
+
+
+def _parse_frontmatter(text: str) -> dict:
+    """Extract the frontmatter mapping from a SKILL.md text blob."""
+    assert text.startswith("---\n"), "expected leading frontmatter fence"
+    rest = text[4:]
+    close = rest.find("\n---\n")
+    assert close != -1, "expected closing frontmatter fence"
+    return yaml.safe_load(rest[:close])
 
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -188,35 +198,41 @@ version: 1.2.3
         )
         mod.restore_description(skill, "the authoritative original description")
         text = skill.read_text(encoding="utf-8")
-        assert 'description: "the authoritative original description"' in text
-        # other keys + order preserved
-        lines = text.split("\n")
-        assert lines[1] == "name: my-skill"
-        assert any(line == "version: 1.2.3" for line in lines)
+        fm = _parse_frontmatter(text)
+        # frontmatter parses as valid YAML with all expected keys
+        assert fm["name"] == "my-skill"
+        assert fm["description"] == "the authoritative original description"
+        assert fm["version"] == "1.2.3"
+        # key order preserved (name → description → version)
+        assert list(fm.keys()) == ["name", "description", "version"]
         # body untouched
         assert "# Body" in text
 
     def test_restore_quoted(self, tmp_path: Path) -> None:
         skill = _write_skill(tmp_path, "tool wrote this", shape="quoted")
         mod.restore_description(skill, "original")
-        text = skill.read_text(encoding="utf-8")
-        assert 'description: "original"' in text
+        fm = _parse_frontmatter(skill.read_text(encoding="utf-8"))
+        assert fm["description"] == "original"
 
     def test_restore_block_scalar_collapses_to_inline(self, tmp_path: Path) -> None:
         skill = _write_skill(tmp_path, "tool wrote this", shape="block")
         mod.restore_description(skill, "original")
         text = skill.read_text(encoding="utf-8")
-        # block scalar lines are removed; replaced with single inline line
-        assert 'description: "original"' in text
+        fm = _parse_frontmatter(text)
+        assert fm["description"] == "original"
+        # the prior block-scalar shape (`description: |` with continuation lines)
+        # MUST NOT survive — its leftover continuation block was the original
+        # failure mode this fix targets
         assert "description: |" not in text
+        assert "description: >" not in text
 
     def test_restore_escapes_embedded_quotes(self, tmp_path: Path) -> None:
         skill = _write_skill(tmp_path, "x", shape="inline")
         mod.restore_description(skill, 'has "double" quotes and \\ backslash')
-        text = skill.read_text(encoding="utf-8")
-        assert (
-            'description: "has \\"double\\" quotes and \\\\ backslash"' in text
-        )
+        fm = _parse_frontmatter(skill.read_text(encoding="utf-8"))
+        # round-trip through YAML emit/parse preserves the value verbatim,
+        # regardless of which quoting style safe_dump chose
+        assert fm["description"] == 'has "double" quotes and \\ backslash'
 
     def test_restore_atomic_no_partial_file(self, tmp_path: Path) -> None:
         # after restore, no .skf-guard.tmp files remain in the directory
@@ -230,6 +246,83 @@ version: 1.2.3
         mod.restore_description(skill, "the original")
         desc, _ = mod.read_description(skill)
         assert desc == "the original"
+
+    def test_restore_block_scalar_with_keys_after(self, tmp_path: Path) -> None:
+        """Regression: folded `>` description followed by sibling keys.
+
+        The previous line-rewrite implementation could leave continuation
+        lines on disk in certain layouts, producing invalid YAML where the
+        new inline `description:` was followed by orphan indented text.
+        With YAML round-trip, the output is always parseable.
+        """
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            """---
+name: my-skill
+description: >
+  Tool-rewritten short
+  version on multiple
+  lines.
+license: MIT
+metadata:
+  version: 1.2.3
+---
+
+# Body
+""",
+            encoding="utf-8",
+        )
+        mod.restore_description(skill, "the authoritative original")
+        text = skill.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(text)
+        assert fm["description"] == "the authoritative original"
+        assert fm["name"] == "my-skill"
+        assert fm["license"] == "MIT"
+        assert fm["metadata"] == {"version": "1.2.3"}
+
+    def test_restore_does_not_touch_nested_description_key(self, tmp_path: Path) -> None:
+        """Regression: a `description:` inside a nested mapping must not
+        be mistaken for the top-level field, and must be left untouched.
+        """
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            """---
+metadata:
+  description: nested — must not be touched
+name: my-skill
+description: top-level tool-rewritten
+---
+
+# Body
+""",
+            encoding="utf-8",
+        )
+        mod.restore_description(skill, "top-level original")
+        fm = _parse_frontmatter(skill.read_text(encoding="utf-8"))
+        assert fm["description"] == "top-level original"
+        assert fm["metadata"]["description"] == "nested — must not be touched"
+
+    def test_restore_when_only_nested_description_exists_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: if the top-level frontmatter has no `description`
+        field (only a nested one), restore must fail loudly rather than
+        silently rewriting the nested key.
+        """
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            """---
+name: my-skill
+related:
+  description: nested only
+---
+
+# Body
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="no `description`"):
+            mod.restore_description(skill, "should not be written anywhere")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`skf-description-guard.py verify-restore` previously rewrote the frontmatter `description:` field via line-level substitution. The line walker had two latent failure modes:

1. **Folded-block layouts could produce invalid YAML.** When the on-disk shape was `description: >` followed by continuation lines, certain layouts left stale continuation lines on disk after the inline replacement, e.g.:
   ```yaml
   description: "the captured value"
     orphan continuation
     from prior block
   license: MIT
   ```
   which the next YAML read parsed as `expected <block end>, but found '<scalar>'`. The post-restore re-validation hook in `validate.md` §0 caught this but only flipped the schema score back to `FAIL` — the broken file was still on disk and downstream artifact generation continued against it.

2. **Nested `description:` keys could be matched instead of the top-level one.** The walker matched the first `description:` line it saw regardless of indentation depth, so a sibling mapping with its own `description:` (e.g. `metadata.description`) could be silently rewritten while the top-level field remained untouched. The reverse case (top-level missing the field, nested mapping present) would also silently rewrite the wrong key.

## Fix

Replace the line-rewrite with a YAML parse → mutate `fm["description"]` → `yaml.safe_dump` round-trip in `restore_description()`. The output is always valid YAML regardless of the source representation (inline / double-quoted / folded `>` / literal `|`), and the operation only touches the top-level field.

- `sort_keys=False` preserves Python 3.10+ dict insertion order (this script's `requires-python` declaration guarantees ordered dicts).
- `width=10**9` keeps the description on a single line — without it, PyYAML re-introduces folded continuation lines at ~80 chars, which would recreate the original failure mode.
- Removed now-unused helpers `_rewrite_description_line`, `_is_description_key_line`, `_yaml_quote_inline`.

## Test changes

- Relaxed string-form assertions in the restore tests to parse-and-compare on the frontmatter dict, since `safe_dump`'s quoting heuristics may differ from the prior implementation's hardcoded double-quoted output. Behavior tests still assert what callers actually care about (the parsed `description` value, key order preservation, body untouched).
- Added 3 regression tests:
  - `test_restore_block_scalar_with_keys_after` — covers the multi-key folded-scalar layout that produced the original on-disk YAML breakage.
  - `test_restore_does_not_touch_nested_description_key` — covers the false-positive case.
  - `test_restore_when_only_nested_description_exists_raises` — covers the silent-wrong-key case; now fails loudly.

## Cross-impact

- `description-guard-protocol.md` makes no claims about the restore implementation — only what it does end-to-end. No protocol-doc change needed.
- `validate.md`'s post-restore re-validation hook stays in place — it also catches non-YAML failures (length limits, forbidden tokens, required-field shape) that this fix doesn't address.
- Real-world SKF skill frontmatters are flat `name` + `description` only, so the user-visible style change is negligible.

## Test plan

- [x] `npm test` (full suite: 33 description-guard tests including new regressions, lint, markdownlint, prettier) — green
- [x] Manual: round-trip a SKILL.md whose `description:` is a folded `>` block scalar through `verify-restore`; confirm the resulting file parses as valid YAML and `description` equals the captured value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)