### PR TITLE
fix(skf): align quick-skill section vocabulary with SKF gates

### DIFF
--- a/src/shared/scripts/skf-scan-skill-md-structure.py
+++ b/src/shared/scripts/skf-scan-skill-md-structure.py
@@ -97,13 +97,17 @@ from pathlib import Path
 
 # These mirror the canonical synonyms documented in
 # `src/skf-test-skill/references/coherence-check.md` §2.1, with the
-# SKF-template-specific headings (`Quick Start`, `Common Workflows`,
-# `Key API Summary`) folded in so they are first-class matches rather
-# than literal-name misses (per the §2.1 "Note" paragraph).
+# SKF-template-specific headings folded in so they are first-class
+# matches rather than literal-name misses (per the §2.1 "Note"
+# paragraph). The set covers both the Deep/create-skill template
+# (`Quick Start`, `Common Workflows`, `Key API Summary`, `Key Types`)
+# and the quick-skill template (`Usage Patterns`, `Key Exports`), since
+# headings are matched on the full heading text, not a substring.
 REQUIRED_SYNONYMS: dict[str, list[str]] = {
     "description": ["Description", "Overview", "Purpose", "Summary"],
     "usage": [
         "Usage",
+        "Usage Patterns",
         "Examples",
         "How to use",
         "Quickstart",
@@ -115,6 +119,7 @@ REQUIRED_SYNONYMS: dict[str, list[str]] = {
         "API",
         "API Surface",
         "Exports",
+        "Key Exports",
         "Public API",
         "Interface",
         "Reference",

--- a/src/skf-quick-skill/assets/skill-template.md
+++ b/src/skf-quick-skill/assets/skill-template.md
@@ -54,9 +54,9 @@ Indexed format targeting ~80-120 tokens per skill:
 ```markdown
 [{skill_name} v{version}]|root: skills/{skill_name}/
 |IMPORTANT: {skill_name} v{version} — read SKILL.md before writing {skill_name} code. Do NOT rely on training data.
-|quick-start:{SKILL.md#quick-start}
+|quick-start:{SKILL.md#usage-patterns}
 |api: {top-5 exports with () for functions}
-|key-types:{SKILL.md#key-types} — {inline summary of most important type values}
+|key-types:{SKILL.md#key-exports} — {inline summary of most important type values}
 |gotchas: {2-3 most critical pitfalls or breaking changes, inline}
 ```
 

--- a/src/skf-quick-skill/references/compile.md
+++ b/src/skf-quick-skill/references/compile.md
@@ -75,11 +75,13 @@ Otherwise, create context-snippet.md in Vercel-aligned indexed format (~80-120 t
 ```
 [{skill_name} v{version}]|root: skills/{skill_name}/
 |IMPORTANT: {skill_name} v{version} — read SKILL.md before writing {skill_name} code. Do NOT rely on training data.
-|quick-start:{SKILL.md#quick-start}
+|quick-start:{SKILL.md#usage-patterns}
 |api: {top-5 exports with () for functions}
-|key-types:{SKILL.md#key-types} — {inline summary of most important type values}
+|key-types:{SKILL.md#key-exports} — {inline summary of most important type values}
 |gotchas: {2-3 most critical pitfalls or breaking changes, inline}
 ```
+
+The anchors point to the QS template's actual headings — `#usage-patterns` (Usage Patterns) and `#key-exports` (Key Exports). The QS template has no `## Quick Start` / `## Key Types` headings (those are Deep-tier sections), so the Deep-tier anchors `#quick-start` / `#key-types` would dangle. If the assembled SKILL.md is missing the referenced heading, omit that line rather than emit a dangling anchor.
 
 **If fewer than 5 exports:** Use all available exports.
 **If no exports:** Omit the api line.

--- a/src/skf-test-skill/references/coherence-check.md
+++ b/src/skf-test-skill/references/coherence-check.md
@@ -43,9 +43,9 @@ The first call returns `{ description: {satisfied, matched_synonym, tried[]}, us
 
 - `satisfied: true` → no finding.
 - `satisfied: false` AND family is `description` AND the SKILL.md frontmatter has a non-empty `description` field → no finding (the frontmatter alternative satisfies the family per the original rule).
-- Otherwise → **High severity** finding: `naive-coherence — missing required section: {family}` (the `tried[]` list from the JSON identifies which synonyms were checked: `Description`/`Overview`/`Purpose`/`Summary` for description; `Usage`/`Examples`/`How to use`/`Quickstart`/`Quick Start`/`Getting Started`/`Common Workflows` for usage; `API`/`API Surface`/`Exports`/`Public API`/`Interface`/`Reference`/`Key API Summary` for api_surface).
+- Otherwise → **High severity** finding: `naive-coherence — missing required section: {family}` (the `tried[]` list from the JSON identifies which synonyms were checked: `Description`/`Overview`/`Purpose`/`Summary` for description; `Usage`/`Usage Patterns`/`Examples`/`How to use`/`Quickstart`/`Quick Start`/`Getting Started`/`Common Workflows` for usage; `API`/`API Surface`/`Exports`/`Key Exports`/`Public API`/`Interface`/`Reference`/`Key API Summary` for api_surface).
 
-The script matches case-insensitively and tolerates `##`/`###` heading levels. SKF-template skills' `## Quick Start`, `## Common Workflows`, and `## Key API Summary` are first-class synonyms baked into the script — they will surface with `satisfied: true` and the corresponding `matched_synonym` field.
+The script matches case-insensitively and tolerates `##`/`###` heading levels. SKF-template skills' headings are first-class synonyms baked into the script — the Deep/create-skill `## Quick Start`, `## Common Workflows`, and `## Key API Summary`, and the quick-skill `## Usage Patterns` and `## Key Exports` — so they all surface with `satisfied: true` and the corresponding `matched_synonym` field.
 
 **2.2 Code fence balance.** Read `unbalanced_fences` from the second JSON blob. **`true` → High severity** finding: `naive-coherence — unbalanced code fence (unclosed block)` (the JSON's `fence_count` may be cited in the detail).
 
@@ -54,7 +54,7 @@ The script matches case-insensitively and tolerates `##`/`###` heading levels. S
 **2.4 Exports cross-used in a usage-family section.** For each function name reported in the step 3 subagent inventory (`exports[].name` where `kind == "function"` or `kind == "method"`):
 - Determine the usage-family search scope:
   - **Single-body skill** (no `references/` directory, or `## Full*` sections carry real content): the span from §2.1's `matched_synonym` anchor to the next `^## ` anchor.
-  - **Split-body skill** (a `references/` directory exists alongside SKILL.md AND the SKILL.md `## Full*` sections are stubs/pointers): the union of EVERY usage-family heading present in SKILL.md (`Usage`/`Examples`/`How to use`/`Quickstart`/`Quick Start`/`Getting Started`/`Common Workflows`/`Key API Summary`), each from its anchor to the next `^## ` anchor, PLUS the full text of every file under `references/`.
+  - **Split-body skill** (a `references/` directory exists alongside SKILL.md AND the SKILL.md `## Full*` sections are stubs/pointers): the union of EVERY usage-family heading present in SKILL.md (`Usage`/`Usage Patterns`/`Examples`/`How to use`/`Quickstart`/`Quick Start`/`Getting Started`/`Common Workflows`/`Key API Summary`/`Key Exports`), each from its anchor to the next `^## ` anchor, PLUS the full text of every file under `references/`.
 - `grep -c "{export.name}"` across that scope and sum the counts.
 - **Zero occurrences across the entire scope → High severity** finding: `naive-coherence — exported {kind} \`{name}\` is not referenced in any usage-family section or reference file`. This catches the "documented but unused" failure mode that trivially fails discovery testing. A method referenced in any usage-family section OR any `references/` file satisfies the check.
 

--- a/test/test-skf-scan-skill-md-structure.py
+++ b/test/test-skf-scan-skill-md-structure.py
@@ -104,6 +104,35 @@ class TestRequiredSections:
         result = mod.find_required_sections(text)
         assert result["usage"]["matched_synonym"] == "Common Workflows"
 
+    def test_usage_patterns_satisfies_usage(self) -> None:
+        # quick-skill template heading — full-text match, not a substring of "Usage".
+        text = "## Description\n## Usage Patterns\n## API\n"
+        result = mod.find_required_sections(text)
+        assert result["usage"]["satisfied"] is True
+        assert result["usage"]["matched_synonym"] == "Usage Patterns"
+
+    def test_key_exports_satisfies_api_surface(self) -> None:
+        # quick-skill template heading — distinct from the bare "Exports" synonym.
+        text = "## Description\n## Usage\n## Key Exports\n"
+        result = mod.find_required_sections(text)
+        assert result["api_surface"]["satisfied"] is True
+        assert result["api_surface"]["matched_synonym"] == "Key Exports"
+
+    def test_quick_skill_template_headings_satisfy_all_families(self) -> None:
+        # The quick-skill template's literal headings must satisfy every
+        # required family so its output passes the structural-scan gate
+        # without per-skill heading edits.
+        text = (
+            "## Overview\nblah\n\n"
+            "## Description\nblah\n\n"
+            "## Key Exports\nblah\n\n"
+            "## Usage Patterns\nblah\n"
+        )
+        result = mod.find_required_sections(text)
+        assert all(
+            result[f]["satisfied"] for f in ("description", "usage", "api_surface")
+        )
+
     def test_case_insensitive(self) -> None:
         text = "## description\n## USAGE\n## api\n"
         result = mod.find_required_sections(text)


### PR DESCRIPTION
The quick-skill template's section vocabulary diverged from the rest of SKF, surfacing two defects.

## 1. Dangling context-snippet anchors

The quick-skill context-snippet hardcoded `#quick-start` and `#key-types` section anchors, but the quick-skill `SKILL.md` template has no `## Quick Start` or `## Key Types` headings — those are Deep-tier (create-skill) sections. The quick-skill template's actual headings are `## Usage Patterns` and `## Key Exports`, so the emitted anchors dangled in the always-on managed snippet, and nothing in the quick-skill validation path catches them (the output validator checks snippet format, not anchor resolution).

Repointed the anchors to the headings the template actually emits (`#usage-patterns`, `#key-exports`) in both the compile step and the template's snippet-format block, with an omit-if-missing guard so a future template change can't reintroduce a dangling anchor.

## 2. Contradictory required-section gates

The structural-scan gate (`skf-scan-skill-md-structure.py`) matched required-section headings on the full heading text against a synonym set tuned for the Deep/create-skill template, while the output validator (`skf-validate-output.py`) matched by substring. The quick-skill `## Usage Patterns` and `## Key Exports` headings satisfied the validator but failed the scanner's `usage` and `api_surface` families — no single export/usage heading satisfied both gates, forcing per-skill heading edits and a spurious finding either way.

Folded the quick-skill headings into the scanner's synonym set (`Usage Patterns` → usage, `Key Exports` → api_surface) so the template's literal output passes both gates unchanged. The change is **purely additive** — it only widens what the scanner accepts, so no previously-passing skill regresses. The output validator already accepted these headings via substring matching and is left untouched. Synced the coherence-check synonym documentation the scanner mirrors and added scanner tests covering the two headings and the full quick-skill heading set.

## Validation

Full module test suite green (schemas, install, cli, workflow, python, knowledge, schema/skill/ref validation, lint, format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)