### PR TITLE
fix(skf-analyze-source): validate generated briefs with the deterministic schema check

### DIFF
--- a/src/skf-analyze-source/references/generate-briefs.md
+++ b/src/skf-analyze-source/references/generate-briefs.md
@@ -1,6 +1,9 @@
 ---
 outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 schemaFile: 'assets/skill-brief-schema.md'
+validateBriefSchemaProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-validate-brief-schema.py'
+  - '{project-root}/src/shared/scripts/skf-validate-brief-schema.py'
 nextStepFile: 'health-check.md'
 ---
 
@@ -54,23 +57,39 @@ For EACH unit in `confirmed_units`, construct a skill-brief.yaml using:
 | scope.notes | Rationale from step 05 recommendation card |
 | description | Description from step 05 recommendation card |
 | forge_tier | `{forge_tier}` from frontmatter |
-| created | Current date (ISO format YYYY-MM-DD) |
+| created | Current date as a **quoted** string in ISO format `'YYYY-MM-DD'` — quote it so YAML stores it as text, not a parsed date object (the schema, and the §3a gate, require a string) |
 | created_by | `{user_name}` from frontmatter |
 
 ### 3. Validate Each Brief
 
-For each generated brief, check against {schemaFile} validation rules:
+Validation has two parts: a **deterministic schema gate** (authoritative for structure) and **semantic cross-checks** the schema cannot express. Run the schema gate first.
+
+**3a. Deterministic schema gate.** Resolve `{validateBriefSchemaHelper}` from `{validateBriefSchemaProbeOrder}` (first existing path wins; HALT with a clear message if no candidate exists). For each generated brief, pipe the *exact* assembled YAML to the helper:
+
+```bash
+uv run {validateBriefSchemaHelper} - <<'YAML'
+{assembled-brief-yaml}
+YAML
+```
+
+The script returns JSON `{valid, errors[], warnings[], halt_reason, brief}` — the same validator and contract `skf-brief-skill` runs at consumption time, so a brief that passes here will not be rejected there for structural reasons. Apply the result:
+
+- **`valid: false`** — the `errors[]` name the offending field (e.g. a `description` mis-indented under `scope:`, which leaves the required top-level `description` absent). Repair the assembled YAML and re-run the helper until `valid: true`. **Never write a brief that has not passed this gate.**
+- **`valid: true`** — carry any non-empty `warnings[]` into the §4 preview, then proceed.
+
+This catches structural YAML errors where they are created, rather than letting them surface downstream as a HALT in `skf-brief-skill`'s ratify path.
+
+**3b. Semantic cross-checks** (not expressible in the JSON schema — apply in addition to 3a):
 
 1. **Name uniqueness** — no duplicate names within the batch or existing skills
 2. **Source accessible** — project_path exists
 3. **Language recognized** — valid programming language identifier
-4. **Scope type valid** — matches `full-library`, `specific-modules`, `public-api`, `component-library`, `reference-app`, or `docs-only`
-5. **Include patterns** — at least one glob pattern present
-6. **Forge tier match** — matches forge_tier from config
+4. **Include patterns** — at least one glob pattern present (the schema requires the `scope.include` key but does not enforce a non-empty list)
+5. **Forge tier match** — matches forge_tier from config
 
-**If validation fails for any brief:**
+**If any check fails:**
 - Document the failure with specific field and reason
-- Present to user for correction before writing
+- Repair (3a structural errors) or present to user for correction (3b semantic issues) before writing
 - Do NOT write invalid briefs
 
 ### 4. Present Generation Preview
@@ -100,7 +119,7 @@ Wait for explicit user confirmation before writing files.
 
 For each confirmed brief:
 1. Create directory `{forge_data_folder}/{unit-name}/` if it does not exist
-2. Write `skill-brief.yaml` to `{forge_data_folder}/{unit-name}/skill-brief.yaml`
+2. Write `skill-brief.yaml` to `{forge_data_folder}/{unit-name}/skill-brief.yaml` — write the exact YAML that passed the §3a schema gate verbatim; do not re-serialize, so the bytes on disk are the bytes that validated
 3. Verify file was written successfully
 
 **IF user modifies (M):**


### PR DESCRIPTION
## Summary

`skf-analyze-source` step 6 (generate-briefs) §3 validated each generated brief with **LLM-judged rules only** — it never ran the deterministic `skf-validate-brief-schema.py` that `skf-brief-skill` runs at consumption time. So a structural YAML error in a generated brief passed at creation and only surfaced later as a HALT in brief-skill's ratify path (e.g. a `description` mis-indented under `scope:`, leaving the required top-level `description` absent).

## Changes

- **§3 deterministic schema gate** — for each assembled brief, run `skf-validate-brief-schema.py` (the same validator + contract brief-skill uses), resolved via a `validateBriefSchemaProbeOrder` frontmatter var that mirrors brief-skill's. Repair-and-revalidate on `valid:false`; never write a brief that hasn't passed. Structural errors are caught where they are created.
- **§3 semantic cross-checks retained** — the checks the JSON schema can't express (name uniqueness, source accessibility, language recognition, non-empty `scope.include`, forge-tier match) are kept; only `scope.type` enum validation (now schema-covered) was folded into the gate.
- **`created` field mapping** — now requires a quoted ISO string. Verified empirically: an unquoted `created: 2026-05-25` is parsed by YAML as a date object and rejected by the schema; `'2026-05-25'` passes. Hand-assembled briefs (this workflow) were the only path at risk — brief-skill writes dates via its script.
- **§5** — writes the exact bytes that passed the gate (no re-serialization).

## Validation

- Verified the validator's behavior directly via stdin: the valid case passes, and the `description`-under-`scope` case returns `valid:false` with `halt_reason: brief-invalid` naming the missing `description`.
- Full `npm test` green: 1521 Python tests, schema/CLI/workflow/knowledge suites, `validate:skills`, `validate:refs` (0 broken), `lint`, `lint:md`, `format:check`.

## Note

This is defense-in-depth, not duplication: it's the same script/schema as brief-skill's ratify path, resolved via the same probe-order, so there's no version skew — briefs are just validated earlier (at creation) in addition to at consumption.