### PR TITLE
fix(skf): resolve test report by glob in update-skill --from-test-report

### DIFF
--- a/src/skf-test-skill/SKILL.md
+++ b/src/skf-test-skill/SKILL.md
@@ -51,7 +51,7 @@ These rules apply to every step in this workflow:
 |--------|--------|
 | **Inputs** | skill_name [required]; optional flags: `--allow-workspace-drift`, `--no-discovery` (skip §4b Discovery Testing), `--no-health-check` (skip §7 health-check dispatch), `--tier=<Quick\|Forge\|Forge+\|Deep>` (bypass forge-tier.yaml sidecar requirement), `--threshold=<N>` (override pass threshold; CLI wins over `workflow.default_threshold` scalar) |
 | **Gates** | step 6: Confirm Gate [C] |
-| **Outputs** | test-report-{skill_name}.md with completeness score and result (PASS/FAIL); per-run `skf-test-skill-result-{run_id}.json` and `skf-test-skill-result-latest.json` written atomically under `{forge_version}/` |
+| **Outputs** | per-run `test-report-{skill_name}-{run_id}.md` with completeness score and result (PASS/FAIL); per-run `skf-test-skill-result-{run_id}.json` and `skf-test-skill-result-latest.json` written atomically under `{forge_version}/` — downstream consumers (export-skill, update-skill `--from-test-report`) glob `test-report-{skill_name}-*.md` and pick newest by parsed ISO timestamp |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true |
 | **Exit codes** | See "Exit Codes" below |
 

--- a/src/skf-update-skill/references/init.md
+++ b/src/skf-update-skill/references/init.md
@@ -42,7 +42,14 @@ Provide either:
 Resolve the path to an absolute skill folder location.
 
 **If `--from-test-report` was provided (or user references a test report):**
-Search for the test report at `{forge_data_folder}/{skill_name}/{active_version}/test-report-{skill_name}.md` (i.e., `{forge_version}/test-report-{skill_name}.md`). If not found at the versioned path, fall back to `{forge_data_folder}/{skill_name}/test-report-{skill_name}.md`. If found, set `test_report_path` in context and `update_mode: gap-driven`. If not found at either path, warn and continue with normal source drift mode.
+
+`skf-test-skill` writes timestamped test-report filenames (`test-report-{skill_name}-{ISO-TIMESTAMP}-{HASH}.md`) — there is no exact-name `test-report-{skill_name}.md` on disk. Locate the most recent report by glob, mirroring `skf-export-skill/references/load-skill.md §4b`:
+
+1. Glob `{forge_data_folder}/{skill_name}/{active_version}/test-report-{skill_name}-*.md` (i.e. `{forge_version}/test-report-{skill_name}-*.md`). Sort matches descending by the parsed ISO-timestamp segment in the filename (`YYYYMMDDTHHMMSSZ` between the skill name and the hash — `sort -r` on the filename works because the timestamp is the first variable component). Take the first match.
+2. If the versioned glob returns nothing, fall back to the same glob at the flat path `{forge_data_folder}/{skill_name}/test-report-{skill_name}-*.md`. Pick the newest by parsed timestamp.
+3. If neither glob returns anything, look for the stable companion `skf-test-skill-result-latest.json` in the same two directories (versioned first, then flat). Read the report path from `outputs[]` per the canonical contract documented at `shared/references/output-contract-schema.md` (resolved by skf-test-skill step 6 §4c) and load that file.
+
+If a report is located, set `test_report_path` in context to the resolved absolute path and set `update_mode: gap-driven`. Surface the actual file picked in the message (e.g. `test-report-{skill_name}-20260507T050917Z-487606-9b2f.md`) so an operator can navigate to the report from the log. If all three lookups fail, warn and continue with normal source drift mode.
 
 **If `--allow-workspace-drift` was provided:** set `allow_workspace_drift: true` in workflow context. This flag is consumed by step 3 §0.a's pre-flight drift guard (gap-driven mode only) and has no effect in normal source-drift mode.
 


### PR DESCRIPTION
## Summary

- `skf-update-skill --from-test-report` probed for the exact filename `test-report-{skill_name}.md`, but `skf-test-skill` writes `test-report-{skill_name}-{run_id}.md` (UTC timestamp + PID + random suffix). The lookup missed every report and silently fell back to source-drift mode, breaking the documented `test-skill → update-skill --from-test-report` follow-up sequence.
- Mirror the consumer-side resolution pattern already used by `skf-export-skill/references/load-skill.md §4b`: glob the versioned path → glob the flat path → fall back to `skf-test-skill-result-latest.json` `outputs[]`. Surface the picked filename in the operator message.
- Correct `skf-test-skill/SKILL.md` Outputs description, which misnamed the test report file and was the root of the consumer/producer disagreement.

No producer-side change, no new artifact. Backwards-compatible with every existing test report on disk — works retroactively, no re-run required.

Related: #299 (same bug family in `skf-export-skill`, fixed with the same three-tier glob+envelope strategy).

## Test plan

- [x] Full local suite green (`npm test`): schemas, install, cli, workflow, python, knowledge, validate:schemas, validate:skills, validate:refs, lint, lint:md, format:check.
- [x] Manual: in a project with a recent test report present, invoke `skf-update-skill <name> --from-test-report` and confirm the workflow enters gap-driven mode, reports the actual picked filename, and runs detect-changes against the gap manifest (no fall-through to source-drift mode).