### PR TITLE
fix(skf-brief-skill): workspace manifest_kind precedence in language detection

### DIFF
--- a/src/shared/scripts/skf-detect-language.py
+++ b/src/shared/scripts/skf-detect-language.py
@@ -14,6 +14,13 @@ co-located with a deterministic rule rather than restated in prose.
 
 Detection rules (apply in order, first match wins):
 
+  0. workspace_signal (optional, from skf-detect-workspaces.manifest_kind):
+       "cargo-workspace"       → rust (high)
+       "python-multi-package"  → python (high)
+       A non-JS workspace root's language wins over a nested package.json +
+       tsconfig.json (e.g. a docs/ or website/ site that is not a workspace
+       member). JS-family workspaces (npm/pnpm/lerna) carry no entry here and
+       fall through to rule 1, whose root package.json correctly resolves js/ts.
   1. package.json (with optional tsconfig.json companion):
        tsconfig.json present → typescript (high)
        tsconfig.json absent  → javascript (high)
@@ -37,6 +44,10 @@ CLI:
 
 Input (JSON object on stdin or via --json):
   tree — list of repo-relative file paths (required, non-empty)
+  workspace_signal — optional manifest_kind from skf-detect-workspaces. When it
+                     names a non-JS workspace ("cargo-workspace",
+                     "python-multi-package"), rule 0 returns the root language
+                     and ignores nested package.json/tsconfig matches.
 
 Output (JSON on stdout):
   language          — javascript | typescript | rust | python | go
@@ -59,6 +70,17 @@ import json
 import sys
 from collections import Counter
 from typing import Any
+
+# Workspace manifest_kind → root language (rule 0). Only non-JS workspace kinds
+# appear here: a Cargo/Python workspace root is unambiguously rust/python, and a
+# nested package.json+tsconfig (a docs or website subproject) must not win. JS
+# workspace kinds (npm-workspaces/pnpm-workspaces/lerna) are intentionally
+# absent — their root manifest IS package.json, so rule 1 resolves js/ts
+# correctly. generic-folders / null carry no language signal.
+_WORKSPACE_SIGNAL_LANGUAGE: dict[str, str] = {
+    "cargo-workspace": "rust",
+    "python-multi-package": "python",
+}
 
 # Manifest basenames the rule table checks. Kept tight — tree-wide pattern
 # matches (e.g. *.csproj) are handled separately to avoid false positives
@@ -184,6 +206,18 @@ def detect(payload: dict[str, Any]) -> dict[str, Any]:
         _die("payload.tree must be an array of repo-relative file paths")
     if len(tree) == 0:
         _die("payload.tree must be non-empty")
+
+    # Rule 0 — workspace precedence. A non-JS workspace root (from
+    # skf-detect-workspaces.manifest_kind) wins over any nested package.json +
+    # tsconfig.json, which would otherwise be misread as a typescript root.
+    workspace_signal = payload.get("workspace_signal")
+    if isinstance(workspace_signal, str) and workspace_signal in _WORKSPACE_SIGNAL_LANGUAGE:
+        return {
+            "language": _WORKSPACE_SIGNAL_LANGUAGE[workspace_signal],
+            "confidence": "high",
+            "detection_source": f"workspace manifest_kind={workspace_signal} (root manifest wins over nested package.json)",
+            "fallback_to_extension_frequency": False,
+        }
 
     # Rule 1 — package.json (with tsconfig.json disambiguation)
     if _has_basename(tree, "package.json"):

--- a/src/skf-brief-skill/references/analyze-target.md
+++ b/src/skf-brief-skill/references/analyze-target.md
@@ -117,10 +117,12 @@ List the top-level directory structure:
 Delegate the rule walk to `{detectLanguageHelper}` instead of evaluating manifest presence and extension frequency in prose:
 
 ```bash
-echo '{"tree": [<flat list of repo-relative file paths from §1>]}' | uv run {detectLanguageHelper}
+echo '{"tree": [<flat list of repo-relative file paths from §1>], "workspace_signal": "<§1b manifest_kind, or omit when null>"}' | uv run {detectLanguageHelper}
 ```
 
-The script returns `{language, confidence, detection_source, fallback_to_extension_frequency}` after walking the documented rule table (manifest presence first — package.json with tsconfig.json disambiguation, Cargo.toml, pyproject.toml/setup.py/setup.cfg, go.mod, pom.xml, build.gradle.kts, build.gradle Groovy with Java/Kotlin disambiguation, *.csproj/*.sln, Gemfile — then extension-frequency fallback over recognized source extensions). Use the returned values directly:
+Pass the §1b `manifest_kind` as `workspace_signal` (omit the key when it is `null` / not a monorepo). This gives the workspace root precedence: for a `cargo-workspace` or `python-multi-package` root, the script returns the root language (rust/python) instead of being misled into `typescript` by a nested `package.json` + `tsconfig.json` in a non-workspace subdirectory (e.g. a `docs/` or `website/` site). JS-family workspace kinds (`npm-workspaces`/`pnpm-workspaces`/`lerna`) carry no override — their root `package.json` resolves js/ts normally.
+
+The script returns `{language, confidence, detection_source, fallback_to_extension_frequency}` after walking the documented rule table (the `workspace_signal` precedence above first, then manifest presence — package.json with tsconfig.json disambiguation, Cargo.toml, pyproject.toml/setup.py/setup.cfg, go.mod, pom.xml, build.gradle.kts, build.gradle Groovy with Java/Kotlin disambiguation, *.csproj/*.sln, Gemfile — then extension-frequency fallback over recognized source extensions). Use the returned values directly:
 
 "**Detected language:** {language}
 **Confidence:** {confidence}

--- a/test/test-skf-detect-language.py
+++ b/test/test-skf-detect-language.py
@@ -66,6 +66,56 @@ def test_package_json_in_subdir_still_matches():
 
 
 # --------------------------------------------------------------------------
+# Rule 0 — workspace_signal precedence
+# --------------------------------------------------------------------------
+
+
+def test_cargo_workspace_signal_wins_over_nested_package_json_tsconfig():
+    """The reported bug: a Rust cargo-workspace root with a docs/ TS site must detect rust, not typescript."""
+    tree = [
+        "Cargo.toml",
+        "crates/core/src/lib.rs",
+        "docs/package.json",
+        "docs/tsconfig.json",
+        "docs/pages/index.tsx",
+    ]
+    result = mod.detect({"tree": tree, "workspace_signal": "cargo-workspace"})
+    assert_result_shape(result)
+    assert result["language"] == "rust"
+    assert result["confidence"] == "high"
+    assert result["fallback_to_extension_frequency"] is False
+    assert "cargo-workspace" in result["detection_source"]
+
+
+def test_python_multi_package_signal_returns_python():
+    tree = ["packages/a/pyproject.toml", "docs/package.json", "docs/tsconfig.json"]
+    result = mod.detect({"tree": tree, "workspace_signal": "python-multi-package"})
+    assert result["language"] == "python"
+    assert result["confidence"] == "high"
+
+
+def test_npm_workspace_signal_falls_through_to_package_json_rule():
+    """JS-family workspace kinds carry no override; a root package.json+tsconfig still resolves typescript."""
+    tree = ["package.json", "tsconfig.json", "packages/a/src/index.ts"]
+    result = mod.detect({"tree": tree, "workspace_signal": "npm-workspaces"})
+    assert result["language"] == "typescript"
+    assert result["confidence"] == "high"
+
+
+def test_unknown_or_null_workspace_signal_is_ignored():
+    """generic-folders / unexpected values fall through to the normal rule walk."""
+    tree = ["package.json", "src/index.js"]
+    assert mod.detect({"tree": tree, "workspace_signal": "generic-folders"})["language"] == "javascript"
+    assert mod.detect({"tree": tree, "workspace_signal": None})["language"] == "javascript"
+
+
+def test_no_workspace_signal_preserves_legacy_behavior():
+    """Absent workspace_signal: a nested package.json still matches rule 1 (unchanged)."""
+    result = mod.detect({"tree": ["docs/package.json", "Cargo.toml", "src/lib.rs"]})
+    assert result["language"] == "javascript"
+
+
+# --------------------------------------------------------------------------
 # Rules 2-6 — single-basename manifests
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`skf-detect-language.py` checked `package.json` (rule 1) before `Cargo.toml`, and `_has_basename` matches a manifest at any depth. A Rust **cargo-workspace** at the repo root with a `docs/` TypeScript site (`docs/package.json` + `docs/tsconfig.json`) was therefore misdetected as `typescript` (high confidence) — silently routing extraction down the wrong language path.

- **`skf-detect-language.py` — new rule 0 (workspace precedence).** When the optional `workspace_signal` input names a non-JS workspace (`cargo-workspace` → rust, `python-multi-package` → python), the workspace root's language wins over any nested `package.json`/`tsconfig.json`. JS-family workspace kinds (`npm-workspaces`/`pnpm-workspaces`/`lerna`) carry **no** override — their root manifest *is* `package.json`, so rule 1 resolves js/ts correctly and behavior there is unchanged. `generic-folders`/`null` carry no signal and fall through.
- **`analyze-target.md` §3.** Threads the §1b `manifest_kind` into the detect-language payload as `workspace_signal` (omitted when null / not a monorepo).

The `cargo-workspace` / `python-multi-package` values match the `manifest_kind` enum in `workspace-detection.v1.json` exactly.

### Scope boundary

The fix relies on the workspace signal. A single-crate repo (root `Cargo.toml` with no `[workspace]`) plus a `docs/package.json` has `manifest_kind: null`, so no signal exists and it is not covered here. Depth-only filtering was considered and rejected (it breaks repos whose primary package lives in a subdirectory).

## Test plan

- [x] `test-skf-detect-language.py` — 35 pass (+5 new: cargo-workspace+docs-TS scenario, python case, npm-workspace fall-through, unknown/null signal ignored, unchanged no-signal behavior)
- [x] Full `npm test` suite green (incl. lint, lint:md, format:check, schema/ref validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)