### PR TITLE
fix(skf-create-stack-skill): extract library catalog for large stacks

### DIFF
--- a/src/skf-create-stack-skill/assets/stack-skill-template.md
+++ b/src/skf-create-stack-skill/assets/stack-skill-template.md
@@ -49,6 +49,36 @@ description: >
 - {convention_2}
 ```
 
+## Sizing Guidance for Large Stacks
+
+A stack capstone grows monotonically as patterns and libraries are added, so a
+mature stack eventually pushes SKILL.md past skill-check's `body.max_lines`
+budget (default **500**) and/or the `description` past 1024 chars. Pre-empt both
+ceilings at compile time:
+
+- **Catalog placement.** The `Library Reference Index` table and `Per-Library
+  Summaries` are the largest, most reference-like sections. For a **large stack**
+  (heuristic: **> 6 libraries OR > 6 integration patterns**, the point at which
+  the inline catalog crowds the 500-line budget), author both into
+  `references/stack-catalog.md` and leave only an inline pointer in SKILL.md (see
+  below). For a **small stack**, keep them inline — inline passive context yields
+  higher task accuracy than on-demand retrieval, and small stacks fit comfortably.
+  Integration Patterns and Conventions stay inline regardless (Tier 1, load-bearing).
+- **Inline pointer form** (replaces the two sections above when extracted):
+
+  ```markdown
+  ## Library Catalog
+
+  {lib_count} libraries indexed in [references/stack-catalog.md](references/stack-catalog.md) —
+  reference-index table + per-library summaries. Load it for a specific library's exports or role.
+  ```
+
+- **Description cap.** Keep `description` ≤ 1024 chars. Do NOT enumerate every
+  library by name; the generic "{lib_count} libraries with {integration_count}
+  integration patterns" form already scales. If a per-library parenthetical is
+  used, cap it to the top libraries by import/export count with a `+{N} more`
+  suffix — the full list lives in `metadata.json` `libraries[]` and the catalog.
+
 ## context-snippet.md Format (Vercel-Aligned)
 
 Indexed format targeting ~80-120 tokens per stack:
@@ -105,6 +135,32 @@ Indexed format targeting ~80-120 tokens per stack:
   "dependencies": [],
   "compatibility": "{semver-range}"
 }
+```
+
+## references/stack-catalog.md Structure
+
+Written **only for large stacks** (see Sizing Guidance) when the catalog is
+extracted out of SKILL.md. Holds the two sections verbatim from the inline form:
+
+```markdown
+# {project_name} Stack — Library Catalog
+
+> Reference index + per-library summaries extracted from SKILL.md to keep the
+> capstone under the body-size budget. See SKILL.md for integration patterns.
+
+## Library Reference Index
+
+| Library | Imports | Key Exports | Confidence | Reference |
+|---------|---------|-------------|------------|-----------|
+| {name} | {count} | {top_exports} | {tier} | [ref](references/{name}.md) |
+
+## Per-Library Summaries
+
+### {library_name}
+**Role in stack:** {one-line description of what this library does in this project}
+**Key exports used:** {comma-separated list}
+**Usage pattern:** {brief pattern description}
+**Confidence:** {T1/T1-low/T2}
 ```
 
 ## references/{library}.md Structure

--- a/src/skf-create-stack-skill/references/compile-stack.md
+++ b/src/skf-create-stack-skill/references/compile-stack.md
@@ -41,7 +41,7 @@ description: >
 **Frontmatter rules:**
 
 - `name`: lowercase alphanumeric + hyphens only, must match skill output directory name. **Stack skills MUST end in `-stack`** (e.g., `{project_name}-stack`) — this is how consumers (skf-verify-stack, skf-test-skill) detect stack vs individual skills.
-- `description`: non-empty, max 1024 chars, trigger-optimized for agent discovery. MUST use third-person voice ("Processes..." not "I can..." or "You can...").
+- `description`: non-empty, max 1024 chars, trigger-optimized for agent discovery. MUST use third-person voice ("Processes..." not "I can..." or "You can..."). **Do NOT enumerate every library by name** — a 12+ library stack overruns 1024 chars. Keep the generic "{lib_count} libraries with {integration_count} integration patterns" form; if a per-library parenthetical is used, cap it to the top libraries by import/export count with a `+{N} more` suffix (full list lives in `metadata.json` `libraries[]`). See "Sizing Guidance for Large Stacks" in `{stackSkillTemplate}`.
 - No other frontmatter fields — only `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` are permitted by spec
 
 ### 3. Compile Integration Layer
@@ -68,6 +68,16 @@ description: >
 
 ### 4. Compile Per-Library Sections
 
+**Catalog placement (decide once, applies to this section and §6).** The
+`Per-Library Summaries` and `Library Reference Index` are the largest sections
+and grow with the stack. For a **large stack** (heuristic: **> 6 libraries OR
+> 6 integration patterns**), author both into `references/stack-catalog.md`
+(structure in `{stackSkillTemplate}`) and place only the inline pointer from the
+template's "Sizing Guidance" in SKILL.md — this keeps the body under the 500-line
+`body.max_lines` budget that step 08 enforces. For a **small stack**, keep both
+inline (inline passive context yields higher task accuracy). Either way, step 08's
+body-size gate is the backstop; step 08 (`validate.md` §4) accepts both forms.
+
 For each confirmed library (ordered by integration connectivity, then import count — **in compose-mode**, order by integration connectivity, then skill confidence tier since import counts are not available):
 
 - Role in stack (one-line description)
@@ -86,7 +96,8 @@ Extract project-specific conventions from the extractions:
 
 ### 6. Compile Library Reference Index
 
-Create the reference index table:
+Place per the §4 catalog-placement decision (inline for small stacks; in
+`references/stack-catalog.md` for large stacks). Create the reference index table:
 
 | Library | Imports | Key Exports | Confidence | Reference |
 |---------|---------|-------------|------------|-----------|

--- a/src/skf-create-stack-skill/references/generate-output.md
+++ b/src/skf-create-stack-skill/references/generate-output.md
@@ -109,6 +109,8 @@ Load structure from `{stackSkillTemplate}` references section:
 - Usage patterns with file:line citations (**in compose-mode**: usage patterns from source skill SKILL.md)
 - Confidence tier label
 
+**If the catalog was extracted** (large stack — step 06 §4 placed the `Library Reference Index` + `Per-Library Summaries` out of SKILL.md), also write `{skill_staging}/references/stack-catalog.md` using the structure in `{stackSkillTemplate}`, and confirm SKILL.md carries the inline pointer instead of the two sections. Small stacks keep the catalog inline and write no `stack-catalog.md`.
+
 ### 4. Stage Integration Pair Reference Files
 
 For each detected integration pair, write `{skill_staging}/references/integrations/{libraryA}-{libraryB}.md`:

--- a/src/skf-create-stack-skill/references/validate.md
+++ b/src/skf-create-stack-skill/references/validate.md
@@ -59,7 +59,7 @@ This validates frontmatter, description, body limits, links, formatting — and 
 
 **Post-fix provenance drift guard (S15):** If `fixed[]` is non-empty, `skill-check --fix` has modified `SKILL.md` after step 7 wrote it. The safe default for v1.0 is to emit a **WARNING** finding listing each auto-fix (`"skill-check --fix modified SKILL.md: {fix_description} — metadata.json hashes/provenance may be out of date"`). Do NOT silently accept the fixes without surfacing the drift. If the caller wants authoritative metadata, they should re-run the workflow.
 
-**If `body.max_lines` reported**, prefer selective split: extract only the largest Tier 2 section(s) to `references/`, keeping Tier 1 content inline (inline passive context achieves 100% task accuracy vs 79% for on-demand retrieval). Fall back to `npx skill-check split-body <skill-dir> --write` if not feasible. Verify `#quick-start` and `#key-types` anchors still resolve after split. Then re-validate.
+**If `body.max_lines` reported**, prefer selective split: extract only the largest Tier 2 section(s) to `references/`, keeping Tier 1 content inline (inline passive context achieves 100% task accuracy vs 79% for on-demand retrieval). For a stack capstone the canonical split is the catalog (`Library Reference Index` + `Per-Library Summaries`) → `references/stack-catalog.md`, leaving an inline pointer (see `{stackSkillTemplate}` "Sizing Guidance"). This is the **intended** large-stack layout, not a violation: §4 below accepts the pointer form, so clearing the skill-check body ERROR this way does not also trip the structure check. Fall back to `npx skill-check split-body <skill-dir> --write` if not feasible. Verify any in-SKILL.md anchor links (e.g. to the catalog/pointer or other moved sections) still resolve after the split. Then re-validate.
 
 **If unavailable**, perform manual frontmatter check:
 - [ ] Frontmatter present with `---` delimiters
@@ -75,11 +75,14 @@ Load `{stackSkillTemplate}` and verify SKILL.md contains expected sections:
 
 - [ ] Header with project name, library count, integration count, forge tier
 - [ ] Integration Patterns section (before per-library summaries)
-- [ ] Library Reference Index table
-- [ ] Per-Library Summaries section
 - [ ] Conventions section
+- [ ] **Catalog** — `Library Reference Index` table + `Per-Library Summaries`, in **either** form:
+  - *Inline* (small stacks): both sections present in SKILL.md, **or**
+  - *Pointer* (large stacks): a `Library Catalog` pointer to `references/stack-catalog.md`, **and** that file exists and contains both sections.
 
-Record missing sections as **WARNING** findings.
+  Accept either form — do not WARN when the catalog has been extracted to clear the `body.max_lines` budget (§3). Only record a **WARNING** when *neither* the inline sections *nor* a pointer-plus-`stack-catalog.md` is present, or when the pointer's target file is missing.
+
+Record other missing sections (Header, Integration Patterns, Conventions) as **WARNING** findings.
 
 ### 5. Validate metadata.json Fields
 


### PR DESCRIPTION
## Problem

A stack capstone grows monotonically as integration patterns and libraries accumulate, so a mature stack eventually trips two skill-check ceilings:

- **`body.max_lines`** (default 500) — the required-inline sections plus a handful of patterns already consume most of the budget, so the next pattern of any size fails.
- **description length** (1024 chars) — a per-library parenthetical in a large stack overruns the limit.

The validate step also **contradicted itself**: §3 instructs the author to extract the largest sections to get under `body.max_lines`, while §4 recorded a WARNING when `Library Reference Index` / `Per-Library Summaries` were not inline. Doing the prescribed fix necessarily tripped the structure check.

## Fix

Workflow-doc changes across the create-stack-skill steps (these are LLM-executed instruction docs, not code):

- **Large stacks** (heuristic: >6 libraries or >6 integration patterns) author `Library Reference Index` + `Per-Library Summaries` into `references/stack-catalog.md` with an inline pointer; **small stacks** keep them inline (inline passive context yields higher task accuracy). Integration Patterns and Conventions stay inline regardless.
- **`validate.md` §4** now accepts *either* the inline form *or* the pointer-plus-`stack-catalog.md` form, so the §3 body-size fix no longer trips the §4 structure check. The conditional catalog file is **not** added to the unconditional file-existence ERROR check, so small stacks never falsely error.
- **Description cap**: do not enumerate every library; the generic "{lib_count} libraries with {integration_count} patterns" form scales, and the full list lives in `metadata.json` `libraries[]`.
- Adds the `stack-catalog.md` structure and "Sizing Guidance" to the template; wires conditional staging in `generate-output.md`.

Also corrects a stale instruction in `validate.md` §3 (it referenced `#quick-start`/`#key-types` anchors that exist in individual-skill SKILL.md but not in a stack SKILL.md) to generic anchor-resolution guidance.

## Verification

Full `npm test` suite passes on the rebased branch (1523 Python tests + JS/lint/markdownlint/schema/refs validators). No workflow file added or removed, so installation-component tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)