### PR TITLE
fix(skf-quick-skill): invoke frontmatter validator via uv run

### DIFF
--- a/src/skf-quick-skill/references/write-and-validate.md
+++ b/src/skf-quick-skill/references/write-and-validate.md
@@ -94,7 +94,7 @@ Record quality score, remaining diagnostics, and security findings as validation
 **If skill-check is NOT available**, run the shared frontmatter validator instead of an LLM-walked checklist. Resolve `{frontmatterValidator}` from `{frontmatterValidatorProbeOrder}`; first existing path wins. If no candidate exists, log a high-severity issue ("frontmatter validator unavailable — both `npx skill-check` and `skf-validate-frontmatter.py` missing") and skip frontmatter validation.
 
 ```bash
-python3 {frontmatterValidator} {skill_package}/SKILL.md --skill-dir-name {repo_name}
+uv run {frontmatterValidator} {skill_package}/SKILL.md --skill-dir-name {repo_name}
 ```
 
 The validator emits JSON with `status` (`pass`/`fail`), `issues[]` (each with `severity`, `code`, `message`), and `frontmatter` (the parsed name/description). It checks frontmatter delimiters, name format (Unicode letters + digits + hyphens, no consecutive/trailing hyphens), name-directory match, description presence and length, and unknown fields against the agentskills.io spec — the same shape this step would otherwise hand-walk. Record each `issues[]` entry as a validation issue with its reported severity. Missing frontmatter or missing required fields are high-severity — skills without valid frontmatter will fail `npx skills add` and `npx skill-check check`.


### PR DESCRIPTION
The skill-check fallback path in `src/skf-quick-skill/references/write-and-validate.md` ran `skf-validate-frontmatter.py` with bare `python3`, but the script declares a PEP 723 `pyyaml` dependency and fails with `ModuleNotFoundError` on a fresh interpreter where pyyaml is not installed system-wide.

## Fix

Switches the invocation to `uv run` so the PEP 723 dependency is auto-resolved and cached, matching how `skf-create-skill` invokes the same validator.

## Validation

- Confirmed this is the only bare-`python3` invocation pointing at a pyyaml/uv-required shared script across `src/` — every other bare-`python3 {var}` call resolves to a `dependencies = []` (stdlib-only) script and is correct as-is. The adjacent `{outputValidator}` call (`skf-validate-output.py`, no deps) is intentionally left on `python3`.
- Fallback-path only (used when `npx skill-check` is unavailable).
- Full `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)