### PR TITLE
fix(skf-create-skill): resolve package exports map for entry points outside src/

### DIFF
--- a/src/skf-create-skill/references/extract.md
+++ b/src/skf-create-skill/references/extract.md
@@ -205,6 +205,11 @@ After extraction, validate the collected exports against the package's actual pu
 - **TypeScript/JS:** Read `index.ts`/`index.js` — same comparison logic.
 - **Rust:** Read `lib.rs` — extract `pub use` items. Same logic. **Go:** Scan for exported (capitalized) identifiers.
 
+**Multi-entry packages (`exports` map / declaration-file entry points).** A single per-language entry-point read misses public surface that a package ships through its `package.json` `exports` map — especially committed `.d.ts` / `.d.mts` declaration files that resolve **outside** the conventional source dir (e.g. a monorepo package whose `./macro` subpath maps to `macro/index.d.mts`, listed in `files[]` but not under `src/`). When the in-scope package declares an `exports` map:
+
+- Resolve each `exports` subpath to its target file and treat that file — and any committed `.d.ts` / `.d.mts` declaration it resolves to — as an authoritative public entry point, reading it the same way as the primary barrel above even when it lives outside `src/`.
+- If a resolved `exports` subpath target falls **outside** the brief's `scope.include` globs, surface a note: `"warn: public entry point {path} (exports subpath '{subpath}') resolves outside scope.include — widen scope.include before extraction, or this surface stays undocumented and excluded from the coverage denominator."` Widening `scope.include` here keeps the documented surface aligned with the `effective_denominator` that compile.md §4 derives from those same globs, without mid-run scope surgery.
+
 Use the entry point as the authoritative source for `metadata.json`'s `exports[]` array.
 
 **If entry point is missing or unreadable:** Skip validation with a warning.


### PR DESCRIPTION
## Problem

`extract.md` §4b (*Validate Exports Against Package Entry Point*) validates extracted exports against a **single** per-language entry point and assumes the public API lives under the conventional source dir.

A monorepo package that ships its public API through `package.json` `exports` subpaths — resolving to committed `.d.ts` / `.d.mts` declaration files **outside** `src/` (e.g. a package whose `./macro` subpath maps to `macro/index.d.mts`, listed in `files[]` but not under `src/`) — has that surface silently missed. The `effective_denominator` that `compile.md` §4 derives from the same `scope.include` globs then disagrees with the documented surface, requiring manual scope surgery mid-run.

## Fix

Extend §4b with a **multi-entry packages** clause:

- Resolve each in-scope package's `exports` map and treat every subpath target (and its committed `.d.ts` / `.d.mts` declaration) as an authoritative public entry point, read the same way as the primary barrel — even when it lives outside `src/`.
- When a resolved subpath target falls outside the brief's `scope.include` globs, surface a warning so the forger can widen scope before extraction, keeping the documented surface aligned with the coverage denominator.

## Scope / safety

- Additive guidance to one reference file; no script or schema changes.
- The clause triggers **only** when a `package.json` `exports` map is present, so single-package extraction is unchanged — no regression for existing skills.
- Full suite green (`lint:md`, `validate:skills`, `validate:refs`, `test:python` 95/0, knowledge, format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)