### PR TITLE
fix(skf-export-skill): prevent managed-section wipe and marker duplication

### DIFF
--- a/src/shared/scripts/skf-rebuild-managed-sections.py
+++ b/src/shared/scripts/skf-rebuild-managed-sections.py
@@ -179,15 +179,15 @@ def main():
     elif action == "read":
         result = cmd_read(file_path)
     elif action == "replace":
-        if content_arg is None:
-            result = {"status": "error", "error": "replace requires --content or stdin"}
+        if content_arg is None or not content_arg.strip():
+            result = {"status": "error", "error": "replace requires non-empty --content or stdin"}
         else:
             result = cmd_replace(file_path, content_arg)
     elif action == "clear":
         result = cmd_clear(file_path)
     elif action == "insert":
-        if content_arg is None:
-            result = {"status": "error", "error": "insert requires --content or stdin"}
+        if content_arg is None or not content_arg.strip():
+            result = {"status": "error", "error": "insert requires non-empty --content or stdin"}
         else:
             result = cmd_insert(file_path, content_arg)
     else:

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -166,10 +166,11 @@ Count totals:
 
 ### 5. Generate Managed Section
 
-Assemble the complete managed section:
+Assemble the managed section in **two shapes** — the §9 write paths consume different forms, and conflating them double-wraps the markers.
+
+**`{managed_section_inner}`** — the between-marker body only, **no** `<!-- SKF:BEGIN/END -->` markers. The `insert` and `replace` helper actions supply the markers (and the `updated:` timestamp) themselves, so they take this inner form:
 
 ```markdown
-<!-- SKF:BEGIN updated:{current-date} -->
 [SKF Skills]|{n} skills|{m} stack
 |IMPORTANT: Prefer documented APIs over training data.
 |When using a listed library, read its SKILL.md before writing code.
@@ -179,6 +180,13 @@ Assemble the complete managed section:
 |{skill-snippet-2}
 |
 |{skill-snippet-N}
+```
+
+**`{managed_section_full}`** — `{managed_section_inner}` wrapped in markers. Used for the new-file create path (atomic write, which writes the text verbatim) and the §7 preview:
+
+```markdown
+<!-- SKF:BEGIN updated:{current-date} -->
+{managed_section_inner}
 <!-- SKF:END -->
 ```
 
@@ -273,26 +281,26 @@ For each target context file, dispatch by case:
 **Case 1 (Create — file does not exist):**
 
 ```bash
-echo "{new_managed_section_text}" | python3 {atomicWriteHelper} write "{target-file}"
+echo "{managed_section_full}" | python3 {atomicWriteHelper} write "{target-file}"
 ```
 
-The helper stages the content into `<target>.skf-tmp`, fsyncs, and atomically renames into place.
+The helper stages the content into `<target>.skf-tmp`, fsyncs, and atomically renames into place. This path writes verbatim, so it takes the **marker-bearing** `{managed_section_full}`.
 
 **Case 2 (Append — file exists, no `<!-- SKF:BEGIN` marker):**
 
 ```bash
-python3 {rebuildManagedSectionsHelper} {target-file} insert --content "{new_managed_section_text}"
+python3 {rebuildManagedSectionsHelper} {target-file} insert --content "{managed_section_inner}"
 ```
 
-The helper appends the managed section to the end of the file via the same atomic temp-file + rename pattern.
+The helper appends the managed section to the end of the file via the same atomic temp-file + rename pattern. Pass the **inner-only** `{managed_section_inner}` — the helper adds the markers and `updated:` timestamp itself; passing marker-bearing text double-wraps them.
 
 **Case 3 (Regenerate — file contains `<!-- SKF:BEGIN` and `<!-- SKF:END -->`):**
 
 ```bash
-python3 {rebuildManagedSectionsHelper} {target-file} replace --content "{new_managed_section_text}"
+python3 {rebuildManagedSectionsHelper} {target-file} replace --content "{managed_section_inner}"
 ```
 
-The helper performs the surgical between-marker swap with post-write verification (markers present, content outside markers byte-identical).
+The helper performs the surgical between-marker swap with post-write verification (markers present, content outside markers byte-identical). Pass the **inner-only** `{managed_section_inner}` — as with `insert`, the helper supplies the markers; marker-bearing text double-wraps them.
 
 **Case 4 (malformed markers — already HALTed in §6):** never reaches here.
 

--- a/test/test-skf-rebuild-managed-sections.py
+++ b/test/test-skf-rebuild-managed-sections.py
@@ -4,15 +4,16 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
+import sys
 import tempfile
 
 import pytest
 from pathlib import Path
 
-spec = importlib.util.spec_from_file_location(
-    "skf_rms",
-    Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-rebuild-managed-sections.py",
-)
+SCRIPT = Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-rebuild-managed-sections.py"
+
+spec = importlib.util.spec_from_file_location("skf_rms", SCRIPT)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
@@ -168,4 +169,60 @@ class TestMalformedMarkers:
         r = mod.cmd_check(fp)
         assert r["markers_valid"] is False
         assert "no matching" in r.get("error_detail", "").lower()
+        Path(fp).unlink()
+
+
+class TestEmptyContentGuard:
+    """Suite 9: replace/insert must reject empty content instead of silently wiping the section.
+
+    Exercises main() via subprocess because the guard lives in the CLI layer. The empty-stdin
+    path (no --content, non-tty stdin) previously read "" and wiped the managed section.
+    """
+
+    @pytest.mark.parametrize("action", ["replace", "insert"])
+    def test_missing_content_with_empty_stdin_preserves_file(self, action):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), fp, action],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 1
+        assert "non-empty" in proc.stdout
+        assert Path(fp).read_text(encoding="utf-8") == SAMPLE_FILE
+        Path(fp).unlink()
+
+    @pytest.mark.parametrize("action", ["replace", "insert"])
+    def test_whitespace_only_content_preserves_file(self, action):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), fp, action, "--content", "   \n  "],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 1
+        assert "non-empty" in proc.stdout
+        assert Path(fp).read_text(encoding="utf-8") == SAMPLE_FILE
+        Path(fp).unlink()
+
+    def test_real_replace_still_succeeds(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), fp, "replace", "--content", "Fresh body."],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0
+        updated = Path(fp).read_text(encoding="utf-8")
+        assert "Fresh body." in updated
+        assert "Old skill snippets" not in updated
         Path(fp).unlink()


### PR DESCRIPTION
## Summary

Two defects in the `skf-export-skill` context-rebuild path:

- **Silent managed-section wipe.** `skf-rebuild-managed-sections.py` `replace`/`insert` invoked without `--content` fell through to an empty-string read from non-interactive stdin, bypassing the `content_arg is None` guard and wiping the managed section to empty while returning a success envelope (exit 0). Now empty/whitespace content is rejected for both actions (exit 1); `clear` remains the intended removal path.
- **Duplicated SKF markers on first write.** `update-context.md` §5 assembled a single marker-bearing managed-section string that §9 Cases 2/3 passed to the `insert`/`replace` helper — but that helper supplies the `SKF:BEGIN/END` markers itself, so the markers were double-wrapped. §5 now defines two explicit shapes: `{managed_section_inner}` (body only, for the marker-supplying helper) and `{managed_section_full}` (marker-bearing, for the new-file atomic write and the preview), and §9 uses the correct shape per case.

Adds regression tests covering the empty-content guard (including the empty-stdin path) and a successful replace.

## Test plan

- [x] `test-skf-rebuild-managed-sections.py` — 14 pass, incl. 5 new guard tests
- [x] Full `npm test` suite green (schemas, install, cli, workflow, python, knowledge, validate, refs, lint, lint:md, format:check)
- [x] Empirically reproduced the wipe pre-fix and confirmed it errors (exit 1) post-fix; confirmed a real `replace` still swaps content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)