### PR TITLE
fix(skf-test-skill): guard non-git auto-reuse against date-only timestamp collision

### DIFF
--- a/src/skf-test-skill/references/external-validators.md
+++ b/src/skf-test-skill/references/external-validators.md
@@ -24,10 +24,10 @@ Before running external validators, check if `{forge_data_folder}/{skill_name}/e
 **Pre-check (untracked or staged-only file):** Run `git ls-files --error-unmatch {skillDir}/SKILL.md 2>/dev/null`.
 - If the command fails (exit code non-zero) or git is not available, the file is either **untracked** (new, never committed) or we're in a **non-git environment**:
   - Check if `{skillDir}/metadata.json` exists and has a `generation_date` field
-  - Compare `metadata.json` `generation_date` against the evidence report's generation date (from its frontmatter or `## Validation Results` timestamp)
-  - If timestamps match within the same minute (same workflow session): auto-reuse is safe — the evidence report was generated from the same SKILL.md content
-  - If timestamps differ or metadata.json is missing: treat as stale, proceed to section 2 for a fresh run
-  - Note: "Staleness check: SKILL.md is untracked/non-git — using metadata.json timestamp comparison."
+  - Compare `metadata.json` `generation_date` against the evidence report's generation date (from its frontmatter `generated` field or the `## Validation Results` timestamp)
+  - **Precision guard (mirror of the git-path Primary-cross check):** date-granularity equality is NOT proof of same-session generation. A same-day `update-skill` that regenerates SKILL.md *after* the cached evidence report was produced yields the same calendar date (e.g. `metadata.generation_date: 2026-05-23T00:00:00Z` vs evidence `generated: 2026-05-23`), so reusing on date-equality alone would publish pre-update scores for post-update content. Auto-reuse is safe **only** when BOTH timestamps carry a real time-of-day component — neither a date-only string (`2026-05-23`) nor a midnight-coerced `…T00:00:00Z` — AND they match to the minute. In that case auto-reuse: the evidence report was generated from the same SKILL.md content.
+  - Otherwise — if either timestamp is date-only or midnight-coerced, if they differ, or if `metadata.json` is missing or has no `generation_date` — treat as stale and proceed to section 2 for a fresh run. Forcing a fresh run on ambiguous precision matches the git path's bias toward freshness over reusing possibly-stale scores.
+  - Note: "Staleness check: SKILL.md is untracked/non-git — using metadata.json timestamp comparison (date-only/midnight timestamps force a fresh run)."
 - If the command succeeds (file is tracked by git), continue to Primary check below.
 
 **Primary (git-tracked):** Run `git log -1 --format=%cI -- {skillDir}/SKILL.md` to get the last commit date of SKILL.md. Compare against the evidence report's generation date (from its frontmatter or the `## Validation Results` timestamp). If SKILL.md's last commit is newer, results are stale.


### PR DESCRIPTION
## Summary

The §1b non-git staleness check in `external-validators.md` treated date-granularity timestamp equality as proof of a same-session generation. So a same-day `update-skill` that regenerated `SKILL.md` *after* the cached evidence report was produced — both reducing to the same calendar date (e.g. `metadata.generation_date: 2026-05-23T00:00:00Z` vs evidence `generated: 2026-05-23`) — would auto-reuse the cached block and publish pre-update validation scores for post-update content. The git path already defends this via the Primary-cross check; the non-git fallback had no equivalent.

- Restrict non-git auto-reuse to cases where **both** timestamps carry a real time-of-day component (not a date-only string, not a midnight-coerced `…T00:00:00Z`) **and** match to the minute.
- Date-only or midnight-coerced timestamps now force a fresh validator run, matching the git path's bias toward freshness over reusing possibly-stale scores.

This is a self-contained instruction fix — it relies only on `metadata.generation_date` and the evidence report's `generated`/`## Validation Results` timestamp, which already exist, so no create-skill/update-skill changes are needed.

## Test plan

- [x] `npm run lint:md`, `npm run validate:refs`, `npm run validate:skills` clean
- [x] Documentation-only change to a skill reference step; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)