### PR TITLE
fix(skf-export-skill): exclude shared managed section from package total

### DIFF
--- a/src/skf-export-skill/references/token-report.md
+++ b/src/skf-export-skill/references/token-report.md
@@ -29,7 +29,7 @@ For each artifact, estimate tokens using the heuristic: **words * 1.3** (approxi
 3. **SKILL.md** — The full active skill document
 4. **metadata.json** — The machine-readable metadata
 5. **references/** — Total across all reference files (if present)
-6. **Full package total** — Sum of all above
+6. **Full package total** — Sum of this skill's own artifacts (context-snippet.md + SKILL.md + metadata.json + references/). **Exclude the Managed section row (item 2)** — it is a shared all-skills cost (it bundles this skill's snippet plus every other skill's snippet), reported separately under Context Budget Impact. Including it would double-count this skill's snippet and fold in unrelated skills' costs.
 
 **If passive_context was disabled:** Skip context-snippet.md and managed section measurements, note as "N/A (disabled)".
 
@@ -44,7 +44,7 @@ For each artifact, estimate tokens using the heuristic: **words * 1.3** (approxi
 | SKILL.md | {n} | ~{t} | Active skill (on-trigger) |
 | metadata.json | {n} | ~{t} | Machine-readable |
 | references/ | {n} | ~{t} | {count} files |
-| **Package total** | **{n}** | **~{t}** | **All artifacts combined** |
+| **Package total** | **{n}** | **~{t}** | **This skill's own artifacts (snippet + SKILL.md + metadata + references); excludes the shared Managed section row** |
 
 **Context Budget Impact:**
 - **Always-on cost:** ~{managed-section-tokens} tokens (managed section in {target-file-list})


### PR DESCRIPTION
## Summary

- `token-report` §1 item 6 defined the "Full package total" as the "Sum of all above", which includes the "Managed section (all skills)" row — a **shared** all-skills cost that already bundles this skill's snippet plus every other skill's snippet. Following that literally double-counts this skill's snippet and folds in unrelated skills' costs into a single skill's package total.
- Reworded §1 item 6 and the §2 table's Package-total notes cell to sum only **this skill's own artifacts** (snippet + SKILL.md + metadata + references). The managed section remains reported separately under **Context Budget Impact** (the always-on cost).

## Test plan

- [x] Full `npm test` passes (exit 0).
- [x] `lint:md` clean.
- [x] Consistent with the multi-skill per-skill row definition (§Rules) — package total = the four own-artifact rows; managed section measured once for the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)