### PR TITLE
fix(skf-refine-architecture): scope gap/issue analysis to the document's surface

### DIFF
--- a/src/skf-refine-architecture/SKILL.md
+++ b/src/skf-refine-architecture/SKILL.md
@@ -49,7 +49,7 @@ These rules apply to every step in this workflow:
 | Aspect | Detail |
 |--------|--------|
 | **Inputs** | architecture_doc_path [required], vs_report_path [optional] |
-| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--architecture-doc <path>` (skip step 1 prompt for the required input); `--vs-report-path <path>` (skip step 1 prompt for the optional VS report) |
+| **Flags** | `--headless` / `-H` (auto-resolve all gates); `--architecture-doc <path>` (skip step 1 prompt for the required input); `--vs-report-path <path>` (skip step 1 prompt for the optional VS report); `--scope-skills <names>` (comma-separated in-scope skill names; overrides scope derivation in gap analysis) |
 | **Gates** | step 1: Input Gate [use args] | step 5: Review Gate [C] |
 | **Outputs** | `refined-architecture-{project_name}.md` at `{outputFolderPath}`, plus `refine-architecture-result-{timestamp}.json` and `refine-architecture-result-latest.json` |
 | **Headless** | All gates auto-resolve with default action when `{headless_mode}` is true. Per-flag args (`--architecture-doc`, `--vs-report-path`) consumed at the gates that would otherwise prompt. |

--- a/src/skf-refine-architecture/references/gap-analysis.md
+++ b/src/skf-refine-architecture/references/gap-analysis.md
@@ -42,6 +42,21 @@ Parse the architecture document for statements describing two or more technologi
 - Each pair: `{library_a, library_b, architectural_context}`
 - `architectural_context`: the quoted text or paraphrased description of their relationship
 
+### 2b. Establish Document Scope
+
+The skill inventory (Step 01 §2) can span a wider product surface than the architecture document under refinement. Pairs drawn from a different surface are NOT actionable gaps for THIS document — surfacing them injects irrelevant integration recommendations (e.g. wiring real-time A/V libraries into an admin-dashboard architecture).
+
+Resolve the in-scope skill set:
+
+- **If `{scope_skills}` was provided** (via `--scope-skills`, resolved in Step 01 §1): use it verbatim as `{in_scope_skills}` — it is authoritative.
+- **Otherwise derive:** `{in_scope_skills}` = every inventory skill whose name or primary technology is referenced anywhere in the architecture document (reuse the technology references parsed in §2; match on skill name and library/technology keywords, case-insensitive, word-boundary). Be conservative — when a skill's relevance is ambiguous, treat it as **in-scope**. Surfacing a borderline gap is safer than burying a real one.
+
+`{out_of_scope_skills}` = inventory skills not in `{in_scope_skills}`. A library pair is **out-of-scope** when either of its libraries is in `{out_of_scope_skills}`.
+
+**Safe default:** If scope cannot be derived (e.g. the architecture references no inventory skill by name) and no `{scope_skills}` was provided, treat ALL skills as in-scope and note: "Could not derive document scope — analyzing all skill pairs." This preserves prior behavior rather than hiding gaps.
+
+Store `{in_scope_skills}` and `{out_of_scope_skills}` as workflow state — Step 03 (issue detection) reuses them.
+
 ### 3. Generate All Possible Library Pairs
 
 From the skill inventory, generate all unique combinations of library pairs.
@@ -89,7 +104,9 @@ For each possible library pair NOT already documented in the architecture:
 - Do both libraries share a compatible protocol or data format?
 - Are they in the same language or is there a bridge mechanism available?
 
-**If compatible APIs exist but NO architecture mention:**
+**Scope routing (from §2b):** Before classifying, check the pair's scope. If the pair is **out-of-scope** (either library is in `{out_of_scope_skills}`), do NOT add it to the gap list even when its APIs are compatible — record it in the informational **Out-of-Scope** bucket instead (a compatible pair that belongs to a different product surface than this architecture). Only **in-scope** pairs proceed to gap classification below.
+
+**If compatible APIs exist (in-scope pair) but NO architecture mention:**
 - Classify the gap type (Missing Integration Path, Undocumented Data Flow, or Absent Bridge Layer)
 - Document the connecting APIs from both skills
 - Propose a brief architecture section describing the integration
@@ -112,7 +129,7 @@ Suggestion: {proposed architecture section content}
 
 "**Pass 1: Gap Analysis — Undocumented Integration Paths**
 
-**Gaps Found:** {count}
+**Gaps Found (in-scope):** {count}
 
 {IF gaps found:}
 | # | Library A | Library B | Gap Type | Connecting APIs |
@@ -121,15 +138,24 @@ Suggestion: {proposed architecture section content}
 
 {For each gap, display the full citation with evidence and suggestion}
 
+{IF out-of-scope compatible pairs exist (from §2b/§5):}
+**Out of scope for this document:** {oos_count} compatible pair(s) involve skills outside this architecture's surface — `{out_of_scope_skills}` — and were NOT counted as gaps. Listed for awareness only:
+
+| Library A | Library B | Reason |
+|-----------|-----------|--------|
+| {lib_a} | {lib_b} | out-of-scope — not referenced in this architecture |
+
+If any of these belongs in this architecture, re-run with `--scope-skills` naming the skills to include.
+
 {IF no gaps found AND N > 1:}
-**No undocumented integration paths detected.** The architecture document covers all compatible library pairs.
+**No undocumented integration paths detected.** The architecture document covers all compatible in-scope library pairs.
 
 {IF no gaps found AND N == 1:}
 **⚠️ Gap analysis skipped — only 1 skill loaded.** Pairwise integration analysis requires at least 2 skills. If the architecture references multiple libraries, those without a matching skill are invisible to gap analysis. **Recommendation:** Generate skills for all architecture libraries with [CS] or [QS] before running [RA] for comprehensive gap detection.
 
 **Proceeding to issue detection (still produces value with 1 skill)...**"
 
-Store all gap findings as workflow state for Step 05. To ensure durability across long runs, also append a `<!-- [RA-GAPS] ... -->` comment block to `{forge_data_folder}/ra-state-{project_name}.md` containing the **complete formatted gap findings** (full citation blocks with evidence and suggestions, not just counts) — Step 05 can read this back if context degrades. **Do NOT write to `{output_folder}/refined-architecture-{project_name}.md` — that file is created only in step 5.**
+Store all **in-scope** gap findings as workflow state for Step 05. To ensure durability across long runs, also append a `<!-- [RA-GAPS] ... -->` comment block to `{forge_data_folder}/ra-state-{project_name}.md` containing the **complete formatted gap findings** (full citation blocks with evidence and suggestions, not just counts) — Step 05 can read this back if context degrades. Record out-of-scope pairs under a separate `<!-- [RA-OUT-OF-SCOPE] ... -->` marker (NOT `[RA-GAPS]`) so Step 05 does not compile them into the refined document — they are informational only. **Do NOT write to `{output_folder}/refined-architecture-{project_name}.md` — that file is created only in step 5.**
 
 ### 7. Auto-Proceed to Next Step
 

--- a/src/skf-refine-architecture/references/init.md
+++ b/src/skf-refine-architecture/references/init.md
@@ -51,6 +51,8 @@ Wait for user input. Store the validated architecture document path as `architec
 - If missing at user-provided path: attempt auto-probe (below) before giving up
 - Store VS report availability as `vs_report_available: true|false` and `vs_report_path`
 
+**Scope hint (optional, `--scope-skills`):** If `--scope-skills <names>` was provided, store the parsed comma-separated list as `{scope_skills}` — gap analysis (Step 02 §2b) uses it as the authoritative in-scope skill set. If absent, leave `{scope_skills}` empty; Step 02 derives scope from the architecture document instead.
+
 ### 2. Scan Skills Folder
 
 **Resolve `{enumerateStackSkillsHelper}`** from `{enumerateStackSkillsProbeOrder}`; first existing path wins.

--- a/src/skf-refine-architecture/references/issue-detection.md
+++ b/src/skf-refine-architecture/references/issue-detection.md
@@ -66,6 +66,8 @@ For each extracted claim, load the relevant skill(s) and check:
 
 If `vs_report_available` is true:
 
+**Scope filter (reuse `{out_of_scope_skills}` from Step 02 §2b):** The VS report carries verdicts across the entire skill set, which may exceed this architecture's surface. Before promoting any verdict, check the pair's scope — if a verdict is for an **out-of-scope** pair (either library in `{out_of_scope_skills}`), do NOT promote it to an issue for THIS architecture; record it under the informational Out-of-Scope bucket instead. Only **in-scope** pairs' verdicts are promoted by the rules below.
+
 **Load the VS feasibility report and extract verdicts:**
 - **Risky verdicts** (match case-insensitively: "Risky", "RISKY", "risky"): Promote to confirmed issues with the VS evidence as additional citation
 - **Blocked verdicts** (match case-insensitively: "Blocked", "BLOCKED", "blocked"): Promote to critical issues requiring architecture redesign
@@ -100,7 +102,7 @@ Suggestion: {specific correction with API evidence}
 
 "**Pass 2: Issue Detection — Architecture vs. API Reality**
 
-**Issues Found:** {count} ({critical_count} critical, {major_count} major, {minor_count} minor)
+**Issues Found (in-scope):** {count} ({critical_count} critical, {major_count} major, {minor_count} minor)
 
 {IF issues found:}
 | # | Libraries | Issue Type | Severity | Summary |
@@ -109,12 +111,15 @@ Suggestion: {specific correction with API evidence}
 
 {For each issue, display the full citation with evidence and suggestion}
 
+{IF out-of-scope VS verdicts were set aside (from §4):}
+**Out of scope for this document:** {oos_issue_count} VS verdict(s) involve skills outside this architecture's surface (`{out_of_scope_skills}`) and were NOT counted as issues. Listed for awareness only — re-run with `--scope-skills` if any belongs in scope.
+
 {IF no issues found:}
-**No contradictions detected.** Architecture claims align with verified skill API surfaces.
+**No contradictions detected.** Architecture claims align with verified in-scope skill API surfaces.
 
 **Proceeding to improvement detection...**"
 
-Store all issue findings as workflow state for Step 05. To ensure durability across long runs, also append a `<!-- [RA-ISSUES] ... -->` comment block to `{forge_data_folder}/ra-state-{project_name}.md` containing the **complete formatted issue findings** (full citation blocks with architecture claims, skill evidence, VS verdicts, severity, and suggestions — not just counts) — Step 05 can read this back if context degrades. **Do NOT write to `{output_folder}/refined-architecture-{project_name}.md` — that file is created only in step 5.**
+Store all **in-scope** issue findings as workflow state for Step 05. To ensure durability across long runs, also append a `<!-- [RA-ISSUES] ... -->` comment block to `{forge_data_folder}/ra-state-{project_name}.md` containing the **complete formatted issue findings** (full citation blocks with architecture claims, skill evidence, VS verdicts, severity, and suggestions — not just counts) — Step 05 can read this back if context degrades. Record any out-of-scope VS verdicts under the shared `<!-- [RA-OUT-OF-SCOPE] ... -->` marker (NOT `[RA-ISSUES]`) so Step 05 does not compile them — they are informational only. **Do NOT write to `{output_folder}/refined-architecture-{project_name}.md` — that file is created only in step 5.**
 
 ### 7. Auto-Proceed to Next Step
 


### PR DESCRIPTION
## Summary

Gap analysis (`gap-analysis.md`) enumerated all N·(N-1)/2 skill pairs and flagged every compatible-but-undocumented pair as a gap, with no notion that the skill inventory can span a wider product surface than the architecture under refinement. The only filter was API compatibility. Consequences:

- Pairs from a different surface (e.g. real-time A/V libraries in an admin-dashboard doc) surfaced as actionable gaps and — via `compile.md`, which inserts every Step-02 gap into the refined doc — injected irrelevant integration recommendations.
- VS `Risky`/`Blocked` verdicts for out-of-scope pairs were likewise promoted to issues in `issue-detection.md` §4.

## Changes

- **`gap-analysis.md` §2b (new):** resolve an in-scope skill set — derived from the architecture's referenced technologies by default, or an explicit `--scope-skills` list when provided. Conservative: ambiguous skills default to **in-scope**, and if scope can't be derived it falls back to analyzing all pairs (prior behavior) — real gaps are never silently hidden.
- **`gap-analysis.md` §5/§6:** out-of-scope compatible pairs route to an informational *Out of scope for this document* bucket instead of the gap list, stored under a separate `[RA-OUT-OF-SCOPE]` state marker (never `[RA-GAPS]`), so `compile.md` does not write them into the refined document.
- **`issue-detection.md` §4/§6:** reuse the same set so out-of-scope VS verdicts stay out of the actionable issue list (same informational marker).
- **`SKILL.md` + `init.md`:** wire the optional `--scope-skills <names>` override flag.

`gap_count`/`issue_count` now count actionable in-scope findings; out-of-scope pairs are surfaced informationally, not buried. No script, schema, or result-contract changes — `report.md`/`compile.md` already consume only the primary findings.

## Test plan

- [x] `npm run validate:skills` / `validate:refs` / `test:install` / `test:workflow` — structural, step-chain, and frontmatter validation green
- [x] Full `npm test` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)