### PR TITLE
fix(installer): write output_folder to generated SKF config

### DIFF
--- a/test/test-cli-integration.js
+++ b/test/test-cli-integration.js
@@ -114,6 +114,7 @@ async function testFreshInstall() {
     const configContent = yaml.load(await fs.readFile(configPath, 'utf8'));
     assert(configContent.project_name === 'test-project', 'config.yaml has correct project_name');
     assert(configContent.skills_output_folder === 'skills', 'config.yaml has correct skills_output_folder');
+    assert(configContent.output_folder === '_bmad-output', 'config.yaml has output_folder (inherited from core config)');
     assert(Array.isArray(configContent.ides) && configContent.ides.includes('claude-code'), 'config.yaml has IDEs');
 
     // Verify skills installed to IDE directory (.claude/skills/)

--- a/tools/cli/lib/installer.js
+++ b/tools/cli/lib/installer.js
@@ -227,6 +227,7 @@ class Installer {
       project_name: config.project_name || 'Untitled Project',
       communication_language: 'en',
       document_output_language: 'en',
+      output_folder: config.output_folder || '_bmad-output',
       skills_output_folder: config.skills_output_folder || 'skills',
       forge_data_folder: config.forge_data_folder || 'forge-data',
       sidecar_path: '_bmad/_memory/forger-sidecar',


### PR DESCRIPTION
## Summary

- `src/module.yaml` declares `output_folder` among the variables inherited from BMAD Core Config, but `tools/cli/lib/installer.js` emitted only `user_name`, `communication_language`, and `document_output_language` — dropping `output_folder` from the generated `_bmad/skf/config.yaml`.
- Workflows that resolve `output_folder` from the SKF config (`skf-refine-architecture` at init §3 / On-Activation §4, `skf-create-stack-skill` at init §0) HARD HALT on a clean install because the required key is absent, forcing a manual config edit mid-run.
- This inserts `output_folder` (default `_bmad-output`, matching the core config default) so those workflows resolve it without intervention.

This is the design-intended layer for the fix — `output_folder` is a Core-Config-inserted variable per `module.yaml`, not a per-workflow concern. Workflow files are unchanged.

## Test plan

- [x] `npm run test:cli` — new assertion verifies the generated config contains `output_folder: _bmad-output`
- [x] Full `npm test` suite green (schemas, install, cli, workflow, python, knowledge, validate, lint, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)