### PR TITLE
fix(skf-brief-skill): warn when a cross-ecosystem workspace manifest is dropped

### DIFF
--- a/src/shared/scripts/skf-detect-workspaces.py
+++ b/src/shared/scripts/skf-detect-workspaces.py
@@ -361,6 +361,59 @@ DETECTORS: list[tuple[str, callable]] = [
     ("generic-folders",      detect_generic_folders),
 ]
 
+# Language ecosystem each manifest kind belongs to. Drives the cross-ecosystem
+# secondary-manifest warning below. `generic-folders` is intentionally absent —
+# it is a tree-shape heuristic, not a distinct root workspace manifest, so it
+# never participates in cross-ecosystem warnings.
+ECOSYSTEM_OF_KIND = {
+    "npm-workspaces":       "js",
+    "pnpm-workspaces":      "js",
+    "lerna":                "js",
+    "cargo-workspace":      "rust",
+    "python-multi-package": "python",
+}
+
+ROOT_MANIFEST_OF_KIND = {
+    "npm-workspaces":       "package.json",
+    "pnpm-workspaces":      "pnpm-workspace.yaml",
+    "lerna":                "lerna.json",
+    "cargo-workspace":      "Cargo.toml",
+    "python-multi-package": None,  # discovered from the tree; no single root manifest
+}
+
+
+def _cross_ecosystem_warnings(
+    primary_kind: str, tree: set[str], manifests: dict[str, str]
+) -> list[str]:
+    """Warn when a root workspace manifest from a *different* language ecosystem
+    than the surfaced one also resolves members.
+
+    First-match-wins detection silently drops a co-located workspace from another
+    ecosystem (e.g. a root `Cargo.toml [workspace]` when a pnpm workspace wins),
+    which then poisons downstream language detection and the §1b workspace menu.
+    This re-runs only the manifest-backed detectors from a different ecosystem,
+    against a throwaway warnings sink so their parse errors are not propagated,
+    and emits one warning per ignored cross-ecosystem kind that resolves >=1
+    member. The surfaced `manifest_kind` / `workspaces` are left unchanged.
+    """
+    primary_eco = ECOSYSTEM_OF_KIND.get(primary_kind)
+    out: list[str] = []
+    for kind, detector in DETECTORS:
+        eco = ECOSYSTEM_OF_KIND.get(kind)
+        if kind == primary_kind or eco is None or eco == primary_eco:
+            continue  # self, generic-folders, or same ecosystem as the winner
+        result = detector(tree, manifests, [])
+        if result and len(result) >= 1:
+            manifest = ROOT_MANIFEST_OF_KIND.get(kind)
+            where = f" (root {manifest})" if manifest else ""
+            out.append(
+                f"cross-ecosystem workspace ignored: {kind}{where} resolves "
+                f"{len(result)} member(s) but only {primary_kind} was surfaced. "
+                f"If the skill targets the {kind} ecosystem, re-scope to it — "
+                f"language detection keys off the surfaced manifest_kind."
+            )
+    return out
+
 
 # --------------------------------------------------------------------------
 # Entry point
@@ -381,6 +434,7 @@ def detect(payload: dict) -> dict:
     for kind, detector in DETECTORS:
         result = detector(tree, manifests, warnings)
         if result and len(result) >= 1:
+            warnings.extend(_cross_ecosystem_warnings(kind, tree, manifests))
             return {
                 "is_monorepo":   True,
                 "manifest_kind": kind,

--- a/src/skf-brief-skill/references/analyze-target.md
+++ b/src/skf-brief-skill/references/analyze-target.md
@@ -96,6 +96,8 @@ Headless: if the input contract supplied an `include` glob that begins with one 
 
 Surface any non-empty `warnings[]` from the script to the operator log so a malformed root manifest is debuggable; the workflow does not HALT — falling back to repo-root analysis is always safe.
 
+**`cross-ecosystem workspace ignored` warning:** when a root workspace manifest from a different language ecosystem co-exists with the surfaced one (e.g. a root `Cargo.toml [workspace]` alongside a pnpm workspace), the script surfaces only the higher-priority kind and emits this warning naming the ignored kind and its member count. The ignored ecosystem's workspaces are **not** in `workspaces[]`, so the numbered menu above will not list them. When this warning is present, tell the operator both ecosystems exist and ask which the skill should cover; if they pick the ignored ecosystem, scope §2-§4b at its root (or the relevant member) rather than the surfaced workspace, and carry the ignored kind into §3 (see the `workspace_signal` note there).
+
 ### 2. Read Repository Structure
 
 List the top-level directory structure:
@@ -121,6 +123,8 @@ echo '{"tree": [<flat list of repo-relative file paths from §1>], "workspace_si
 ```
 
 Pass the §1b `manifest_kind` as `workspace_signal` (omit the key when it is `null` / not a monorepo). This gives the workspace root precedence: for a `cargo-workspace` or `python-multi-package` root, the script returns the root language (rust/python) instead of being misled into `typescript` by a nested `package.json` + `tsconfig.json` in a non-workspace subdirectory (e.g. a `docs/` or `website/` site). JS-family workspace kinds (`npm-workspaces`/`pnpm-workspaces`/`lerna`) carry no override — their root `package.json` resolves js/ts normally.
+
+**When §1b surfaced a `cross-ecosystem workspace ignored` warning and the operator chose the ignored ecosystem:** pass that ignored kind as `workspace_signal` (not the surfaced kind), so a co-located `cargo-workspace`/`python-multi-package` root resolves to rust/python instead of being pinned to the surfaced ecosystem's language by the workspace that won detection priority.
 
 The script returns `{language, confidence, detection_source, fallback_to_extension_frequency}` after walking the documented rule table (the `workspace_signal` precedence above first, then manifest presence — package.json with tsconfig.json disambiguation, Cargo.toml, pyproject.toml/setup.py/setup.cfg, go.mod, pom.xml, build.gradle.kts, build.gradle Groovy with Java/Kotlin disambiguation, *.csproj/*.sln, Gemfile — then extension-frequency fallback over recognized source extensions). Use the returned values directly:
 

--- a/test/test-skf-detect-workspaces.py
+++ b/test/test-skf-detect-workspaces.py
@@ -611,6 +611,122 @@ class TestGenericFolders:
 
 
 # --------------------------------------------------------------------------
+# Cross-ecosystem secondary-manifest warning
+# --------------------------------------------------------------------------
+
+
+class TestCrossEcosystemWarning:
+    # tauri-style repo: a root pnpm workspace (JS) co-located with a root
+    # `Cargo.toml [workspace]` (Rust). pnpm wins by priority; the cargo
+    # workspace must not vanish silently.
+    DUAL = {
+        "tree": [
+            "pnpm-workspace.yaml",
+            "packages/api/package.json",
+            "packages/cli/package.json",
+            "Cargo.toml",
+            "crates/tauri/Cargo.toml",
+            "crates/tauri-runtime/Cargo.toml",
+        ],
+        "manifests": {
+            "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+            "packages/api/package.json": json.dumps({"name": "api"}),
+            "packages/cli/package.json": json.dumps({"name": "cli"}),
+            "Cargo.toml": '[workspace]\nmembers = ["crates/*"]\n',
+            "crates/tauri/Cargo.toml": '[package]\nname = "tauri"\nversion = "2.11.2"\n',
+            "crates/tauri-runtime/Cargo.toml": '[package]\nname = "tauri-runtime"\n',
+        },
+    }
+
+    def test_pnpm_wins_but_cargo_workspace_is_flagged_not_dropped(self):
+        out = mod.detect(self.DUAL)
+        # Surfaced result is unchanged (non-breaking): pnpm still wins.
+        assert out["manifest_kind"] == "pnpm-workspaces"
+        assert {ws["path"] for ws in out["workspaces"]} == {"packages/api", "packages/cli"}
+        # ...but the ignored cargo workspace now surfaces as a warning.
+        cargo_warns = [w for w in out["warnings"] if "cargo-workspace" in w]
+        assert len(cargo_warns) == 1, out["warnings"]
+        assert "Cargo.toml" in cargo_warns[0]
+        assert "2 member" in cargo_warns[0]
+        assert_envelope_shape(out)
+
+    def test_cargo_wins_flags_co_located_python_workspace(self):
+        # Inverse direction: a JS root workspace always wins by priority over
+        # cargo, so the reachable inverse is cargo (priority 4) winning over a
+        # co-located python-multi-package layout (priority 5), which must be
+        # flagged rather than silently dropped.
+        out = mod.detect(
+            {
+                "tree": [
+                    "Cargo.toml",
+                    "crates/core/Cargo.toml",
+                    "crates/cli/Cargo.toml",
+                    "packages/svc-a/pyproject.toml",
+                    "packages/svc-b/pyproject.toml",
+                ],
+                "manifests": {
+                    "Cargo.toml": '[workspace]\nmembers = ["crates/*"]\n',
+                    "crates/core/Cargo.toml": '[package]\nname = "core"\n',
+                    "crates/cli/Cargo.toml": '[package]\nname = "cli"\n',
+                    "packages/svc-a/pyproject.toml": '[project]\nname = "svc-a"\n',
+                    "packages/svc-b/pyproject.toml": '[project]\nname = "svc-b"\n',
+                },
+            }
+        )
+        assert out["manifest_kind"] == "cargo-workspace"
+        assert any("python-multi-package" in w for w in out["warnings"]), out["warnings"]
+
+    def test_same_ecosystem_npm_and_pnpm_do_not_warn(self):
+        # npm + pnpm are both JS — the priority pick is expected, not a
+        # cross-ecosystem drop, so no warning should fire.
+        out = mod.detect(
+            {
+                "tree": [
+                    "package.json",
+                    "pnpm-workspace.yaml",
+                    "packages/foo/package.json",
+                ],
+                "manifests": {
+                    "package.json": json.dumps({"workspaces": ["packages/*"]}),
+                    "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+                    "packages/foo/package.json": json.dumps({"name": "foo"}),
+                },
+            }
+        )
+        assert out["manifest_kind"] == "npm-workspaces"
+        assert not any("cross-ecosystem" in w for w in out["warnings"]), out["warnings"]
+
+    def test_single_ecosystem_repo_emits_no_cross_ecosystem_warning(self):
+        out = mod.detect(
+            {
+                "tree": ["pnpm-workspace.yaml", "packages/foo/package.json"],
+                "manifests": {
+                    "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+                    "packages/foo/package.json": json.dumps({"name": "foo"}),
+                },
+            }
+        )
+        assert not any("cross-ecosystem" in w for w in out["warnings"]), out["warnings"]
+
+    def test_malformed_secondary_manifest_does_not_leak_into_warnings(self):
+        # A broken Cargo.toml alongside the winning pnpm workspace must not
+        # surface a "Cargo.toml parse error" — the secondary detector's parse
+        # warnings go to a throwaway sink.
+        out = mod.detect(
+            {
+                "tree": ["pnpm-workspace.yaml", "packages/foo/package.json", "Cargo.toml"],
+                "manifests": {
+                    "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+                    "packages/foo/package.json": json.dumps({"name": "foo"}),
+                    "Cargo.toml": "[workspace\nmembers =",  # broken
+                },
+            }
+        )
+        assert out["manifest_kind"] == "pnpm-workspaces"
+        assert not any("parse error" in w for w in out["warnings"]), out["warnings"]
+
+
+# --------------------------------------------------------------------------
 # CLI / I/O
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `skf-detect-workspaces` returns the **first** matching detector by priority, so a co-located root `Cargo.toml [workspace]` (or a `python-multi-package` layout) was **silently dropped** whenever a higher-priority JS workspace won — poisoning downstream language detection and the §1b workspace-selection menu with a `manifest_kind` that omitted the actual target ecosystem.
- The detector now re-runs the manifest-backed detectors from *other* ecosystems against a throwaway warnings sink (so their parse errors don't leak) and appends a `cross-ecosystem workspace ignored` warning naming the dropped kind and its member count. The surfaced `manifest_kind` / `workspaces` are **unchanged** — non-breaking, and no schema change since `warnings[]` already exists in the result envelope.
- `analyze-target.md` §1b/§3 now tell the operator both ecosystems exist and route the chosen ecosystem's `workspace_signal`, so language detection isn't pinned to the detector that won priority.

## Test plan

- [x] `test-skf-detect-workspaces.py` — added 5 cases: tauri-style pnpm+cargo (warning fires, pnpm still surfaced), cargo+python inverse, same-ecosystem npm+pnpm no-warn guard, single-ecosystem no-warn, malformed-secondary-manifest-no-leak. 44/44 pass.
- [x] Full `npm test` passes (exit 0).
- [x] `lint:md` + `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)