### PR TITLE
fix(skf-export-skill): atomic managed-section writes + correct helper-contract docs

### DIFF
--- a/src/shared/scripts/skf-rebuild-managed-sections.py
+++ b/src/shared/scripts/skf-rebuild-managed-sections.py
@@ -58,8 +58,12 @@ def _atomic_write(file_path, text):
     """
     path = Path(file_path)
     tmp = path.with_name(path.name + ".skf-tmp")
+    # O_BINARY (Windows only; 0 elsewhere) suppresses the text-mode \n -> \r\n
+    # translation that would otherwise diverge the on-disk bytes from the staged
+    # string and trip the byte-identity verify below.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0)
     try:
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        fd = os.open(tmp, flags, 0o644)
         try:
             os.write(fd, text.encode("utf-8"))
             os.fsync(fd)

--- a/src/shared/scripts/skf-rebuild-managed-sections.py
+++ b/src/shared/scripts/skf-rebuild-managed-sections.py
@@ -21,6 +21,7 @@ Actions:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -45,6 +46,60 @@ def read_context_file(file_path):
 def find_managed_section(content):
     """Find the managed section in content. Returns match or None."""
     return MARKER_PATTERN.search(content)
+
+
+def _atomic_write(file_path, text):
+    """Stage `text` into <file>.skf-tmp, fsync, then os.replace into place.
+
+    Mirrors skf-atomic-write.py's `write` so the marker-surgery actions deliver
+    the crash-safety the step file documents: a mid-write process kill leaves
+    the original file intact rather than truncated. Cleans up the temp file on
+    failure. Raises OSError on any I/O failure.
+    """
+    path = Path(file_path)
+    tmp = path.with_name(path.name + ".skf-tmp")
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        try:
+            os.write(fd, text.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(tmp, path)
+    except OSError:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        raise
+
+
+def _write_and_verify(file_path, updated, *, expect_section):
+    """Atomically write `updated`, then re-read to confirm integrity.
+
+    Returns None on success or an error string. The re-read asserts the on-disk
+    bytes match what was staged (so content outside the markers is byte-identical)
+    and that managed-section marker presence matches `expect_section`.
+    """
+    try:
+        _atomic_write(file_path, updated)
+    except OSError as e:
+        return f"atomic write failed: {e}"
+
+    # Re-read raw bytes (no newline translation) for a true byte-identity check.
+    try:
+        on_disk = Path(file_path).read_bytes()
+    except OSError as e:
+        return f"post-write verification failed: {e}"
+    if on_disk != updated.encode("utf-8"):
+        return "post-write verification failed: on-disk bytes do not match staged content"
+    if (find_managed_section(on_disk.decode("utf-8")) is not None) != expect_section:
+        return (
+            "post-write verification failed: managed section "
+            + ("missing after write" if expect_section else "still present after clear")
+        )
+    return None
 
 
 def cmd_check(file_path):
@@ -112,7 +167,9 @@ def cmd_replace(file_path, new_content):
     new_section = f"<!-- SKF:BEGIN updated:{today} -->\n{new_content}\n{END_MARKER}"
     updated = content[: match.start()] + new_section + content[match.end() :]
 
-    Path(file_path).write_text(updated, encoding="utf-8")
+    verify_err = _write_and_verify(file_path, updated, expect_section=True)
+    if verify_err:
+        return {"status": "error", "error": verify_err}
     return {"status": "ok", "action": "replaced", "bytes_written": len(updated)}
 
 
@@ -131,7 +188,9 @@ def cmd_clear(file_path):
     after = content[match.end() :].lstrip("\n")
     updated = before + ("\n\n" if before and after else "") + after
 
-    Path(file_path).write_text(updated, encoding="utf-8")
+    verify_err = _write_and_verify(file_path, updated, expect_section=False)
+    if verify_err:
+        return {"status": "error", "error": verify_err}
     return {"status": "ok", "action": "cleared", "bytes_written": len(updated)}
 
 
@@ -153,7 +212,9 @@ def cmd_insert(file_path, new_content):
     section = f"\n<!-- SKF:BEGIN updated:{today} -->\n{new_content}\n{END_MARKER}\n"
     updated = content.rstrip("\n") + "\n" + section if content.strip() else section.lstrip("\n")
 
-    Path(file_path).write_text(updated, encoding="utf-8")
+    verify_err = _write_and_verify(file_path, updated, expect_section=True)
+    if verify_err:
+        return {"status": "error", "error": verify_err}
     return {"status": "ok", "action": "inserted", "bytes_written": len(updated)}
 
 

--- a/src/skf-export-skill/references/manifest-rebuild.md
+++ b/src/skf-export-skill/references/manifest-rebuild.md
@@ -61,7 +61,7 @@ For v1 manifests (no `schema_version` field), the helper migrates in-place on th
 3. Wrap in v2 structure: `active_version` ← resolved version, single entry in `versions` with `status: "active"`, `ides: []` (unknown — fills on next successful export), and `last_exported`
 4. Set `schema_version: "2"` at root
 
-Workflows that load the manifest via `skf-manifest-ops.py read` always receive the v2 shape regardless of on-disk state.
+Workflows that load the manifest via `skf-manifest-ops.py read` receive a `{"status": "ok", "manifest": {...}}` envelope; the `manifest` value is always in canonical v2 shape regardless of on-disk state (parse `result["manifest"]`, not the top-level object).
 
 ## Integrity invariant
 

--- a/src/skf-export-skill/references/update-context.md
+++ b/src/skf-export-skill/references/update-context.md
@@ -87,13 +87,13 @@ Read the manifest via `{manifestOpsHelper}` (resolved at §9 from `{manifestOpsP
 python3 {manifestOpsHelper} {skills_output_folder} read
 ```
 
-The helper handles v2-schema enforcement, v1→v2 migration, and the `platforms`→`ides` rename internally. The returned JSON is always in canonical v2 shape regardless of on-disk state.
+The helper handles v2-schema enforcement, v1→v2 migration, and the `platforms`→`ides` rename internally. The `read` action returns a `{"status": "ok", "manifest": {...}}` envelope — parse `result["manifest"]`, **not** the top-level object (`result["exports"]` raises `KeyError`). The `manifest` value is always in canonical v2 shape regardless of on-disk state.
 
 **Schema reference:** `references/manifest-rebuild.md` documents the v2 shape, the status enum (`active`/`archived`/`deprecated`/`draft`), the v1 migration path, and the `active_version` integrity invariant. Load that file only when an inline schema reminder is needed — the helper enforces the shape so the in-prompt prose is not load-bearing.
 
 **Integrity guard:** if the helper returns an entry where `active_version` does not resolve to a key in `versions`, the manifest is inconsistent. Skip the affected skill and log: "**Manifest integrity warning:** `{skill-name}.active_version = v{active_version}` has no matching entry under `versions`. Skipping. Re-run `[EX] Export Skill` on `{skill-name}` to repair the manifest entry."
 
-**If the manifest does not exist** (first export or fresh forge): the helper returns `{"schema_version": "2", "exports": {}}`. Only the current export target will appear in the rebuilt index.
+**If the manifest does not exist** (first export or fresh forge): the envelope wraps an empty manifest — `result["manifest"]` is `{"schema_version": "2", "exports": {}}`, so `result["manifest"]["exports"]` is `{}`. Only the current export target will appear in the rebuilt index.
 
 #### 4b. Build Exported Skill Set (version-aware)
 
@@ -281,7 +281,7 @@ For each target context file, dispatch by case:
 **Case 1 (Create — file does not exist):**
 
 ```bash
-echo "{managed_section_full}" | python3 {atomicWriteHelper} write "{target-file}"
+echo "{managed_section_full}" | python3 {atomicWriteHelper} write --target "{target-file}"
 ```
 
 The helper stages the content into `<target>.skf-tmp`, fsyncs, and atomically renames into place. This path writes verbatim, so it takes the **marker-bearing** `{managed_section_full}`.
@@ -346,7 +346,7 @@ On success per file, report: "**{target-file} updated successfully.** Verified b
    python3 {manifestOpsHelper} {skills_output_folder} set {skill-name} {version} --ides {ides_written}
    ```
 
-   `{ides_written}` is the comma-joined sorted IDE set computed in step 3. The helper handles v2-schema validation, v1→v2 migration, and `platforms`→`ides` rename internally — no in-prompt JSON manipulation needed. Each `set` invocation unions the supplied `--ides` into the version entry's existing `ides` (deduplicated, sorted) server-side and refreshes `last_exported`. After all skills have been set, re-read the manifest via `{manifestOpsHelper} {skills_output_folder} read` to confirm the final state matches expectations.
+   `{ides_written}` is the comma-joined sorted IDE set computed in step 3. The helper handles v2-schema validation, v1→v2 migration, and `platforms`→`ides` rename internally — no in-prompt JSON manipulation needed. Each `set` invocation unions the supplied `--ides` into the version entry's existing `ides` (deduplicated, sorted) server-side and refreshes `last_exported`. After all skills have been set, re-read the manifest via `{manifestOpsHelper} {skills_output_folder} read` (the v2 manifest is under the `manifest` key of the returned envelope — see §4a) to confirm the final state matches expectations.
 
 **Dry-run mode:** Do NOT update the manifest. Display: "**[DRY RUN] Export manifest would be updated for {skill-name-list} — ides: {ides_written}.**" (list every skill in `skill_batch`)
 

--- a/test/test-skf-rebuild-managed-sections.py
+++ b/test/test-skf-rebuild-managed-sections.py
@@ -226,3 +226,70 @@ class TestEmptyContentGuard:
         assert "Fresh body." in updated
         assert "Old skill snippets" not in updated
         Path(fp).unlink()
+
+
+class TestAtomicWrite:
+    """Suite 10: replace/insert/clear write atomically and verify the result.
+
+    The marker-surgery actions stage to <file>.skf-tmp + os.replace, then
+    re-read to confirm on-disk bytes match what was staged. These tests assert
+    no temp file is left behind and that out-of-marker content is preserved
+    byte-for-byte.
+    """
+
+    def _tmp_sibling(self, fp):
+        p = Path(fp)
+        return p.with_name(p.name + ".skf-tmp")
+
+    def test_replace_leaves_no_temp_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        r = mod.cmd_replace(fp, "New body.")
+        assert r["status"] == "ok"
+        assert not self._tmp_sibling(fp).exists()
+        Path(fp).unlink()
+
+    def test_insert_leaves_no_temp_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("# My Project\n\nExisting content.\n")
+            fp = f.name
+        r = mod.cmd_insert(fp, "Inserted body.")
+        assert r["status"] == "ok"
+        assert not self._tmp_sibling(fp).exists()
+        Path(fp).unlink()
+
+    def test_clear_leaves_no_temp_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        r = mod.cmd_clear(fp)
+        assert r["status"] == "ok"
+        assert not self._tmp_sibling(fp).exists()
+        Path(fp).unlink()
+
+    def test_replace_preserves_out_of_marker_bytes(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        before = Path(fp).read_text(encoding="utf-8")
+        match = mod.find_managed_section(before)
+        prefix, suffix = before[: match.start()], before[match.end():]
+        r = mod.cmd_replace(fp, "New body.")
+        assert r["status"] == "ok"
+        after = Path(fp).read_text(encoding="utf-8")
+        match2 = mod.find_managed_section(after)
+        assert after[: match2.start()] == prefix
+        assert after[match2.end():] == suffix
+        Path(fp).unlink()
+
+    def test_verify_helper_reports_present_section(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(SAMPLE_FILE)
+            fp = f.name
+        updated = "# X\n\n<!-- SKF:BEGIN updated:2026-05-23 -->\nbody\n<!-- SKF:END -->\n"
+        assert mod._write_and_verify(fp, updated, expect_section=True) is None
+        # expecting absence when a section is present must fail verification
+        err = mod._write_and_verify(fp, updated, expect_section=False)
+        assert err is not None and "still present" in err
+        Path(fp).unlink()


### PR DESCRIPTION
## Summary

Hardens the export-skill context-update step so its documented safety and helper contracts actually hold.

- **Atomic, verified managed-section writes.** `cmd_replace`/`cmd_insert`/`cmd_clear` in `skf-rebuild-managed-sections.py` did a plain `write_text`, so a mid-write process kill could leave a user's context file (`CLAUDE.md`/`AGENTS.md`/`.cursorrules`) truncated — yet `update-context.md` §9 and its frontmatter promise an atomic temp-file + rename plus post-write verify. The helper now stages to `<file>.skf-tmp` → fsync → `os.replace`, then re-reads the raw bytes to confirm they match the staged content and the managed section is present/absent as expected (mirrors `skf-atomic-write.py`).
- **Manifest-ops `read` envelope documented.** `skf-manifest-ops.py read` returns a `{status, manifest}` envelope, but `update-context.md` §4a/§9b and `manifest-rebuild.md` described it as returning the bare v2 manifest, so following the docs literally raised `KeyError` on `result["exports"]`. The docs now state the canonical v2 manifest is under the `manifest` key.
- **Case-1 invocation fix.** The §9 Case 1 example invoked `skf-atomic-write.py write` with a positional target, but the `write` subcommand requires `--target`; corrected.

## Test plan

- [x] `npm test` (full suite) green
- [x] `npm run lint:md`, `npm run validate:refs`, `npm run validate:skills` clean
- [x] Added tests: no leftover `.skf-tmp` after replace/insert/clear, out-of-marker bytes preserved byte-for-byte, and the verify helper catches marker-presence mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)