### PR TITLE
docs(skf-analyze-source,skf-create-skill): document language references as a reference-app sub-shape

### DIFF
--- a/src/skf-analyze-source/assets/skill-brief-schema.md
+++ b/src/skf-analyze-source/assets/skill-brief-schema.md
@@ -88,8 +88,10 @@ scope:
 | specific-modules  | Selected components or packages                                                      |
 | public-api        | Only exported interfaces                                                             |
 | component-library | UI component libraries with registries, props-based APIs, and design system variants |
-| reference-app     | Whole app whose value is wiring patterns, not public exports (embedded sidecars, CLI demos, integration-pattern demonstrators) |
+| reference-app     | Whole app whose value is wiring patterns, not public exports (embedded sidecars, CLI demos, integration-pattern demonstrators). Also the home for **language / spec references** — engine- or spec-versioned query languages, grammars, or DSLs (e.g. SurrealQL) whose value is construct idioms, not exports. These have no separate scope type; they ride `reference-app` as a sub-shape (see `skf-create-skill` Language / spec-reference sub-shape) |
 | docs-only         | When source_type is docs-only — no source code available, all content from doc_urls  |
+
+> **Documented vs source language.** The `language` field records the language the skill *documents*. For a language / spec reference this may differ from the source language it is extracted from — e.g. a SurrealQL reference extracted from a Rust engine records `language: surrealql`, not `rust`. Use the documented language and a matching code-fence default (e.g. ` ```surql `) throughout the brief.
 
 ## YAML Template
 

--- a/src/skf-analyze-source/references/generate-briefs.md
+++ b/src/skf-analyze-source/references/generate-briefs.md
@@ -49,7 +49,7 @@ For EACH unit in `confirmed_units`, construct a skill-brief.yaml using:
 | name | Confirmed name from step 05 recommendation card |
 | version | Auto-detect from source (see schema Version Detection), fall back to `1.0.0` |
 | source_repo | `{project_paths[0]}` from frontmatter (or per-unit path if multi-repo) |
-| language | Primary language detected in step 03 |
+| language | Language the skill **documents** (primary language detected in step 03). For a language / spec reference this is the *documented* language, which may differ from the source language it is extracted from — e.g. a SurrealQL reference extracted from a Rust engine records `surrealql`, not `rust` (see {schemaFile} "Documented vs source language") |
 | scope.type | Scope type from step 05 recommendation card |
 | scope.include | Include patterns from step 05 recommendation card |
 | scope.exclude | Inferred from heuristics (test files, generated code) |

--- a/src/skf-analyze-source/references/recommend.md
+++ b/src/skf-analyze-source/references/recommend.md
@@ -57,7 +57,7 @@ For EACH qualifying unit, prepare a recommendation card:
 
 **Proposed Brief Fields:**
 - name: {suggested kebab-case name}
-- scope.type: {full-library / specific-modules / public-api / component-library}
+- scope.type: {full-library / specific-modules / public-api / component-library / reference-app / docs-only}
 - scope.include: {suggested glob patterns}
 - description: {suggested 1-3 sentence description}
 ```

--- a/src/skf-create-skill/assets/compile-assembly-rules.md
+++ b/src/skf-create-skill/assets/compile-assembly-rules.md
@@ -270,6 +270,24 @@ Replace per-function subsections with `references/pattern-*.md` groupings: one r
 - Do NOT fabricate signature / type-coverage data from pattern surfaces. skf-test-skill will skip those categories when metadata flags a reference-app (same skip path as `stackSkill` once that flag is wired — see scoring-rules.md).
 - Do NOT emit `effective_denominator` for reference-app scope, even when the source is a monorepo. `effective_denominator` counts public exports from the authoring-surface barrel — a library concept that `pattern_surfaces_documented` already replaces here. A reference-app-in-monorepo literally satisfies `compile.md` §4's emit-conditions (monorepo + non-`full-library` + stratified `scope.notes`), so this carve-out takes precedence: pattern-surface coverage is the reference-app basis, and skf-test-skill skips library-export coverage for it.
 
+**Language / spec-reference sub-shape:** A reference app that documents an engine- or spec-versioned **language** — a query language, grammar, or DSL (e.g. SurrealQL @ SurrealDB) whose value is construct idioms rather than wiring or exports — is a recognized reference-app sub-shape. Keep `scope.type: "reference-app"` (there is no separate enum value), so every carve-out above applies unchanged (`pattern_surfaces_documented` proxy, no `effective_denominator`, test-skill signature/type skip). Adapt the three overrides to the language's surface instead of app wiring:
+
+- **Section 4 (Pattern Surface)** becomes a **construct-area map**, not a wiring list. Each row is a language construct area, where it lives in the source, and what the user writes there:
+
+  ```markdown
+  ## Pattern Surface
+
+  | # | Construct Area | Where in Source | Purpose |
+  |---|----------------|-----------------|---------|
+  | 1 | {statements / DDL} | {sql::statements} | {what the user writes} |
+  | 2 | {operators} | {sql::operator} | {…} |
+  | … | … | … | … |
+  ```
+
+- **Section 3 (Adoption Steps)** becomes **production-task workflows** — ordered tasks a user performs *in the language* (define a schema, write a query, call a built-in function), each with a minimal snippet — not a copy-this-wiring narrative.
+- **Tier 2** groups `references/*.md` by **language concern** (e.g. `statements.md`, `functions.md`, `types.md`) — one file per construct family — instead of `pattern-*.md` wiring concerns.
+- **metadata.json:** `pattern_surfaces_documented` counts the documented construct areas; the no-`effective_denominator` carve-out applies (a language has no export barrel). The brief's `language` field records the **documented** language (e.g. `surrealql`), which may differ from the source language it was extracted from (e.g. `rust`) — see `skf-analyze-source/assets/skill-brief-schema.md`.
+
 **When this clause does NOT apply:** `full-library`, `specific-modules`, `public-api`, `component-library`, or `docs-only`. Those scope types have their own assembly semantics and export-count conventions — do not mix.
 
 ### Assembly Rules


### PR DESCRIPTION
## Summary

Language / spec references — engine- or spec-versioned query languages, grammars, or DSLs (e.g. SurrealQL @ SurrealDB) whose value is construct idioms rather than exports or app wiring — previously had to borrow the `reference-app` scope type with **no assembly guidance for their actual surface**, and the source-language assumption left nowhere to record a documented language that differs from the source.

This treats language references as a **documented sub-shape of `reference-app`** rather than introducing a new enum value. That keeps the change small and zero-risk on the deterministic layer: language references continue to score correctly on the (now-working) reference-app path — the SurrealQL skill already scored 100/100 riding on `reference-app`.

## Changes

- **`skf-create-skill` `compile-assembly-rules.md`** — adds a *Language / spec-reference sub-shape* block to the Reference-App Assembly Overrides: Pattern Surface becomes a construct-area map (area / where-in-source / purpose), Adoption Steps become production-task workflows, and Tier 2 groups `references/*.md` by language concern. Every reference-app carve-out (`pattern_surfaces_documented`, no `effective_denominator`, test-skill signature/type skip) applies unchanged.
- **`skf-analyze-source` `skill-brief-schema.md`** — documents the sub-shape in the scope-types table and adds a "documented vs source language" note (the `language` field records the *documented* language, which may differ from the source it's extracted from — e.g. `surrealql` from a Rust engine).
- **`skf-analyze-source` `generate-briefs.md`** — the `language` field mapping references the documented-vs-source convention.
- **`skf-analyze-source` `recommend.md`** — syncs the proposed-brief card's scope-type list, which was stale at four types, to the full six-type enum (pre-existing bug).

## Why a sub-shape, not a new enum value

A first-class `language-reference` enum value would require lockstep edits across two JSON schemas, four shared `VALID_SCOPE_TYPES` validators, a new auto-detection heuristic in `skf-recommend-scope-type.py`, and five test suites (~25 files) — with an open design question on detection. The findings explicitly endorse the sub-shape path until/unless that's warranted, and it delivers the actual value (assembly guidance + documented-language handling) without the churn.

## Validation

- No `.py` or `.json` files touched — the deterministic enum/validator surface is untouched by design.
- Full `npm test` green: 1521 Python tests, `validate:skills`, `validate:refs` (0 broken), `lint`, `lint:md`, `format:check`.

## Noted, not changed

`skf-analyze-source/references/map-and-detect.md` mandates an export-surface subagent fan-out with no reference-app carve-out — a pre-existing reference-app-wide gap (a reference app / language reference has no public-export barrel). It's broader than this sub-shape work and left for a separate reference-app fix; in practice the grammar-surface verification was substituted by hand without affecting the result.