### PR TITLE
fix(skf-test-skill,skf-export-skill): prefer active symlink when export manifest lags

### DIFF
--- a/src/knowledge/version-paths.md
+++ b/src/knowledge/version-paths.md
@@ -119,9 +119,10 @@ When reading artifacts, resolve the skill path using the export manifest:
 1. Read `{skills_output_folder}/.export-manifest.json`
 2. Look up the skill name in `exports`
 3. Read `active_version` to get the target version
-4. Resolve to `{skill_package}` using the active version
-5. If manifest does not contain the skill: check for `active` symlink at `{skill_group}/active`
-6. If neither manifest nor symlink: fall back to flat-path resolution (migration — see below)
+4. **Manifest-lag guard.** If the `active` symlink at `{skill_group}/active` resolves to a *different* version than the manifest's `active_version`, prefer the **symlink target** and emit an Info note. The manifest `active_version` only advances when `export-skill` runs, but the `active` symlink is flipped forward by every writing workflow (CS/QS/SS/US) the instant it commits a new version. So in the canonical SS→TS→EX order the manifest lags the just-forged version in the window between forge and export — a manifest-first read would otherwise resolve the *previously exported* version. Preferring the symlink target closes this gap (and, for `export-skill`, makes that export publish the forged version and reconcile the manifest). This guard never overrides legitimate state: `drop-skill` — the only workflow that switches the active version — repoints the symlink to the manifest's `active_version` (it never leaves them diverged), and no workflow flips the symlink *backward*, so the only divergence that can occur is exactly this forge→export lag.
+5. Resolve to `{skill_package}` using the chosen version — the symlink target when it diverges per step 4, otherwise `active_version`
+6. If manifest does not contain the skill: check for `active` symlink at `{skill_group}/active`
+7. If neither manifest nor symlink: fall back to flat-path resolution (migration — see below)
 
 ### Manifest-Driven Snippet Scanning (EX Step-04)
 

--- a/src/skf-export-skill/references/load-skill.md
+++ b/src/skf-export-skill/references/load-skill.md
@@ -79,10 +79,11 @@ For each IDE in `config.yaml.ides`:
 Resolve the skill's versioned path before loading artifacts:
 
 1. Read `{skills_output_folder}/.export-manifest.json` and look up `{skill-name}` in `exports` to get `active_version`
-2. If found: resolve to `{skill_package}` = `{skills_output_folder}/{skill-name}/{active_version}/{skill-name}/`
-3. If not in manifest: check for `active` symlink at `{skills_output_folder}/{skill-name}/active` — resolve to `{skill_group}/active/{skill-name}/`
-4. If neither: fall back to flat path `{skills_output_folder}/{skill-name}/`. If SKILL.md exists at the flat path, auto-migrate per `knowledge/version-paths.md` migration rules
-5. Store the resolved path as `{resolved_skill_package}` for all subsequent artifact loading
+2. **Manifest-lag guard.** If the skill is in the manifest, also read the `active` symlink target at `{skills_output_folder}/{skill-name}/active`. If that symlink resolves to a *different* version than `active_version`, prefer the **symlink target** as `{resolved_version}` and emit an Info note: "manifest active_version {M} lags the active symlink {N} — exporting the symlink target (the just-forged version); the manifest active_version advances to {N} on this export." This is the canonical SS→TS→EX case: create-stack-skill flipped `active` to the new version, but the manifest only advances when *this* export runs. A bare manifest-first resolution would re-export the *previously exported* version, and step 4 §4b/step-5 (`update-context.md`) — which derives the published version from `{resolved_skill_package}/metadata.json` — would then write that stale version straight back as `active_version`, so the forged version could never be published. Resolving to the symlink target here makes this export publish {N} and reconcile the manifest. When the symlink matches `active_version` (or no `active` symlink exists), use `active_version`. See `knowledge/version-paths.md` "Reading Workflows".
+3. If found: resolve to `{skill_package}` = `{skills_output_folder}/{skill-name}/{resolved_version}/{skill-name}/`
+4. If not in manifest: check for `active` symlink at `{skills_output_folder}/{skill-name}/active` — resolve to `{skill_group}/active/{skill-name}/`
+5. If neither: fall back to flat path `{skills_output_folder}/{skill-name}/`. If SKILL.md exists at the flat path, auto-migrate per `knowledge/version-paths.md` migration rules
+6. Store the resolved path as `{resolved_skill_package}` for all subsequent artifact loading
 
 Load all files from `{resolved_skill_package}`:
 

--- a/src/skf-test-skill/references/init.md
+++ b/src/skf-test-skill/references/init.md
@@ -45,10 +45,11 @@ Provide the skill path or name. I'll search in `{skillsOutputFolder}`.
 Resolve the skill path using version-aware resolution (see `{versionPathsKnowledge}`):
 
 1. Read `{skillsOutputFolder}/.export-manifest.json` and look up the skill name in `exports` to get `active_version`
-2. If found: resolve to `{skill_package}` = `{skillsOutputFolder}/{skill_name}/{active_version}/{skill_name}/`
-3. If not in manifest: check for `active` symlink at `{skillsOutputFolder}/{skill_name}/active` — resolve to `{skill_group}/active/{skill_name}/`
-4. If neither: fall back to flat path `{skillsOutputFolder}/{skill_name}/`. If SKILL.md exists at the flat path, auto-migrate per `{versionPathsKnowledge}` migration rules
-5. Store the resolved path as `{resolved_skill_package}`
+2. **Manifest-lag guard.** If the skill is in the manifest, also read the `active` symlink target at `{skillsOutputFolder}/{skill_name}/active`. If that symlink resolves to a *different* version than `active_version`, prefer the **symlink target** as `{resolved_version}` and emit an Info note: "manifest active_version {M} lags the active symlink {N} — testing the symlink target (the just-forged version); run export-skill to reconcile the manifest." This is the canonical SS→TS→EX case: create-stack-skill flipped `active` to the new version, but the manifest only advances when export-skill runs — so a bare manifest-first resolution would test the *previously exported* version and report a PASS for the wrong version (silent false confidence). When the symlink matches `active_version` (or no `active` symlink exists), use `active_version`. See `{versionPathsKnowledge}` "Reading Workflows".
+3. If found: resolve to `{skill_package}` = `{skillsOutputFolder}/{skill_name}/{resolved_version}/{skill_name}/`
+4. If not in manifest: check for `active` symlink at `{skillsOutputFolder}/{skill_name}/active` — resolve to `{skill_group}/active/{skill_name}/`
+5. If neither: fall back to flat path `{skillsOutputFolder}/{skill_name}/`. If SKILL.md exists at the flat path, auto-migrate per `{versionPathsKnowledge}` migration rules
+6. Store the resolved path as `{resolved_skill_package}`
 
 Check that the skill package contains required files:
 


### PR DESCRIPTION
## Problem

In the canonical **SS→TS→EX** order, `create-stack-skill` flips the `active` symlink to the just-forged version, but the export manifest's `active_version` only advances when `export-skill` runs. Both reading workflows resolved the manifest's `active_version` **first** (the `active` symlink was a fallback used only when the skill was absent from the manifest), so in the window between forge and export a bare invocation resolved the *previously exported* version:

- **`test-skill`** — tested the prior version while the operator believed the just-forged version was under test: a silent false-confidence PASS for the wrong version.
- **`export-skill`** — re-loaded the prior version; because the published version is derived from `{resolved_skill_package}/metadata.json`, it wrote that stale version straight back as `active_version`, so the newly forged version could never be published without an explicit override.

## Change

Add a **manifest-lag guard** to both §2 resolvers: when the `active` symlink target differs from the manifest `active_version`, prefer the **symlink target** and emit an Info note. Document the rule once in `knowledge/version-paths.md` → "Reading Workflows".

- `knowledge/version-paths.md` — canonical "Reading Workflows" resolution gains the guard step.
- `skf-test-skill/references/init.md` §2 — guard + Info note ("…testing the symlink target; run export-skill to reconcile").
- `skf-export-skill/references/load-skill.md` §2 — guard + Info note. This makes the export publish the forged version; the existing §9b manifest write then adds the new `versions` entry, sets `active_version`, and archives the prior version — the `active_version` integrity invariant is preserved.

## Why it is regression-safe

The only place the symlink and manifest `active_version` can diverge is this forge→export lag:
- `drop-skill` — the **only** workflow that switches the active version — repoints the symlink to the manifest's `active_version` (`execute.md`), never leaving them diverged.
- No workflow flips the symlink **backward**.

So "prefer the symlink on divergence" can only ever correct the lag; it cannot override deliberate state.

## Impact review (other reading workflows)

- **`skf-audit-skill`** already implements an equivalent (richer, interactive) manifest-vs-symlink drift gate in `init.md` — already protected and now consistent with the documented canonical rule.
- **`skf-verify-stack` / `skf-refine-architecture`** resolve via deterministic helpers rather than prose and are outside the acute forge→export window; aligning those helpers to the canonical rule is a possible follow-up, not part of these findings.

Note: the findings' alternative "have the forge write the manifest at flip time" was deliberately **not** taken — it would make `create-stack-skill` claim an unexported version is `active`, desyncing the manifest from the actual managed section and breaking the `active_version` semantics (`active_version` = the last *exported* version; a freshly forged, unexported version is `draft`).

## Tests

Resolution is workflow prose (no script change), so no unit tests apply. Full `npm test` suite green (workflow/ref/skill validation, lint, format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)