### PR TITLE
feat(skf): ratify existing skill-brief.yaml in brief-skill

### DIFF
--- a/src/skf-brief-skill/SKILL.md
+++ b/src/skf-brief-skill/SKILL.md
@@ -13,6 +13,8 @@ A good skill brief sets a tight, cohesive boundary: one capability with 3-8 prim
 
 Brief-skill is split from create-skill so the scoping conversation runs *once*, on cheap signals (manifests, top-level exports, intent), without paying for AST extraction. Compilation is expensive; scoping decisions are cheap to revise. Keeping them in separate workflows lets a user iterate on the brief, share it for review, and re-run create-skill against the same brief whenever the upstream version moves.
 
+**Ratify path (interactive only).** When the user already has a `skill-brief.yaml` produced by another workflow — typically `skf-analyze-source`'s `generate-briefs` step, where one analyze pass emits several recommended briefs — invoking `/skf-brief-skill` with a path to that brief at the first prompt routes to a fast-path review: gather-intent §3.1a loads the YAML, hydrates the brief context, and jumps straight to step 4 (confirm-brief) where the standard review/edit cycle still applies before step 5 writes. This skips re-deriving fields the upstream draft already supplies and saves the 5-10 minutes a full re-run of intent + analyze + scope would cost.
+
 ## Conventions
 
 - Bare paths (e.g. `references/<name>.md`) resolve from the skill root.

--- a/src/skf-brief-skill/references/gather-intent.md
+++ b/src/skf-brief-skill/references/gather-intent.md
@@ -1,5 +1,6 @@
 ---
 nextStepFile: 'analyze-target.md'
+ratifyTargetFile: 'confirm-brief.md'
 forgeTierFile: '{sidecar_path}/forge-tier.yaml'
 descriptionVoiceExamplesFile: 'assets/description-voice-examples.md'
 headlessArgsFile: 'references/headless-args.md'
@@ -9,6 +10,9 @@ draftCheckpointFile: 'references/draft-checkpoint.md'
 validateBriefInputsProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-validate-brief-inputs.py'
   - '{project-root}/src/shared/scripts/skf-validate-brief-inputs.py'
+validateBriefSchemaProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-validate-brief-schema.py'
+  - '{project-root}/src/shared/scripts/skf-validate-brief-schema.py'
 emitBriefEnvelopeProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-emit-brief-result-envelope.py'
   - '{project-root}/src/shared/scripts/skf-emit-brief-result-envelope.py'
@@ -84,7 +88,7 @@ Let's get started."
 
 ### 3. Gather Target Repository
 
-This section has three sub-flows. Execute exactly one branch — 3.2 *or* 3.3 — based on the user's response in 3.1, then end with the shared confirmation. Do not mix branches.
+This section has four sub-flows. Execute exactly one branch — 3.1a *or* 3.2 *or* 3.3 — based on the user's response in 3.1, then end with the shared confirmation (3.1a is terminal for §3 and jumps directly to confirm-brief.md). Do not mix branches.
 
 #### 3.1 Collect target
 
@@ -94,6 +98,7 @@ Provide one of:
 - A **GitHub URL** (e.g., `https://github.com/org/repo`)
 - A **local path** (e.g., `/path/to/project`)
 - **Documentation URLs** for a docs-only skill (e.g., `https://docs.stripe.com/api`) — use this when no source code is available (SaaS, closed-source)
+- A **path to an existing `skill-brief.yaml`** (file path or a directory containing one) — use this to ratify a brief produced by another workflow (e.g. `skf-analyze-source`) without re-deriving fields
 
 Or type `cancel` / `exit` / `[X]` to leave without writing anything.
 
@@ -102,9 +107,63 @@ Or type `cancel` / `exit` / `[X]` to leave without writing anything.
 Wait for user response. Branch on the response:
 
 - Empty input, `cancel`, `exit`, `[X]`, `q`, or `:q` → Display `"Cancelled — no brief was written."` and HALT (exit code 6, `halt_reason: "user-cancelled"`). Cancellation here is non-destructive — no files have been written yet by step 1. Headless mode never reaches this branch (the GATE in §8 short-circuits the interactive sub-flows).
+- Path that resolves to an existing `skill-brief.yaml` (file path ending in `skill-brief.yaml` that exists, OR a directory containing a `skill-brief.yaml`) → §3.1a
 - Documentation URLs only (no source location) → §3.2
 - GitHub URL or local filesystem path → §3.3
 - Any other free-form question (e.g. "what is this?", "show me an example", "how does SKF work?") → answer briefly, re-display the prompt
+
+#### 3.1a Branch — Ratify existing brief
+
+This branch handles the AN→BS handoff: another workflow (typically `skf-analyze-source`) has already produced a `skill-brief.yaml`, and the user wants to review and confirm it without re-running gather-intent / analyze-target / scope-definition. **This branch is interactive-only** — headless mode reaches step 1 via §8's GATE with `target_repo`/`skill_name` args, not via this §3.1a path. (A headless ratify equivalent could be added later via a `from_brief` argument; out of scope here.)
+
+Resolve the path:
+
+- If the user's input ends in `skill-brief.yaml` and points at an existing file → that is the brief path.
+- Otherwise (input was a directory) → the brief path is `<input>/skill-brief.yaml`.
+
+**Validate the brief against the schema** before presenting it. Resolve `{validateBriefSchemaHelper}` from `{validateBriefSchemaProbeOrder}` (first existing path wins; HALT if no candidate exists), then:
+
+```bash
+uv run {validateBriefSchemaHelper} <resolved-brief-path>
+```
+
+The script returns JSON `{valid, errors[], warnings[], halt_reason, brief}`. Apply the result:
+
+- **`valid: false`** — surface the `errors[]` messages and the `halt_reason` to the user, then re-display the §3.1 prompt for a corrected path (or another target altogether). Do not HALT — the user may simply have pointed at the wrong file. Example: `"**Brief at `{path}` is invalid:** {first error message}. Pick a different brief, or supply a repo / docs URL instead."`
+- **`valid: true`** — proceed with the parsed `brief` payload.
+
+Surface any non-empty `warnings[]` as a single grouped line (`"**Brief validation warnings:** {joined warnings}"`), then present the ratify menu:
+
+```
+**Existing brief detected at `{path}`.**
+
+- **Name:** {brief.name}
+- **Target:** {brief.source_repo}
+- **Description:** "{brief.description}"
+- **Created:** {brief.created} by {brief.created_by}
+- **Scope:** {brief.scope.type}
+
+Pick one:
+  [R] Ratify — review in step 4 and write (overwriting this file once approved)
+  [F] Start fresh — discard this brief and re-prompt for a target
+  [X] Cancel and exit
+```
+
+Wait for user response. Branch:
+
+- **[R] Ratify** — Confirm overwrite up front: store `ratify_mode: true` and `ratify_source_path: <resolved-brief-path>` in workflow context. Hydrate the brief context variables from the parsed `brief` payload so step 4 has the same field set it normally derives from steps 1-3:
+  - `name` ← `brief.name`; `version` ← `brief.version`; `target_version` ← `brief.target_version`
+  - `source_repo` ← `brief.source_repo`; `source_type` ← `brief.source_type`; `source_authority` ← `brief.source_authority`; `doc_urls` ← `brief.doc_urls`
+  - `language` ← `brief.language`; `description` ← `brief.description`; `forge_tier` ← `brief.forge_tier`
+  - `created` ← `brief.created`; `created_by` ← `brief.created_by`
+  - `scope.type` / `scope.include` / `scope.exclude` / `scope.notes` / `scope.rationale` ← `brief.scope.*`
+  - `scripts_intent` ← `brief.scripts_intent`; `assets_intent` ← `brief.assets_intent`
+
+  Then load, read entirely, and execute `{ratifyTargetFile}` — bypassing §3.1b/§3.2/§3.3, §3b, §4, §5, §6, §7, §7b, and §8 entirely. Skip step 2 (analyze-target) and step 3 (scope-definition) — both would re-derive fields already on disk. The forward chain resumes at step 4 (confirm-brief) where the user gets the standard review pass and can still adjust fields inline via §4.
+
+- **[F] Start fresh** — discard the loaded brief and re-display §3.1 above (the user is now at the same point as if they had typed nothing).
+- **[X] Cancel** — Display `"Cancelled — no brief was written."` and HALT (exit code 6, `halt_reason: "user-cancelled"`). Non-destructive.
+- **Any other input** — treat as a fresh §3.1 response and re-evaluate the routing branches above (a typed GitHub URL after seeing the menu means "I changed my mind, brief this repo instead").
 
 #### 3.2 Branch — Documentation URLs (docs-only)
 

--- a/src/skf-brief-skill/references/write-brief.md
+++ b/src/skf-brief-skill/references/write-brief.md
@@ -52,7 +52,11 @@ The script's atomic-write helper creates parent directories as needed (`mkdir -p
 
 Before writing, check whether the resolved target path already exists.
 
-**Interactive (`{headless_mode}` is false):**
+**Ratify path (`ratify_mode: true` in workflow context):**
+
+The user already confirmed overwrite up-front at step 1 §3.1a when they chose `[R] Ratify` against the same file. Skip the interactive prompt below; log a single-line `brief-skill: ratify-mode auto-overwriting existing brief at {path}` and proceed to §3. Resuming the prompt would be friction — the user has by now also reviewed and approved the brief at step 4. This auto-accept does not apply to headless mode (handled below) nor to the standard interactive path (also below).
+
+**Interactive (`{headless_mode}` is false, `ratify_mode` not set):**
 
 If the file exists, present:
 


### PR DESCRIPTION
## Summary

`skf-brief-skill` had no documented branch for the case where another workflow (typically `skf-analyze-source`'s `generate-briefs` step) has already produced a `skill-brief.yaml` and the user wants to review and confirm it without re-running the full intent → analyze → scope sequence. Step 1 §3.1 only accepted GitHub URL / local path / docs URL inputs, and the existing-brief overwrite gate was buried in step 5 §2b — by the time the workflow noticed an existing brief at the target path, it had already re-derived every field that brief already supplied. Operators bridging the AN→BS handoff either accepted ~5–10 minutes of redundant re-derivation or invented an ad-hoc menu out-of-band.

This PR adds an interactive **ratify path**:

- `gather-intent.md` §3.1 now recognises a path that resolves to an existing `skill-brief.yaml` (either a file path ending in `skill-brief.yaml` or a directory containing one). On match, route to a new §3.1a sub-flow.
- §3.1a validates the brief via the existing `skf-validate-brief-schema.py` script (which already returns the parsed payload), surfaces any validation errors, and presents an explicit `[R] Ratify` / `[F] Start fresh` / `[X] Cancel` menu.
- On `[R]`, brief context is hydrated from the parsed YAML (`name`, `version`, `source_repo`, `language`, `description`, `forge_tier`, `scope.*`, `source_authority`, `doc_urls`, `scripts_intent`, `assets_intent`, `created`, `created_by`) and the workflow jumps directly to step 4 (`confirm-brief.md`) via a new `ratifyTargetFile` frontmatter pointer, bypassing analyze-target and scope-definition.
- `write-brief.md` §2b auto-accepts the overwrite when `ratify_mode: true` is in context — the up-front confirmation at §3.1a stands; re-asking at step 5 would be friction after the user has already approved the brief at step 4. Headless and non-ratify interactive paths are unchanged.
- `SKILL.md` overview gains a short paragraph documenting the AN→BS handoff capability so callers know it exists.

## Scope

**Interactive-only.** A headless ratify equivalent (e.g. a `from_brief` argument) is a deliberate follow-up — the headless GATE in step 1 §8 already enforces `target_repo` + `skill_name` as required args, and changing that contract is a larger surface than this finding called for. The friction this PR addresses was specifically interactive (~3-4 min of out-of-band negotiation per AN→BS handoff session).

## Cross-impact

- `test-skf-chain-reachability.py` walks `nextStepFile` only — the new `ratifyTargetFile` pointer is invisible to it; `confirm-brief.md` is already reachable via the forward chain. ✓
- `test-installation-components.js` enumerates step filenames; no new files added. ✓
- `skf-validate-brief-schema.py` already exists at the probe-order paths in dev (`src/shared/scripts/`) and installed (`_bmad/skf/shared/scripts/`). ✓
- `confirm-brief.md` §1 reads from conversation-context variables — no change needed there since §3.1a hydrates the same variables from the loaded YAML.

## Design choices

- **§3.1a is a jump, not a chain step.** No new entry in `SKILL.md` Stages table; this is a within-step branch.
- **Three-option menu, not four.** The session that produced this finding ad-hoc'd four modes (ratify / refine / re-run / verify). "Refine" collapses into `[R]` + edit at step 4's adjustment menu; "verify" is automatic via the schema validator. Two real choices + cancel keeps the prompt clear.
- **Re-validation on disk.** The ratify path still chains through `write-brief.md`, so the canonical writer script's schema validation and atomic-write semantics still apply. An untouched ratify produces a byte-identical file; an edited one produces an updated valid YAML.

## Test plan

- [x] `npm test` (full suite: pytest, jest, lint, markdownlint, prettier, validate:refs, validate:skills, validate:schemas) — green
- [x] Manual interactive: `/skf-brief-skill` → enter path to an existing `skill-brief.yaml` → confirm `§3.1a` menu appears → pick `[R]` → confirm-brief presents the loaded fields → approve → write-brief writes without re-asking overwrite.
- [x] Manual interactive: `/skf-brief-skill` → enter path to a directory containing `skill-brief.yaml` → same flow.
- [x] Manual interactive: `/skf-brief-skill` → enter path to a malformed brief → §3.1a surfaces validator errors → re-prompt §3.1.
- [x] Manual interactive: standard non-ratify path still works (GitHub URL → analyze-target → scope-definition → confirm-brief → write-brief with the standard overwrite prompt).
- [x] Manual headless: `--headless --target-repo ... --skill-name ...` still routes via §8 GATE unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)