### PR TITLE
fix(skf-manifest-ops): archive all stale active versions on set

### DIFF
--- a/src/shared/scripts/skf-manifest-ops.py
+++ b/src/shared/scripts/skf-manifest-ops.py
@@ -135,13 +135,17 @@ def cmd_set(manifest_path, skill_name, version, ides=None):
     existing = exports.get(skill_name, {})
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    # Preserve existing versions dict, archive the previously-active version
+    # Preserve existing versions dict, archive every *other* still-active version.
+    # Archiving by status (rather than only the entry matching the prior
+    # active_version) keeps a single active version even when active_version was
+    # advanced to this version before set() ran — otherwise the genuine prior
+    # version would stay active, breaking the single-active invariant. Idempotent.
     versions = existing.get("versions", {})
     if isinstance(versions, list):
         versions = {}  # Safety: handle any residual v1 data
-    old_active = existing.get("active_version")
-    if old_active and old_active in versions and old_active != version:
-        versions[old_active]["status"] = "archived"
+    for other_version, other_entry in versions.items():
+        if other_version != version and other_entry.get("status") == "active":
+            other_entry["status"] = "archived"
 
     # Add or update the new active version. Absent --ides preserves the
     # existing ides/platforms list verbatim (backward-compatible). When

--- a/test/test-skf-manifest-ops.py
+++ b/test/test-skf-manifest-ops.py
@@ -226,6 +226,56 @@ class TestManifestOps:
         entry = mod.cmd_get(manifest_path, "cocoindex")["entry"]["versions"]["2.0.0"]
         assert entry["ides"] == ["claude-code", "cursor"]
 
+    def test_set_archives_stranded_active_when_active_version_pre_advanced(self, manifest_path):
+        """S18: set archives any *other* still-active version, even when active_version
+        was advanced to the new version before set ran. Guards the single-active invariant
+        against a pre-advanced active_version (the genuine prior version must not stay active)."""
+        data = {
+            "schema_version": "2",
+            "exports": {
+                "cocoindex": {
+                    "active_version": "2.1.0",  # advanced to the new version before set ran
+                    "versions": {
+                        "2.0.0": {
+                            "ides": ["claude-code"],
+                            "last_exported": "2026-05-01",
+                            "status": "active",
+                        }
+                    },
+                }
+            },
+        }
+        manifest_path.write_text(json.dumps(data), encoding="utf-8")
+        mod.cmd_set(manifest_path, "cocoindex", "2.1.0")
+        entry = mod.cmd_get(manifest_path, "cocoindex")["entry"]
+        versions = entry["versions"]
+        assert entry["active_version"] == "2.1.0"
+        assert versions["2.1.0"]["status"] == "active"
+        assert versions["2.0.0"]["status"] == "archived"
+        # Exactly one active version remains.
+        assert [v for v, e in versions.items() if e["status"] == "active"] == ["2.1.0"]
+
+    def test_set_does_not_touch_deprecated_versions(self, manifest_path):
+        """S19: archiving other actives leaves deprecated versions untouched."""
+        data = {
+            "schema_version": "2",
+            "exports": {
+                "cocoindex": {
+                    "active_version": "2.0.0",
+                    "versions": {
+                        "1.0.0": {"ides": [], "last_exported": "2026-01-01", "status": "deprecated"},
+                        "2.0.0": {"ides": [], "last_exported": "2026-04-01", "status": "active"},
+                    },
+                }
+            },
+        }
+        manifest_path.write_text(json.dumps(data), encoding="utf-8")
+        mod.cmd_set(manifest_path, "cocoindex", "2.1.0")
+        versions = mod.cmd_get(manifest_path, "cocoindex")["entry"]["versions"]
+        assert versions["1.0.0"]["status"] == "deprecated"
+        assert versions["2.0.0"]["status"] == "archived"
+        assert versions["2.1.0"]["status"] == "active"
+
     def test_cli_set_parses_ides_flag(self, manifest_path):
         """S17: the `set ... --ides a,b` CLI dispatch path parses and unions the list."""
         script = Path(__file__).parent.parent / "src" / "shared" / "scripts" / "skf-manifest-ops.py"


### PR DESCRIPTION
## Problem

`skf-manifest-ops.py`'s `set` archived only the version whose key matched the prior `active_version`. When `active_version` was advanced to the *new* version before `set` ran, that guard matched nothing, so the genuine prior version stayed `status: active` — leaving **two active versions** and breaking the single-active invariant documented in `knowledge/version-paths.md`.

## Fix

`cmd_set` now archives **every other** still-active version instead of only the one matching the prior `active_version`:

- Idempotent and independent of `active_version`.
- `deprecated` entries are left untouched.
- Identical net behavior in the normal single-active update path.
- Enforces (rather than assumes) the single-active invariant.

## Tests

Adds two regression cases to `test/test-skf-manifest-ops.py`:
- a pre-advanced `active_version` strands the prior version under the old code (now archived correctly);
- archiving other actives does not disturb `deprecated` versions.

Full `npm test` suite passes (1521 Python tests + JS/lint/schema/refs validators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)