### PR TITLE
fix(skf-brief-skill): document monorepo subpackage scope convention

### DIFF
--- a/src/skf-brief-skill/references/scope-definition.md
+++ b/src/skf-brief-skill/references/scope-definition.md
@@ -126,6 +126,16 @@ Wait for user selection. Empty input or just Enter accepts the recommendation; a
 
 Using the boundary definitions from `{scopeTemplatesPath}`, present the appropriate flow for the user's selected scope type ([F], [M], [P], [C], or [R]). Follow each type's prompts and wait for user input at each phase before proceeding.
 
+### 3b. Monorepo Subpackage Convention
+
+**Applies only when step 02 §1b selected a workspace (`monorepo_workspace` is set).** A subpackage skill documents one package inside a larger repository, so the source and scope fields follow a fixed convention. Express them wrong and `skf-create-skill` cannot resolve the scope globs against the cloned source:
+
+- **`source_repo` stays the repository URL**, never the subpackage. `skf-create-skill` clones the whole repo at the pinned ref and then roots extraction at the subpackage, so the repo URL is what it clones.
+- **`scope.include` / `scope.exclude` globs are repo-root-relative and subpackage-prefixed.** Step 02 rebased its analysis against `monorepo_workspace`, but the emitted globs must still carry the workspace prefix (e.g. `packages/sdk/src/**`, not `src/**`) because they resolve against the repo root, not the subpackage root.
+- **Record the subpackage layout in `scope.notes`:** the subpackage root (the `monorepo_workspace` path), the published package name and version, the resolved git ref, and the local-clone directory. This is the only field that maps the repo-URL `source_repo` to the actual skilled subpackage — downstream workflows and re-forges read it to reconstruct the source layout.
+
+Carry the `monorepo_workspace` path forward from step 02 §1b into the `scope.notes` you draft here rather than recomputing it.
+
 ### 4. Handle Language Override
 
 {If language detection confidence was low from step 02:}


### PR DESCRIPTION
## Problem

When a brief targets one package inside a monorepo, the source and scope fields follow a fixed convention — but it is documented in no step file. An author has to reverse-engineer it from sibling briefs, and a first-time forger is likely to emit subpackage-relative globs that `skf-create-skill` cannot resolve against a repo-URL `source_repo`.

## Fix

Document the convention in `scope-definition.md` as a new **§3b. Monorepo Subpackage Convention**, gated on a workspace having been selected during analysis (`monorepo_workspace` set):

- `source_repo` stays the **repository URL**, never the subpackage — create-skill clones the whole repo and roots extraction at the subpackage.
- `scope.include` / `scope.exclude` globs are **repo-root-relative and subpackage-prefixed** (e.g. `packages/sdk/src/**`, not `src/**`).
- The subpackage layout (root path, package name, version, git ref, local-clone dir) is recorded in `scope.notes` — the only field that maps the repo-URL `source_repo` to the skilled subpackage.

Also carries the `monorepo_workspace` path forward from analysis into `scope.notes` rather than recomputing it.

## Scope / impact

- Documentation-only change to one workflow step file. No schema, script, or contract change.
- Matches the convention already followed by existing monorepo-subpackage briefs.

## Validation

Full `npm test` suite green (schemas, install, cli, workflow, python, knowledge, validate:*, lint, lint:md, format:check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)