### PR TITLE
fix(skf-create-stack-skill): fix compose-mode provenance, version, and constituent enumeration

### DIFF
--- a/src/shared/scripts/skf-enumerate-stack-skills.py
+++ b/src/shared/scripts/skf-enumerate-stack-skills.py
@@ -24,11 +24,16 @@ benefit from LLM judgment).
 Subcommand:
   enumerate <skills-root>
       Emit JSON {"skills": [...], "cycles": [...], "warnings": [...]}
-      describing every subdirectory of <skills-root> that contains a
-      SKILL.md. Each entry carries:
+      describing every subdirectory of <skills-root> that resolves to a
+      skill package. Both layouts from knowledge/version-paths.md are
+      supported: the flat layout (<child>/SKILL.md) and the version-nested
+      layout (<child>/active/<name>/SKILL.md via the `active` symlink, or
+      <child>/<version>/<name>/SKILL.md by highest version). Each entry
+      carries:
 
-        name             — skill name (subdirectory name)
-        path             — relative path under skills-root, forward-slash
+        name             — skill name (top-level subdirectory name)
+        path             — relative path to the resolved package under
+                           skills-root, forward-slash
         exports          — exports list resolved via cascade
         exports_source   — "metadata|references|skill-md|unknown"
         confidence       — "T1|T2|T1-low" (mapped from exports_source)
@@ -394,6 +399,80 @@ def detect_cycles(graph: dict[str, list[str]]) -> list[str]:
 
 
 # --------------------------------------------------------------------------
+# Version-nested layout resolution
+# --------------------------------------------------------------------------
+
+
+def _version_sort_key(name: str) -> tuple:
+    """Sort key for version directory names — higher sorts as newer.
+
+    Parses the leading dotted numeric core (`N.N.N`); a pre-release suffix
+    (`-rc1`, `-beta.2`, ...) ranks below the same core release. Names without
+    a numeric core rank lowest. Deterministic tie-break on the raw name.
+    """
+    core, _, pre = name.partition("-")
+    nums: list[int] = []
+    for part in core.split("."):
+        if part.isdigit():
+            nums.append(int(part))
+        else:
+            break
+    return (tuple(nums), 0 if pre == "" else -1, name)
+
+
+def _inner_package(version_dir: Path) -> Path | None:
+    """Within a version directory, return the inner package dir holding SKILL.md.
+
+    Matches the `{version}/{skill-name}/SKILL.md` shape from
+    knowledge/version-paths.md. Returns None if no inner dir has a SKILL.md.
+    """
+    try:
+        for inner in sorted(version_dir.iterdir()):
+            if inner.is_dir() and (inner / "SKILL.md").is_file():
+                return inner
+    except OSError:
+        return None
+    return None
+
+
+def _resolve_package_dir(child: Path) -> Path | None:
+    """Resolve the agentskills package dir (the one containing SKILL.md).
+
+    Supports both layouts defined in knowledge/version-paths.md:
+      - flat:           {child}/SKILL.md
+      - version-nested: {child}/active/{skill-name}/SKILL.md (via the `active`
+                        symlink) or {child}/{version}/{skill-name}/SKILL.md.
+
+    For the nested layout the `active` symlink wins; otherwise the highest
+    version directory by semver precedence is used. Returns None when no
+    SKILL.md is reachable (caller skips the entry as a non-package).
+    """
+    # Flat layout — direct SKILL.md.
+    if (child / "SKILL.md").is_file():
+        return child
+
+    # Nested layout — prefer the stable `active` pointer.
+    active = child / "active"
+    if active.is_dir():  # is_dir() follows the symlink; False if broken
+        pkg = _inner_package(active)
+        if pkg is not None:
+            return pkg
+
+    # Fallback — highest version directory.
+    try:
+        version_dirs = [
+            d for d in child.iterdir() if d.is_dir() and d.name != "active"
+        ]
+    except OSError:
+        return None
+    for vdir in sorted(version_dirs, key=lambda d: _version_sort_key(d.name), reverse=True):
+        pkg = _inner_package(vdir)
+        if pkg is not None:
+            return pkg
+    return None
+
+
+# --------------------------------------------------------------------------
 # Enumeration entry point
 # --------------------------------------------------------------------------
 
@@ -416,8 +495,10 @@ def enumerate_stack_skills(skills_root: Path) -> dict:
         if name.startswith("."):
             continue
 
-        # Symlink fallback — resolve and verify target is a directory we
-        # can read. If anything fails, warn and skip the entry.
+        # Symlink fallback — a child-level symlink (e.g. a top-level `active`
+        # pointer) must resolve to a readable directory. If it's broken, warn
+        # and skip; otherwise keep the original path so the reported `path`
+        # stays relative to skills_root.
         if child.is_symlink():
             try:
                 target = child.resolve(strict=True)
@@ -431,16 +512,18 @@ def enumerate_stack_skills(skills_root: Path) -> dict:
                     f"{name}: symlink target is not a directory"
                 )
                 continue
-            skill_dir = target
-        else:
-            if not child.is_dir():
-                continue
-            skill_dir = child
+        elif not child.is_dir():
+            continue
 
-        # Require SKILL.md to consider this a skill package. Subdirs
-        # without SKILL.md (e.g. `shared/`, `knowledge/`) are skipped
-        # silently — they're not skill packages by definition.
-        if not (skill_dir / "SKILL.md").is_file():
+        # Resolve the package dir across flat and version-nested layouts
+        # (knowledge/version-paths.md). Subdirs with no reachable SKILL.md
+        # (e.g. `shared/`, `knowledge/`) are skipped silently — not packages.
+        try:
+            skill_dir = _resolve_package_dir(child)
+        except OSError as exc:
+            result["warnings"].append(f"{name}: failed to resolve package dir ({exc})")
+            continue
+        if skill_dir is None:
             continue
 
         try:
@@ -448,6 +531,14 @@ def enumerate_stack_skills(skills_root: Path) -> dict:
         except Exception as exc:  # noqa: BLE001 — per-skill failures are warnings, not fatal
             result["warnings"].append(f"{name}: enumeration failed: {exc}")
             continue
+
+        # Reflect the resolved package location (forward-slash, relative to
+        # skills_root) — for the nested layout this is the `{active_skill}`
+        # path, for the flat layout just the skill name.
+        try:
+            entry["path"] = skill_dir.relative_to(skills_root).as_posix()
+        except ValueError:
+            entry["path"] = name
 
         result["skills"].append(entry)
         result["warnings"].extend(skill_warnings)

--- a/src/skf-create-stack-skill/assets/provenance-map-schema.md
+++ b/src/skf-create-stack-skill/assets/provenance-map-schema.md
@@ -53,7 +53,7 @@ Used when the workflow ran in code-mode against an actual codebase. `source_repo
 
 ## Compose-mode variant
 
-Used when the workflow ran in compose-mode against pre-generated constituent skills. Source-anchor fields (`source_repo`, `source_commit`, `source_ref`) are `null` because there is no codebase to anchor against — provenance traces back to the constituent skills instead, captured in the `constituents[]` array. Each entry's `extraction_method` is `"compose-from-skill"`; integrations have `detection_method` of `"architecture_co_mention"` (named in the architecture doc) or `"inferred_from_shared_domain"` (synthesized inference, must carry T2/T3 confidence).
+Used when the workflow ran in compose-mode against pre-generated constituent skills. Source-anchor fields (`source_repo`, `source_commit`, `source_ref`) are `null` because there is no codebase to anchor against — provenance traces back to the constituent skills instead, captured in the `constituents[]` array. Each entry's `extraction_method` is `"compose-from-skill"`; integrations have `detection_method` of `"architecture_co_mention"` (named in the architecture doc), `"constituent_documented_contract"` (a cross-library contract documented in a constituent skill's integration docs but not co-mentioned in the architecture document — e.g. a grep-verified upstream seam cited from a source skill), or `"inferred_from_shared_domain"` (synthesized inference from shared language/domain, no cited contract). `detection_method` records *how* an edge was discovered; it is orthogonal to `confidence`, which is inherited from the constituent skills per the Confidence Tier Inheritance matrix in `references/compose-mode-rules.md` (the integration tier is the weaker of the pair — never forced to a fixed band by detection method).
 
 ```json
 {
@@ -82,9 +82,9 @@ Used when the workflow ran in compose-mode against pre-generated constituent ski
     {
       "libraries": ["{libA}", "{libB}"],
       "pattern_type": "{type}",
-      "detection_method": "architecture_co_mention|inferred_from_shared_domain",
+      "detection_method": "architecture_co_mention|constituent_documented_contract|inferred_from_shared_domain",
       "co_import_files": [],
-      "confidence": "T2|T3"
+      "confidence": "T1|T1-low|T2|T3"
     }
   ],
   "constituents": [

--- a/src/skf-create-stack-skill/references/compose-mode-rules.md
+++ b/src/skf-create-stack-skill/references/compose-mode-rules.md
@@ -85,3 +85,5 @@ When no architecture document is available:
 - Infer from skills sharing domain keywords in their `SKILL.md` descriptions
 - Mark all inferred integrations: `[inferred from shared domain]`
 - Inferred integrations default to lowest confidence of the pair with `[inferred from shared domain]` suffix (use this instead of `[composed]` for inferred integrations)
+
+**Constituent-documented contracts (distinct from shared-domain inference):** When a constituent skill's own integration docs cite a verifiable cross-library contract (e.g. a grep-verified upstream seam) that the architecture document does not co-mention, record it with `detection_method: constituent_documented_contract` (see `assets/provenance-map-schema.md`) — NOT `inferred_from_shared_domain`. It is a cited contract, not a synthesized guess. Its confidence still inherits the weaker tier of the pair per the matrix above — detection method is orthogonal to tier and never forces a fixed band.

--- a/src/skf-create-stack-skill/references/detect-integrations.md
+++ b/src/skf-create-stack-skill/references/detect-integrations.md
@@ -142,9 +142,12 @@ For each detected integration:
 - **Assign confidence (M1/M3) — derive from per-library tiers + detection-method qualifier (NOT from AST):** integration detection here is grep + co-import (optionally CCC-augmented), never AST. The integration's confidence is the **weaker** of the two libraries' tiers from `per_library_extractions[]` (tie-break: T1-low > T1, T2 > T1-low, T3 > T2 — never overstate). Then append a detection-method qualifier:
   - `grep-co-import` — the pair qualified via direct co-import grep (the default).
   - `ccc-augmented` — the pair qualified only after CCC semantic search elevated it (per §2 CCC augmentation), and the post-hoc import verification (H3) confirmed both imports.
-  - `architecture-co-mention` — compose-mode pair qualified via word-boundary co-mention in the architecture document (per §2 H2 guards).
-  - `inferred-shared-domain` — compose-mode pair without an architecture document, inferred from shared `language` or domain keywords.
+  - `architecture-co-mention` — compose-mode pair qualified via word-boundary co-mention in the architecture document (per §2 H2 guards). Maps to `detection_method: architecture_co_mention` in `provenance-map.json`.
+  - `constituent-documented-contract` — compose-mode pair whose cross-library contract is documented in a constituent skill's integration docs (cited, e.g. a grep-verified upstream seam) but not co-mentioned in the architecture document. Maps to `detection_method: constituent_documented_contract` in `provenance-map.json`.
+  - `inferred-shared-domain` — compose-mode pair without an architecture document, inferred from shared `language` or domain keywords (no cited contract). Maps to `detection_method: inferred_from_shared_domain` in `provenance-map.json`.
   - Render as `{tier} ({qualifier})` — e.g., `T1-low (grep-co-import)`, `T1 (ccc-augmented)`, `T1-low (architecture-co-mention) [composed]`. The `[composed]`/`[inferred from shared domain]` suffix from `compose-mode-rules.md` is appended after the qualifier in compose-mode.
+
+  **Provenance ↔ SKILL.md tier parity:** The tier derived above is the single value for this edge — write the *same* tier to both the SKILL.md integration label and `provenance-map.json` `integrations[].confidence`. The detection-method qualifier (and the `provenance-map.json` `detection_method` it maps to) records *how* the edge was found and is orthogonal to confidence; it never forces the tier into a fixed band.
 
 ### 4. Build Integration Graph
 

--- a/src/skf-create-stack-skill/references/generate-output.md
+++ b/src/skf-create-stack-skill/references/generate-output.md
@@ -41,7 +41,7 @@ Resolve `{version}` from the primary library version or default to `1.0.0` (see 
 
 Where the skill name is `{project_name}-stack` and `{version}` is the semver version (with build metadata stripped per `knowledge/version-paths.md`).
 
-**Primary library definition (S11):** In code-mode, the primary library is the dependency with the highest import count from step 3; its `version` (from the manifest) becomes `{primary_library_version}`. In compose-mode, use the highest semver across constituent skill `metadata.json` files. If neither is available, fall back to `1.0.0`.
+**Primary library definition (S11):** In code-mode, the primary library is the dependency with the highest import count from step 3; its `version` (from the manifest) becomes `{primary_library_version}`, falling back to `1.0.0` if unavailable. In compose-mode, the stack carries its own release identity: default `{version}` to `1.0.0` (a stack-local scheme) — do NOT borrow the highest constituent semver. Constituent versions are preserved in `dependencies[]`, so no information is lost, and the package no longer reads as tracking whichever constituent happened to have the highest version.
 
 **Pre-flight: group-dir type check (S3):** If `{skills_output_folder}/{project_name}-stack/` already exists, probe `{skills_output_folder}/{project_name}-stack/active/{project_name}-stack/metadata.json`. If that metadata exists and `skill_type != "stack"`, HALT with:
 
@@ -112,7 +112,7 @@ Write `{skill_staging}/context-snippet.md`:
 Use the Vercel-aligned indexed format targeting **~80-120 tokens** (M2). Token estimation is heuristic — use `ceil(char_count / 4)` as the working approximation (the standard rule-of-thumb for English text in BPE-style tokenizers; precise counts differ per model). Compute against the rendered snippet body (excluding trailing newline).
 
 ```
-[{project_name}-stack v{version — in code-mode: primary_library_version or 1.0.0; in compose-mode: highest version across constituent skill metadata.json files, or 1.0.0 if none}]|root: skills/{project_name}-stack/
+[{project_name}-stack v{version — in code-mode: primary_library_version or 1.0.0; in compose-mode: 1.0.0 (stack-local scheme, per S11)}]|root: skills/{project_name}-stack/
 |IMPORTANT: {project_name}-stack — read SKILL.md before writing integration code. Do NOT rely on training data.
 |stack: {dep-1}@{v1}, {dep-2}@{v2}, {dep-3}@{v3}
 |integrations: {pattern-1}, {pattern-2}
@@ -144,7 +144,7 @@ Populate all fields from the metadata.json schema defined in `{stackSkillTemplat
 {
   "skill_type": "stack",
   "name": "{project_name}-stack",
-  "version": "{primary_library_version or 1.0.0}",
+  "version": "{version — resolved per S11: code-mode primary_library_version or 1.0.0; compose-mode 1.0.0}",
   "generation_date": "{current_date}",
   "forge_tier": "{Quick|Forge|Forge+|Deep — the tier under which this run executed}",
   "confidence_tier": "{T1|T1-low|T2|T3 — dominant T-code from confidence_distribution below}",
@@ -195,7 +195,7 @@ If any workspace write fails, invoke the rollback contract from §1.
 Use the schema from `{provenanceMapSchemaPath}` — see that asset for the canonical templates and field definitions of both variants:
 
 - **In code-mode:** use the code-mode variant (`source_repo` / `source_commit` populated; `extraction_method` ∈ `ast_bridge|source_reading|qmd_bridge`; `detection_method = "co-import grep"`).
-- **In compose-mode:** use the compose-mode variant (source-anchor fields `null`; `extraction_method = "compose-from-skill"`; `detection_method ∈ "architecture_co_mention|inferred_from_shared_domain"`; includes the additional `constituents[]` array for drift detection).
+- **In compose-mode:** use the compose-mode variant (source-anchor fields `null`; `extraction_method = "compose-from-skill"`; `detection_method ∈ "architecture_co_mention|constituent_documented_contract|inferred_from_shared_domain"`; includes the additional `constituents[]` array for drift detection).
 
 **Use the `metadata_hash` value already stored in workflow state during step 2 (S13) — do NOT re-read and re-hash at step 7 time. The stored hash captures the state as it was at manifest-detection time, which is the correct provenance anchor.**
 

--- a/test/test-skf-enumerate-stack-skills.py
+++ b/test/test-skf-enumerate-stack-skills.py
@@ -77,6 +77,40 @@ def _make_skill(
     return skill_dir
 
 
+def _make_nested_skill(
+    root: Path,
+    name: str,
+    version: str,
+    *,
+    skill_md: str | None = "# placeholder\n",
+    metadata: dict | None = None,
+    references: dict[str, str] | None = None,
+    active: bool = True,
+) -> Path:
+    """Create a version-nested skill package and return the inner package dir.
+
+    Layout (knowledge/version-paths.md):
+        {root}/{name}/{version}/{name}/SKILL.md
+        {root}/{name}/active -> {version}      (when `active` is True)
+    """
+    pkg = _make_skill(
+        root / name / version,
+        name,
+        skill_md=skill_md,
+        metadata=metadata,
+        references=references,
+    )
+    if active:
+        import pytest
+
+        link = root / name / "active"
+        try:
+            os.symlink(version, link, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+    return pkg
+
+
 def _expected_hash(content: bytes) -> str:
     return "sha256:" + hashlib.sha256(content).hexdigest()
 
@@ -528,6 +562,130 @@ class TestEnumerateStackSkills:
         # `path` is relative to skills-root; for a single-level package
         # that's just the name. No backslashes regardless of platform.
         assert "\\" not in result["skills"][0]["path"]
+
+
+# --------------------------------------------------------------------------
+# Version-nested layout resolution
+# --------------------------------------------------------------------------
+
+
+class TestVersionSortKey:
+    def test_numeric_ordering(self) -> None:
+        assert mod._version_sort_key("1.10.0") > mod._version_sort_key("1.2.0")
+
+    def test_major_dominates(self) -> None:
+        assert mod._version_sort_key("2.0.0") > mod._version_sort_key("1.12.0")
+
+    def test_release_ranks_above_prerelease(self) -> None:
+        assert mod._version_sort_key("1.0.0") > mod._version_sort_key("1.0.0-rc1")
+
+    def test_non_numeric_ranks_lowest(self) -> None:
+        assert mod._version_sort_key("active") < mod._version_sort_key("0.0.1")
+
+
+class TestVersionNestedLayout:
+    """`{name}/{version}/{name}/SKILL.md` with an `active` symlink — the
+    canonical layout from knowledge/version-paths.md that the flat-only walk
+    used to skip entirely (empty inventory for every constituent)."""
+
+    def test_active_symlink_resolves(self, tmp_path: Path) -> None:
+        _make_nested_skill(
+            tmp_path,
+            "surreal",
+            "3.0.5",
+            metadata={"name": "surreal", "exports": ["query", "connect"]},
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        assert len(result["skills"]) == 1
+        s = result["skills"][0]
+        assert s["name"] == "surreal"
+        assert s["path"] == "surreal/active/surreal"
+        assert s["exports"] == ["query", "connect"]
+        assert s["exports_source"] == "metadata"
+        assert s["confidence"] == "T1"
+        assert s["metadata_hash"] is not None
+        assert result["warnings"] == []
+
+    def test_highest_version_when_no_active(self, tmp_path: Path) -> None:
+        _make_nested_skill(
+            tmp_path, "lib", "1.2.0",
+            metadata={"name": "lib", "exports": ["old"]}, active=False,
+        )
+        _make_nested_skill(
+            tmp_path, "lib", "1.10.0",
+            metadata={"name": "lib", "exports": ["new"]}, active=False,
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        assert len(result["skills"]) == 1
+        s = result["skills"][0]
+        assert s["exports"] == ["new"]
+        assert s["path"] == "lib/1.10.0/lib"
+
+    def test_prerelease_loses_to_release_fallback(self, tmp_path: Path) -> None:
+        _make_nested_skill(
+            tmp_path, "lib", "1.0.0-rc1",
+            metadata={"name": "lib", "exports": ["pre"]}, active=False,
+        )
+        _make_nested_skill(
+            tmp_path, "lib", "1.0.0",
+            metadata={"name": "lib", "exports": ["rel"]}, active=False,
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        assert result["skills"][0]["exports"] == ["rel"]
+
+    def test_active_symlink_wins_over_higher_version(self, tmp_path: Path) -> None:
+        # The stable `active` pointer is authoritative even if a higher
+        # version directory exists alongside it.
+        _make_nested_skill(
+            tmp_path, "lib", "1.0.0",
+            metadata={"name": "lib", "exports": ["pinned"]}, active=True,
+        )
+        _make_nested_skill(
+            tmp_path, "lib", "2.0.0",
+            metadata={"name": "lib", "exports": ["newer"]}, active=False,
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        assert len(result["skills"]) == 1
+        assert result["skills"][0]["exports"] == ["pinned"]
+        assert result["skills"][0]["path"] == "lib/active/lib"
+
+    def test_nested_composes_cycle_detected(self, tmp_path: Path) -> None:
+        # Cycle detection keys on the top-level dir name, unaffected by nesting.
+        _make_nested_skill(
+            tmp_path, "alpha", "1.0.0",
+            metadata={"name": "alpha", "exports": [], "composes": ["beta"]},
+        )
+        _make_nested_skill(
+            tmp_path, "beta", "1.0.0",
+            metadata={"name": "beta", "exports": [], "composes": ["alpha"]},
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        assert "alpha" in result["cycles"]
+        assert any("composes cycle detected" in w for w in result["warnings"])
+
+    def test_mixed_flat_and_nested(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "flatlib", metadata={"name": "flatlib", "exports": ["f"]},
+        )
+        _make_nested_skill(
+            tmp_path, "nestlib", "0.1.0",
+            metadata={"name": "nestlib", "exports": ["n"]},
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        by_name = {s["name"]: s for s in result["skills"]}
+        assert by_name["flatlib"]["path"] == "flatlib"
+        assert by_name["nestlib"]["path"] == "nestlib/active/nestlib"
+
+    def test_version_dir_without_inner_skill_md_skipped(self, tmp_path: Path) -> None:
+        # A version dir whose inner package lacks SKILL.md is not a package.
+        inner = tmp_path / "broken" / "1.0.0" / "broken"
+        inner.mkdir(parents=True)
+        (inner / "metadata.json").write_text('{"name":"broken","exports":[]}')
+        _make_skill(
+            tmp_path, "real", metadata={"name": "real", "exports": ["x"]},
+        )
+        result = mod.enumerate_stack_skills(tmp_path)
+        assert [s["name"] for s in result["skills"]] == ["real"]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three correctness fixes in the `skf-create-stack-skill` compose-mode path:

- **Provenance confidence consistency** — the provenance-map schema forced inferred integration edges to T2/T3, while `detect-integrations.md` and `compose-mode-rules.md` inherit the weaker tier of the pair, so the SKILL.md edge label and `provenance-map.json` could not both follow their spec. `detection_method` and `confidence` are now explicitly orthogonal: confidence is inherited per the tier matrix; `detection_method` records only how the edge was found. A "provenance ↔ SKILL.md tier parity" note makes the two artifacts agree by construction.
- **New `constituent_documented_contract` detection_method** — cited cross-library contracts documented in a constituent skill (but not co-mentioned in the architecture doc) previously had to be recorded as `inferred_from_shared_domain`, flattening real contracts into synthesized guesses. They now have a dedicated, evidence-appropriate detection class.
- **Constituent enumeration on the version-nested layout** — `skf-enumerate-stack-skills.py enumerate` only checked immediate children for a direct `SKILL.md`, so the canonical `{name}/{version}/{name}/SKILL.md` layout (with an `active` symlink, per `knowledge/version-paths.md`) produced an empty inventory and every constituent was skipped. It now descends via the `active` symlink (or the highest version directory) and reports the resolved package path.
- **Compose-mode stack version** — defaulted to the highest constituent semver, making the stack package read as tracking that constituent. Now defaults to `1.0.0` (stack-local scheme); constituent versions remain in `dependencies[]`.

## Test plan

- [x] `npm test` (full suite): Python tests, ref validation, eslint, markdownlint, prettier — all green
- [x] Extended `test/test-skf-enumerate-stack-skills.py` with flat/nested/mixed-layout coverage, `active`-symlink precedence, and version-ordering cases (48 tests pass)
- [x] Ran the fixed enumerate script against a real version-nested skills tree: all constituents resolve (previously zero), no spurious warnings or cycles
- [x] Reviewer: confirm the orthogonal confidence/detection_method model reads correctly across the schema, detect-integrations §3, and compose-mode-rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)