### PR TITLE
fix(skf-brief-skill): capture tier_a_include for coarse-glob monorepo subsets

### DIFF
--- a/src/skf-brief-skill/references/confirm-brief.md
+++ b/src/skf-brief-skill/references/confirm-brief.md
@@ -43,6 +43,7 @@ Compile all gathered data from steps 01-03 into the complete brief:
 - **scope.include:** {include patterns from step 03}
 - **scope.exclude:** {exclude patterns from step 03}
 - **scope.notes:** {any scope notes from step 03}
+- **scope.tier_a_include:** {tier-A authoring-surface patterns from step 03 §3c — omit if unset}
 - **scope.rationale:** {recommended -> chosen, reason — from step 03}
 - **source_type:** {source or docs-only, from step 01}
 - **doc_urls:** {collected documentation URLs with labels, from steps 01/03 — include if source_type is "docs-only" or supplemental URLs were collected}
@@ -71,6 +72,7 @@ Scope: {scope.type}
   Include: {scope.include patterns, one per line}
   Exclude: {scope.exclude patterns, one per line}
   Notes:   {scope.notes}
+  Tier-A:  {scope.tier_a_include patterns, one per line — omit this line entirely if scope.tier_a_include unset}
   Rationale: {chosen} chosen over {recommended} — {reason}
              {omit this line entirely if scope.rationale absent}
 

--- a/src/skf-brief-skill/references/scope-definition.md
+++ b/src/skf-brief-skill/references/scope-definition.md
@@ -22,7 +22,7 @@ To collaboratively define the skill's inclusion and exclusion boundaries using t
 - Do not make scope decisions unilaterally — user drives all scope choices
 - Produce: scope type, include patterns, exclude patterns
 - All user-facing output in `{communication_language}`
-- **Re-entry from step 4 [R] revise:** prior selections (`scope.type`, `scope.include`, `scope.exclude`, `scope.notes`, `scope.rationale`, `scripts_intent`, `assets_intent`, supplemental `doc_urls`) are preserved as the current state. Re-present them at each section as the existing answer; the user only re-confirms or overrides. Do not reset to the §2c template menu unless the user explicitly asks to start scope over. When `scope.rationale` is preserved and the user changes `chosen` (the scope type) on this pass, recompute `accepted_recommendation` (`chosen == recommended`) and refresh `reason` and `recorded` per the §2c capture rules — revise in place, do not append.
+- **Re-entry from step 4 [R] revise:** prior selections (`scope.type`, `scope.include`, `scope.exclude`, `scope.notes`, `scope.tier_a_include`, `scope.rationale`, `scripts_intent`, `assets_intent`, supplemental `doc_urls`) are preserved as the current state. Re-present them at each section as the existing answer; the user only re-confirms or overrides. Do not reset to the §2c template menu unless the user explicitly asks to start scope over. When `scope.rationale` is preserved and the user changes `chosen` (the scope type) on this pass, recompute `accepted_recommendation` (`chosen == recommended`) and refresh `reason` and `recorded` per the §2c capture rules — revise in place, do not append.
 
 ## MANDATORY SEQUENCE
 
@@ -135,6 +135,14 @@ Using the boundary definitions from `{scopeTemplatesPath}`, present the appropri
 - **Record the subpackage layout in `scope.notes`:** the subpackage root (the `monorepo_workspace` path), the published package name and version, the resolved git ref, and the local-clone directory. This is the only field that maps the repo-URL `source_repo` to the actual skilled subpackage — downstream workflows and re-forges read it to reconstruct the source layout.
 
 Carry the `monorepo_workspace` path forward from step 02 §1b into the `scope.notes` you draft here rather than recomputing it.
+
+### 3c. Tier-A Authoring Surface (coarse-glob monorepo subsets)
+
+**Applies when a monorepo subpackage's `scope.include` uses coarse directory globs (`packages/foo/src/**`, `bin/**`) rather than an explicit file list.** Coarse globs also sweep in internal-only files (build scripts, state-store impls, generated config) that the package's public entry barrel never re-exports. `skf-create-skill` scores coverage against the *authoring* surface, and `skf-test-skill` re-derives that surface from the brief to guard against a deflated coverage denominator — so when the coarse-glob union is much larger than the documented export count and the brief names no narrower surface, the test gate inflates the denominator and an otherwise-complete skill scores as if it had large coverage gaps.
+
+Head this off by capturing the authoring surface as **`scope.tier_a_include`**: the concrete source files whose named exports the package's public entry barrel (`index.ts`, `lib.rs`, `__init__.py`) actually re-exports. Derive the candidate list by tracing the entry barrel's re-export targets (the entry-point file was fetched in step 02), present it for the user to confirm or adjust, and store the confirmed list as `scope.tier_a_include`. List the definition files, not the umbrella barrel itself — a barrel re-exports the whole package, so including it widens the surface instead of narrowing it.
+
+`scope.tier_a_include` does not change what gets extracted (that still follows `scope.include` / `scope.exclude`); it only pins the coverage denominator so the create-side and test-side counts agree without a mid-test hand-edit. Leave it unset when `scope.include` is already an explicit file list, or when the target is not a monorepo subset — there the coarse-glob union and the authoring surface coincide and no narrowing is needed.
 
 ### 4. Handle Language Override
 

--- a/src/skf-brief-skill/references/write-brief.md
+++ b/src/skf-brief-skill/references/write-brief.md
@@ -96,7 +96,7 @@ Assemble the brief context as a **flat** JSON object — every approved value is
   "scope_exclude":    ["{approved exclude patterns}"],
   "scope_notes":      "{approved scope notes or empty string}",
   "scope_rationale":  null | {"recommended":"...","chosen":"...","accepted_recommendation":true|false,"heuristic":"...","reason":"...","recorded":"YYYY-MM-DD"},
-  "scope_tier_a_include": null | ["{tier-A include patterns — ratify only}"],
+  "scope_tier_a_include": null | ["{tier-A authoring-surface patterns — from step 03 §3c capture, or hydrated on a ratify run}"],
   "scope_amendments":     null | [{"path":"...","action":"...","reason":"...","date":"YYYY-MM-DD","workflow":"..."}],
   "doc_urls":         null | [{"url": "...", "label": "..."}],
   "scripts_intent":   null | "{detect|none|free-text}",


### PR DESCRIPTION
## Problem

When a monorepo subpackage is scoped with coarse directory globs (`packages/foo/src/**`, `bin/**`), the `scope.include` union sweeps in internal-only files (build scripts, state-store impls, generated config) that the package's public entry barrel never re-exports. `skf-create-skill` scores coverage against the *authoring* surface, and `skf-test-skill` re-derives that surface from the brief to guard against a deflated denominator. With no narrower surface named in the brief, the coarse-glob union dwarfs the documented export count, the test gate inflates the denominator, and an otherwise-complete skill scores as if it had large coverage gaps — resolvable today only by hand-adding `scope.tier_a_include` to the brief mid-test.

## Fix

Capture the authoring surface at brief time instead of patching it later. New **§3c** in `scope-definition.md`: when a monorepo subpackage uses coarse `**` globs, derive the candidate tier-A list by tracing the entry barrel's re-export targets, confirm it with the user, and store it as `scope.tier_a_include`. With the field present, create-skill's existing "prefer `tier_a_include`" denominator logic and the test-side deflation guard agree on the first run.

Supporting changes so the captured value is durable and visible:

- `scope-definition.md` — `scope.tier_a_include` added to the `[R]` revise preservation list.
- `confirm-brief.md` — tier-A surface shown in both brief-review blocks (conditional; omitted when unset).
- `write-brief.md` — flat-context annotation updated from "ratify only" to reflect §3c authoring capture.

## Scope / impact

- Instruction-only change across three brief-skill step files.
- **No schema or writer change** — `scope.tier_a_include` is not schema-gated to ratify, and the writer already accepts it on the normal flat path (`skf-write-skill-brief.py`). The field stays `null` when unset, so non-monorepo and explicit-file-list briefs are unaffected.
- Complements the existing ratify-run round-trip of `tier_a_include`; the §3c capture is a new authoring-time source for the same field.

## Validation

Full `npm test` suite green (schemas, install, cli, workflow, python — including the write-skill-brief and brief-schema contract tests — knowledge, validate:*, lint, lint:md, format:check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)