### PR TITLE
fix(skf-brief-skill): harden portfolio-similarity check for qmd output and scale

### DIFF
--- a/src/skf-brief-skill/references/portfolio-similarity-check.md
+++ b/src/skf-brief-skill/references/portfolio-similarity-check.md
@@ -10,17 +10,25 @@ This check catches **semantic near-duplicates** that exact-name collision misses
 
 ## Procedure
 
-The brief portfolio is already indexed in QMD collections — one `{skill-name}-brief` collection per existing brief, registered by step 5 §5 of every prior Deep-tier run. The qmd CLI does not support glob-style collection selection, so enumerate first then query per collection in **a single message with N parallel Bash calls**:
+The brief portfolio is already indexed in QMD collections — one `{skill-name}-brief` collection per existing brief, registered by step 5 §5 of every prior Deep-tier run. The qmd CLI does not support glob-style collection selection, so enumerate first (capping the sweep), then query the capped set per collection in **bounded parallel batches (≈4 concurrent Bash calls at a time)** — each `qmd query` cold-starts an embedding model, so issuing all of them at once on a large portfolio thrashes memory and stalls:
 
 ```bash
-# 1. Enumerate brief collections (one per existing brief)
-qmd collection list | awk '/-brief$/{print $1}'
+# 1. Enumerate brief collections (one per existing brief), capping the sweep.
+#    Match the first whitespace field, not the whole line: `qmd collection list`
+#    rows end in a `(qmd://name/)` URI suffix, so a line-anchored `/-brief$/`
+#    matches nothing and the check silently no-ops. The cap bounds wall-time and
+#    concurrent model loads as the portfolio grows; `qmd collection list` has no
+#    guaranteed recency order, so this caps total count, not "newest N".
+qmd collection list | awk '$1 ~ /-brief$/ {print $1}' | head -n 12
 
-# 2. For each collection, query the proposed name + intent text:
-qmd query "{name} {synthesized-or-intent-text}" -c {collection-name} -n 1 --min-score 0.6
+# 2. For each capped collection, query the proposed name + intent text.
+#    `timeout` bounds each cold model start so a slow qmd degrades instead of
+#    hanging; a non-zero exit (124 = timed out) falls through to the
+#    "times out → warn and continue" failure-mode branch below.
+timeout 20 qmd query "{name} {synthesized-or-intent-text}" -c {collection-name} -n 1 --min-score 0.6
 ```
 
-Aggregate the top hits across all `-brief` collections; keep the 3 highest-scoring across the union. If any results come back, surface them as a heads-up — *not* a HALT:
+Aggregate the top hits across the swept `-brief` collections; keep the 3 highest-scoring across the union. If any results come back, surface them as a heads-up — *not* a HALT:
 
 ```
 **Heads up — these existing briefs look semantically close to `{name}`:**
@@ -32,4 +40,4 @@ Continue with `{name}`, or pick a different name?
 
 ## Failure modes
 
-On any QMD failure (binary missing, collection list empty, any per-collection query times out): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. Quick / Forge / Forge+ tiers do not run this check (qmd is Deep-tier-only per the canonical tier definition: `Deep = + ast-grep + gh + QMD` in `skf-forge-tier-rw.py`).
+On any QMD failure (binary missing, collection list empty, any per-collection query times out — `timeout` returns exit code 124): log `"warn: portfolio-similarity check skipped — qmd query failed: {error}"` and continue silently — never HALT. A timed-out or failed query drops only that collection from the aggregate; the remaining hits still surface. Quick / Forge / Forge+ tiers do not run this check (qmd is Deep-tier-only per the canonical tier definition: `Deep = + ast-grep + gh + QMD` in `skf-forge-tier-rw.py`).


### PR DESCRIPTION
## Summary

Two robustness fixes to the Deep-tier portfolio-similarity (semantic near-duplicate) check in `src/skf-brief-skill/references/portfolio-similarity-check.md`:

- **Collection enumeration matched nothing.** It used a line-anchored `awk '/-brief$/'`, but `qmd collection list` rows end in a `(qmd://name/)` URI suffix, so the anchor never matched and the whole check silently no-opped. Now matches the first whitespace field (`$1 ~ /-brief$/`), which works whether or not the CLI appends the suffix.
- **The per-collection query sweep had no timeout and no bound.** On a growing portfolio it stalled for minutes (each `qmd query` cold-starts an embedding model) and never reached the documented graceful-degradation branch. Now each query is wrapped in `timeout` (exit 124 → warn-and-continue), the sweep is capped, and queries run in bounded parallel batches to avoid many simultaneous cold model loads.

## Test plan

- [x] `npm test` (schemas, install, cli, workflow, python, knowledge, validate:*, lint, lint:md, format:check) — green
- [x] Verified `awk '$1 ~ /-brief$/ {print $1}'` against real `qmd collection list` output (header line + `name (qmd://name/)` rows + indented metadata) — extracts only the brief collection names

🤖 Generated with [Claude Code](https://claude.com/claude-code)