### PR TITLE
fix(skf-create-stack-skill): pre-check SKILL.md body size before commit

### DIFF
--- a/src/shared/scripts/skf-validate-frontmatter.py
+++ b/src/shared/scripts/skf-validate-frontmatter.py
@@ -20,17 +20,24 @@ system-wide:
 
   uv run skf-validate-frontmatter.py <skill-md-path>
   uv run skf-validate-frontmatter.py <skill-md-path> --skill-dir-name <name>
+  uv run skf-validate-frontmatter.py <skill-md-path> --max-body-lines 500
 
 Input:
   Path to a SKILL.md file.
   Optional --skill-dir-name: expected directory name for name-match check.
   If omitted, derived from the parent directory of the SKILL.md path.
+  Optional --max-body-lines N: when set, emit a high-severity `body` issue
+  if the SKILL.md body (lines after the closing frontmatter delimiter)
+  exceeds N lines. Opt-in — when omitted, body size is never checked and
+  the verdict is unchanged. Callers pass the skill-check `body.max_lines`
+  default (500) to pre-catch that hard reject before commit.
 
 Output:
   JSON object:
     status:     "pass" | "fail" | "warn"
     issues:     list of { severity, field, message }
     frontmatter: parsed frontmatter dict (if parseable)
+    body_lines: int body-line count, or null when delimiters are absent
     summary:    { total, high, medium, low }
 
 Exit codes:
@@ -122,6 +129,31 @@ def parse_frontmatter(content: str) -> tuple[dict | None, list[dict]]:
     return fm, issues
 
 
+def body_line_count(content: str) -> int | None:
+    """Count the SKILL.md body lines — every line after the closing
+    frontmatter delimiter.
+
+    Mirrors skill-check's `body.max_lines` definition (body = content past
+    the frontmatter block) so a pre-commit gate keyed on this count agrees
+    with the post-commit `npx skill-check` verdict. Returns None when the
+    frontmatter delimiters are absent or unclosed — the body boundary is
+    then undefined and size cannot be assessed. Uses splitlines() to match
+    the line-counting convention used elsewhere in the SKF scripts (handles
+    LF/CRLF, no trailing-newline phantom line).
+    """
+    if not content.startswith("---\n") and not content.startswith("---\r\n"):
+        return None
+    lines = content.splitlines()
+    closing = -1
+    for i in range(1, len(lines)):
+        if lines[i] == "---":
+            closing = i
+            break
+    if closing == -1:
+        return None
+    return len(lines) - (closing + 1)
+
+
 def _validate_name(name: str, skill_dir_name: str | None) -> list[dict]:
     """Validate skill name format. Aligned with canonical validator.py."""
     issues: list[dict] = []
@@ -187,12 +219,25 @@ def _validate_name(name: str, skill_dir_name: str | None) -> list[dict]:
 def validate_frontmatter(
     content: str,
     skill_dir_name: str | None = None,
+    max_body_lines: int | None = None,
 ) -> dict:
     """Validate SKILL.md frontmatter against agentskills.io spec.
 
-    Returns a result dict with status, issues, frontmatter, and summary.
+    When `max_body_lines` is set, additionally emit a high-severity `body`
+    issue if the body exceeds that many lines (opt-in — the verdict is
+    unchanged when it is None, so the other consumers of this validator are
+    unaffected). Returns a result dict with status, issues, frontmatter,
+    body_lines, and summary.
     """
     fm, issues = parse_frontmatter(content)
+
+    body_lines = body_line_count(content)
+    if max_body_lines is not None and body_lines is not None and body_lines > max_body_lines:
+        issues.append({
+            "severity": "high",
+            "field": "body",
+            "message": f"body lines {body_lines} exceeds max {max_body_lines}",
+        })
 
     if fm is not None:
         # Name validation
@@ -255,6 +300,7 @@ def validate_frontmatter(
         "status": status,
         "issues": issues,
         "frontmatter": fm,
+        "body_lines": body_lines,
         "summary": {
             "total": len(issues),
             **severity_counts,
@@ -289,6 +335,17 @@ def main() -> int:
         help="expected skill directory name (default: derived from parent directory)",
     )
     parser.add_argument(
+        "--max-body-lines",
+        metavar="N",
+        type=int,
+        default=None,
+        help=(
+            "when set, emit a high-severity 'body' issue if the SKILL.md body "
+            "exceeds N lines (opt-in; omitted = body size not checked). Pass "
+            "the skill-check body.max_lines default (500) to pre-catch that reject."
+        ),
+    )
+    parser.add_argument(
         "-o", "--output",
         metavar="FILE",
         help="write JSON output to FILE instead of stdout",
@@ -302,12 +359,13 @@ def main() -> int:
             "status": "fail",
             "issues": [{"severity": "high", "field": "file", "message": f"File not found: {skill_md_path}"}],
             "frontmatter": None,
+            "body_lines": None,
             "summary": {"total": 1, "high": 1, "medium": 0, "low": 0},
         }
     else:
         content = skill_md_path.read_text(encoding="utf-8")
         skill_dir_name = args.skill_dir_name or skill_md_path.parent.name
-        result = validate_frontmatter(content, skill_dir_name)
+        result = validate_frontmatter(content, skill_dir_name, args.max_body_lines)
 
     output_text = json.dumps(result, indent=2)
 

--- a/src/skf-create-stack-skill/references/generate-output.md
+++ b/src/skf-create-stack-skill/references/generate-output.md
@@ -11,9 +11,9 @@ atomicWriteProbeOrder:
   - '{project-root}/src/shared/scripts/skf-atomic-write.py'
 # Resolve `{frontmatterValidator}` by probing `{frontmatterValidatorProbeOrder}`
 # in order (installed SKF module path first, src/ dev-checkout fallback); first
-# existing path wins. Used by the §8 pre-commit frontmatter gate. If neither
-# resolves, the gate degrades to a WARNING — step 8 (validate.md) still runs the
-# full post-commit check.
+# existing path wins. Used by the §8 pre-commit frontmatter + body-size gate
+# (`--max-body-lines`). If neither resolves, the gate degrades to a WARNING —
+# step 8 (validate.md) still runs the full post-commit check.
 frontmatterValidatorProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-validate-frontmatter.py'
   - '{project-root}/src/shared/scripts/skf-validate-frontmatter.py'
@@ -222,22 +222,26 @@ Use the schema from `{provenanceMapSchemaPath}` — see that asset for the canon
 - Warnings and failures encountered
 - Confidence tier distribution
 
-### 8. Pre-Commit Frontmatter Gate
+### 8. Pre-Commit Frontmatter & Body-Size Gate
 
-The full schema/frontmatter validation runs in step 8 (`validate.md`) — but that runs *after* commit-dir and flip-link have already published the package. A non-auto-fixable frontmatter error (most commonly a `description` over the 1024-char limit, which `skill-check --fix` cannot trim for you) would therefore only surface on an already-committed, symlink-active artifact, forcing edits to the live `SKILL.md`. Catch those errors here, while the package is still in `.skf-tmp`.
+The full schema/frontmatter validation runs in step 8 (`validate.md`) — but that runs *after* commit-dir and flip-link have already published the package. The two most common non-auto-fixable `skill-check` hard rejects — a `description` over the 1024-char limit (which `skill-check --fix` cannot trim for you) and a SKILL.md body over the `body.max_lines` limit (default **500**) — would therefore only surface on an already-committed, symlink-active artifact, forcing edits to the live `SKILL.md`. Additive re-composition of an already-large stack grows the body monotonically, so the body overflow is the likeliest trigger. Catch both here, while the package is still in `.skf-tmp`.
 
-Resolve `{frontmatterValidator}` from `{frontmatterValidatorProbeOrder}` (first existing path wins). Run it against the **staged** `SKILL.md`, passing the real skill name so the directory-match check is not fooled by the `.skf-tmp` staging suffix:
+Resolve `{frontmatterValidator}` from `{frontmatterValidatorProbeOrder}` (first existing path wins). Run it against the **staged** `SKILL.md`, passing the real skill name so the directory-match check is not fooled by the `.skf-tmp` staging suffix, and `--max-body-lines 500` to assert the skill-check body limit pre-commit:
 
 ```bash
-uv run {frontmatterValidator} {skill_staging}/SKILL.md --skill-dir-name {project_name}-stack
+uv run {frontmatterValidator} {skill_staging}/SKILL.md --skill-dir-name {project_name}-stack --max-body-lines 500
 ```
 
-The validator emits JSON: `status` (`pass`/`warn`/`fail`), `issues[]` (each with `severity` ∈ `high|medium|low`, `field`, `message`), and `summary`. Disposition:
+The validator emits JSON: `status` (`pass`/`warn`/`fail`), `issues[]` (each with `severity` ∈ `high|medium|low`, `field`, `message`), `body_lines` (the counted body size), and `summary`. Disposition:
 
-- **`status` is `fail`, OR any `issues[]` entry has `severity` `high` or `medium`** — a hard frontmatter violation that `npx skill-check` (step 8) would reject and `--fix` cannot auto-correct (over-long `description`, missing/empty/invalid `name`, over-long `compatibility`). HALT-to-fix **in staging**: trim/correct `{skill_staging}/SKILL.md` (e.g. shorten `description` to ≤ 1024 chars) and re-run the validator until it clears. Do NOT proceed to §9 commit-dir with an unresolved high/medium issue. Note: an over-long `description` is rated `medium` (not `fail`) and the process still exits `0`, so key the HALT on the issue severities above — not on the exit code.
+- **`status` is `fail`, OR any `issues[]` entry has `severity` `high` or `medium`** — a hard violation that `npx skill-check` (step 8) would reject and `--fix` cannot auto-correct. HALT-to-fix **in staging**, then re-run the validator until it clears. Remediate by `field`:
+  - `description` / `name` / `compatibility` — trim/correct `{skill_staging}/SKILL.md` (e.g. shorten `description` to ≤ 1024 chars).
+  - `body` (`body lines N exceeds max 500`) — reduce the staged body: prefer a **selective split** of the largest Tier-2 section(s) into `{skill_staging}/references/`, keeping Tier-1 content inline (mirrors `validate.md` §3); or trim redundant content. Re-run the gate until `body_lines ≤ 500`.
+
+  Do NOT proceed to §9 commit-dir with an unresolved high/medium issue. Note: an over-long `description` is rated `medium` and exits `0`, so key the HALT on the issue severities above — not on the exit code.
 - **Only `low`-severity issues (e.g. an unexpected field)** — record each as a WARNING in the evidence report and proceed; these do not block the commit.
 
-**If `{frontmatterValidator}` does not resolve** (neither probe path exists) **or the invocation cannot run**, emit a WARNING ("pre-commit frontmatter gate skipped — validator unavailable") and proceed. Step 8 (`validate.md`) remains the post-commit backstop; this gate is a best-effort early catch, never a new hard dependency.
+**If `{frontmatterValidator}` does not resolve** (neither probe path exists) **or the invocation cannot run**, emit a WARNING ("pre-commit frontmatter + body-size gate skipped — validator unavailable") and proceed. Step 8 (`validate.md`) remains the post-commit backstop (including the `body.max_lines` split path in its §3); this gate is a best-effort early catch, never a new hard dependency.
 
 ### 9. Commit Staging Directory
 

--- a/test/test-skf-validate-frontmatter.py
+++ b/test/test-skf-validate-frontmatter.py
@@ -270,3 +270,68 @@ class TestEdgeCases:
         content = f"---\nname: my-skill\ndescription: {desc}\n---\n"
         r = validate_frontmatter(content, "my-skill")
         assert r["status"] == "pass"
+
+
+def _skill_md_with_body(n_body_lines: int) -> str:
+    """Build a valid SKILL.md whose body is exactly `n_body_lines` lines."""
+    body = "\n".join(["x"] * n_body_lines) + "\n"
+    return f"---\nname: my-skill\ndescription: hello\n---\n{body}"
+
+
+class TestBodyLineCount:
+    def test_body_lines_present_in_output(self):
+        """body_lines is an additive output field (backward-compatible)."""
+        r = validate_frontmatter(VALID_SKILL_MD, "my-skill")
+        assert "body_lines" in r
+        assert isinstance(r["body_lines"], int)
+
+    def test_body_lines_exact_count(self):
+        r = validate_frontmatter(_skill_md_with_body(5), "my-skill")
+        assert r["body_lines"] == 5
+
+    def test_body_lines_none_without_closing_delimiter(self):
+        r = validate_frontmatter("---\nname: foo\n", "foo")
+        assert r["body_lines"] is None
+
+    def test_body_lines_none_without_opening_delimiter(self):
+        r = validate_frontmatter("name: foo\n---\nbody\n", "foo")
+        assert r["body_lines"] is None
+
+    def test_body_lines_handles_crlf(self):
+        content = "---\r\nname: my-skill\r\ndescription: hello\r\n---\r\nx\r\ny\r\n"
+        r = validate_frontmatter(content, "my-skill")
+        assert r["body_lines"] == 2
+
+
+class TestBodyMaxLinesGate:
+    def test_no_check_when_flag_unset(self):
+        """Opt-in: an oversized body is ignored when max_body_lines is None,
+        so the other validator consumers are unaffected."""
+        r = validate_frontmatter(_skill_md_with_body(600), "my-skill")
+        assert r["status"] == "pass"
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_exceeds_max_emits_high_body_issue(self):
+        r = validate_frontmatter(_skill_md_with_body(501), "my-skill", max_body_lines=500)
+        assert r["status"] == "fail"
+        body_issues = [i for i in r["issues"] if i["field"] == "body"]
+        assert len(body_issues) == 1
+        assert body_issues[0]["severity"] == "high"
+        assert "exceeds max 500" in body_issues[0]["message"]
+
+    def test_at_limit_passes(self):
+        """Strict `>`: a body exactly at the limit does not trip the gate."""
+        r = validate_frontmatter(_skill_md_with_body(500), "my-skill", max_body_lines=500)
+        assert r["status"] == "pass"
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_under_limit_passes(self):
+        r = validate_frontmatter(_skill_md_with_body(10), "my-skill", max_body_lines=500)
+        assert r["status"] == "pass"
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_undefined_body_does_not_trip_gate(self):
+        """No closing delimiter → body_lines None → no body issue (the
+        missing-delimiter error is reported by frontmatter parsing instead)."""
+        r = validate_frontmatter("---\nname: foo\n", "foo", max_body_lines=500)
+        assert not any(i["field"] == "body" for i in r["issues"])


### PR DESCRIPTION
## Problem

The `create-stack-skill` §8 pre-commit gate (`generate-output.md`) validated **frontmatter only**. A SKILL.md body exceeding `skill-check`'s `body.max_lines` (default **500**) was therefore caught only by the post-commit step 8 check — *after* `commit-dir` + `flip-link` had already published the package — forcing a manual trim of the live, symlink-active `SKILL.md` and a re-run of skill-check. Additive re-composition of an already-large stack grows the body monotonically, so this is the most likely post-commit reject.

This mirrors the exact rationale §8 already gives for pre-checking frontmatter ("would only surface on an already-committed, symlink-active artifact").

## Change

- **`skf-validate-frontmatter.py`** — new opt-in `--max-body-lines N` flag. When set, emits a high-severity `body` issue if the body (lines after the closing frontmatter delimiter) exceeds `N`; always reports a `body_lines` count. Body lines are counted with `splitlines()` to match skill-check's `body.max_lines` definition and the convention used elsewhere in the scripts (LF/CRLF-safe, no trailing-newline phantom line).
  - **Opt-in by design:** with the flag unset the verdict is byte-for-byte unchanged, so the other consumers (`test-skill`, `create-skill`, `update-skill`, `export-skill`) are unaffected.
- **`generate-output.md` §8** — now passes `--max-body-lines 500` and HALTs-to-fix **in staging** on a `body` issue (selective-split the largest Tier-2 section into `references/`, mirroring `validate.md` §3). The post-commit step 8 check remains the authoritative backstop.

## Tests

- 10 new unit tests (body-line counting incl. CRLF + missing-delimiter cases; the opt-in gate incl. the strict `>` boundary at exactly 500). `45/45` pass.
- CLI smoke test confirms a 501-line body fails with `body lines 501 exceeds max 500` (exit 1) **with** the flag, and passes **without** it (backward-compat).
- Full `npm test` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)