### PR TITLE
fix(skf-skills): read skill-check score/counts from correct JSON paths

### DIFF
--- a/src/skf-create-skill/references/validate.md
+++ b/src/skf-create-skill/references/validate.md
@@ -76,7 +76,7 @@ npx skill-check check <staging-skill-dir> --fix --format json {security_scan_fla
 
 This performs frontmatter validation, description quality checks, body limit enforcement, local link resolution, file formatting, auto-fix of deterministic issues, and quality scoring (0-100) across five weighted categories.
 
-**Parse the JSON output** for: `qualityScore` (0-100), `diagnostics[]` (remaining issues), `fixed[]` (auto-corrected issues).
+**Parse the JSON output** for: `scores[].score` (0-100 — match the entry by `relativePath`/`skillId`; falls back to a top-level `qualityScore` on older skill-check builds), `diagnostics[]` (remaining issues), `fixed[]` (auto-corrected issues).
 
 **Description Guard Protocol:** This invocation may modify SKILL.md (especially when `fixed[]` is non-empty). Wrap the `skill-check check --fix` call in the four-phase guard defined in §0 by invoking `{descriptionGuardHelper}` at the capture and verify-restore points:
 
@@ -94,7 +94,7 @@ uv run {descriptionGuardHelper} verify-restore <staging-skill-dir>/SKILL.md \
 
 If `restored: true` in the verify-restore output, apply §0's post-restore re-validation hook. If `fixed[]` was non-empty in the skill-check output, also re-read the modified SKILL.md to sync the in-context copy before proceeding — this prevents silent divergence between the in-context and on-disk versions that step 7 will use for artifact generation.
 
-**Note:** `skill-check` may return non-zero exit code even when `errorCount` is 0. Always rely on parsed JSON, not the shell exit code.
+**Note:** `skill-check` may return non-zero exit code even when `summary.errorCount` is 0. Always rely on parsed JSON, not the shell exit code.
 
 - **Score ≥ 70:** Record "Schema: PASS (score: {score}/100)" in evidence-report
 - **Score < 70:** Log remaining diagnostics as warnings, record "Schema: WARN — score {score}/100, {count} remaining issues", proceed

--- a/src/skf-create-stack-skill/references/validate.md
+++ b/src/skf-create-stack-skill/references/validate.md
@@ -55,7 +55,7 @@ timeout 10s npx --no-install skill-check -h
 
 **If available**, run: `npx skill-check check <skill-dir> --fix --format json --no-security-scan`
 
-This validates frontmatter, description, body limits, links, formatting — and auto-fixes deterministic issues. Parse JSON for `qualityScore`, `diagnostics[]`, `fixed[]`.
+This validates frontmatter, description, body limits, links, formatting — and auto-fixes deterministic issues. Parse JSON for `scores[].score` (match the entry by `relativePath`/`skillId`; falls back to a top-level `qualityScore` on older skill-check builds), `diagnostics[]`, `fixed[]`.
 
 **Post-fix provenance drift guard (S15):** If `fixed[]` is non-empty, `skill-check --fix` has modified `SKILL.md` after step 7 wrote it. The safe default for v1.0 is to emit a **WARNING** finding listing each auto-fix (`"skill-check --fix modified SKILL.md: {fix_description} — metadata.json hashes/provenance may be out of date"`). Do NOT silently accept the fixes without surfacing the drift. If the caller wants authoritative metadata, they should re-run the workflow.
 

--- a/src/skf-quick-skill/references/write-and-validate.md
+++ b/src/skf-quick-skill/references/write-and-validate.md
@@ -84,7 +84,7 @@ npx skill-check check {skill_package} --fix --format json
 This validates frontmatter, description, body limits, links, and formatting; runs the security scan; and auto-fixes deterministic issues (field ordering, slug format, required fields, trailing newlines).
 
 **Parse JSON output** to extract:
-- `qualityScore` — overall score (0-100)
+- `scores[].score` — overall score (0-100); match the entry by `relativePath`/`skillId` (older skill-check builds exposed this as a top-level `qualityScore`)
 - `diagnostics[]` — remaining issues after auto-fix
 - `fixed[]` — issues automatically corrected
 - `security[]` (when present) — security findings, recorded as advisory warnings (security issues do not block output)

--- a/src/skf-test-skill/references/external-validators.md
+++ b/src/skf-test-skill/references/external-validators.md
@@ -66,11 +66,11 @@ timeout 120s npx skill-check check {skillDir} --format json --no-security-scan
 If the command exits non-zero AND the exit code is `124` (GNU timeout's signal for the 120s wall-clock expiring), record `skill_check_score: N/A` with reason `timeout-120s`, log a warning, and skip to section 3. Other non-zero exits fall through to the regular JSON-parse path per the note below.
 
 **Parse JSON output** to extract:
-- `qualityScore` — overall score (0-100)
+- `scores[].score` — overall score (0-100); match the entry by `relativePath` (or `skillId`) to the validated skill dir. Older skill-check builds exposed this as a top-level `qualityScore` — fall back to that if `scores[]` is absent.
 - `diagnostics[]` — any remaining issues
-- `errorCount` and `warningCount`
+- `summary.errorCount` and `summary.warningCount` — issue counts (the counts live under `summary`, not at the top level)
 
-**Note:** `skill-check` may return a non-zero exit code even when `errorCount` is 0. Always rely on the parsed JSON output, not the shell exit code.
+**Note:** `skill-check` may return a non-zero exit code even when `summary.errorCount` is 0. Always rely on the parsed JSON output, not the shell exit code.
 
 Store in context: `skill_check_score`, `skill_check_diagnostics`
 


### PR DESCRIPTION
skill-check 0.x emits the quality score under `scores[].score` and issue counts under `summary.{errorCount,warningCount}`. Four validation steps parsed top-level `qualityScore`/`errorCount`/`warningCount`, which don't exist — the score read back as null, breaking the downstream PASS/WARN gates (create / create-stack) and the score-averaging in test-skill.

## Fix

Corrects the parse instructions to read `scores[].score` (matched by `relativePath`/`skillId`) and `summary.errorCount`/`summary.warningCount`, keeping the old top-level names as a documented fallback for older skill-check builds:

- `src/skf-create-skill/references/validate.md`
- `src/skf-create-stack-skill/references/validate.md`
- `src/skf-quick-skill/references/write-and-validate.md`
- `src/skf-test-skill/references/external-validators.md`

## Validation

- Verified against live skill-check 0.x: top-level keys are exactly `summary` / `diagnostics` / `metadata` / `scores`; an over-long description is reported as a blocking `error` (`description.max_length`).
- Full `npm test` green (`validate:refs`, `lint`, `lint:md`, `format:check` included).

## Scope note

`fixed[]` references were left untouched — their JSON path wasn't empirically confirmed and they're outside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)