### PR TITLE
fix(shared/scripts): close three health-check gaps

### DIFF
--- a/src/shared/scripts/skf-forge-tier-rw.py
+++ b/src/shared/scripts/skf-forge-tier-rw.py
@@ -42,6 +42,17 @@ Subcommands:
                 collections without re-rendering the whole file in
                 prose.
 
+  register-ccc-index
+                Append-or-replace a single entry in the
+                `ccc_index_registry` array. Reads the entry as JSON on
+                stdin (must include `source_repo` and `skill_name`;
+                composite key `source_repo`+`skill_name` is the upsert
+                key — existing entry with the same composite key is
+                replaced, otherwise appended). All other forge-tier
+                state is preserved verbatim. Used by skf-create-skill
+                §6b to register CCC-indexed source paths without
+                re-rendering the whole file in prose.
+
   clean-stale   Two cleanup operations gated by flags:
                   --qmd-live-names a,b,c — remove qmd_collections
                     entries whose `name` is not in the comma-separated
@@ -74,6 +85,7 @@ system-wide:
   uv run skf-forge-tier-rw.py read --target /path/forge-tier.yaml
   echo '{...}' | uv run skf-forge-tier-rw.py write-tools --target /path/forge-tier.yaml
   uv run skf-forge-tier-rw.py init-prefs --target /path/preferences.yaml
+  echo '{...}' | uv run skf-forge-tier-rw.py register-ccc-index --target /path/forge-tier.yaml
   uv run skf-forge-tier-rw.py clean-stale --target /path/forge-tier.yaml \\
       --qmd-live-names foo-brief,bar-extraction --prune-missing-ccc-paths
 """
@@ -373,6 +385,61 @@ def cmd_register_qmd_collection(target: Path) -> None:
     })
 
 
+def cmd_register_ccc_index(target: Path) -> None:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        _die(1, "register-ccc-index: empty stdin (expected JSON entry)")
+    try:
+        entry = json.loads(raw)
+    except json.JSONDecodeError as e:
+        _die(1, f"register-ccc-index: invalid JSON on stdin: {e}")
+
+    if not isinstance(entry, dict):
+        _die(1, "register-ccc-index: entry must be a JSON object")
+    source_repo = entry.get("source_repo")
+    skill_name = entry.get("skill_name")
+    if not source_repo or not isinstance(source_repo, str):
+        _die(1, "register-ccc-index: entry must include a non-empty 'source_repo' string")
+    if not skill_name or not isinstance(skill_name, str):
+        _die(1, "register-ccc-index: entry must include a non-empty 'skill_name' string")
+
+    data = _read_yaml(target)
+    if data is None:
+        _die(1, f"register-ccc-index: target does not exist: {target}. "
+                f"Run setup workflow first to create forge-tier.yaml.")
+
+    registry = list(data.get("ccc_index_registry") or [])
+    replaced = False
+    for i, existing in enumerate(registry):
+        if (isinstance(existing, dict)
+                and existing.get("source_repo") == source_repo
+                and existing.get("skill_name") == skill_name):
+            registry[i] = entry
+            replaced = True
+            break
+    if not replaced:
+        registry.append(entry)
+
+    payload = {
+        "tools": data.get("tools", {}),
+        "tier": data.get("tier", "Quick"),
+        "tier_detected_at": data.get("tier_detected_at",
+                                     datetime.now(timezone.utc).isoformat()),
+        "ccc_index": data.get("ccc_index", {}),
+        "ccc_index_registry": registry,
+        "qmd_collections": data.get("qmd_collections", []),
+    }
+    rendered = render_forge_tier_yaml(payload)
+    _atomic_write(target, rendered)
+    _ok({
+        "source_repo": source_repo,
+        "skill_name": skill_name,
+        "action": "replaced" if replaced else "appended",
+        "ccc_index_registry_count": len(registry),
+        "wrote": str(target),
+    })
+
+
 def cmd_clean_stale(target: Path, qmd_live_names: list[str] | None,
                     prune_missing_ccc_paths: bool) -> None:
     data = _read_yaml(target)
@@ -468,6 +535,10 @@ def main() -> None:
                                 help="Append-or-replace a single qmd_collections entry by name")
     p_register.add_argument("--target", type=Path, required=True)
 
+    p_ccc = sub.add_parser("register-ccc-index",
+                           help="Append-or-replace a single ccc_index_registry entry by source_repo+skill_name")
+    p_ccc.add_argument("--target", type=Path, required=True)
+
     args = parser.parse_args()
 
     if args.cmd == "read":
@@ -483,6 +554,8 @@ def main() -> None:
         cmd_clean_stale(args.target, live, args.prune_missing_ccc_paths)
     elif args.cmd == "register-qmd-collection":
         cmd_register_qmd_collection(args.target)
+    elif args.cmd == "register-ccc-index":
+        cmd_register_ccc_index(args.target)
 
 
 if __name__ == "__main__":

--- a/src/shared/scripts/skf-validate-frontmatter.py
+++ b/src/shared/scripts/skf-validate-frontmatter.py
@@ -21,6 +21,7 @@ system-wide:
   uv run skf-validate-frontmatter.py <skill-md-path>
   uv run skf-validate-frontmatter.py <skill-md-path> --skill-dir-name <name>
   uv run skf-validate-frontmatter.py <skill-md-path> --max-body-lines 500
+  uv run skf-validate-frontmatter.py <skill-md-path> --max-body-lines 500 --max-body-tokens 5000
 
 Input:
   Path to a SKILL.md file.
@@ -31,6 +32,11 @@ Input:
   exceeds N lines. Opt-in — when omitted, body size is never checked and
   the verdict is unchanged. Callers pass the skill-check `body.max_lines`
   default (500) to pre-catch that hard reject before commit.
+  Optional --max-body-tokens N: when set, emit a high-severity `body`
+  issue if the estimated body token count exceeds N. Token count is
+  estimated as ceil(character_count / 4). Callers pass the skill-check
+  `body.max_tokens` default (5000) to pre-catch that soft/hard reject
+  before commit.
 
 Output:
   JSON object:
@@ -154,6 +160,28 @@ def body_line_count(content: str) -> int | None:
     return len(lines) - (closing + 1)
 
 
+def body_token_estimate(content: str) -> int | None:
+    """Estimate the SKILL.md body token count as ceil(char_count / 4).
+
+    Returns None when the frontmatter delimiters are absent or unclosed
+    (same boundary condition as body_line_count). The heuristic matches
+    the agentskills.io spec's token estimation convention.
+    """
+    if not content.startswith("---\n") and not content.startswith("---\r\n"):
+        return None
+    lines = content.splitlines()
+    closing = -1
+    for i in range(1, len(lines)):
+        if lines[i] == "---":
+            closing = i
+            break
+    if closing == -1:
+        return None
+    body = "\n".join(lines[closing + 1:])
+    char_count = len(body)
+    return -(-char_count // 4)  # ceil division
+
+
 def _validate_name(name: str, skill_dir_name: str | None) -> list[dict]:
     """Validate skill name format. Aligned with canonical validator.py."""
     issues: list[dict] = []
@@ -220,14 +248,16 @@ def validate_frontmatter(
     content: str,
     skill_dir_name: str | None = None,
     max_body_lines: int | None = None,
+    max_body_tokens: int | None = None,
 ) -> dict:
     """Validate SKILL.md frontmatter against agentskills.io spec.
 
     When `max_body_lines` is set, additionally emit a high-severity `body`
-    issue if the body exceeds that many lines (opt-in — the verdict is
-    unchanged when it is None, so the other consumers of this validator are
-    unaffected). Returns a result dict with status, issues, frontmatter,
-    body_lines, and summary.
+    issue if the body exceeds that many lines. When `max_body_tokens` is
+    set, emit a high-severity `body` issue if the estimated token count
+    exceeds that limit. Both are opt-in — the verdict is unchanged when
+    they are None. Returns a result dict with status, issues, frontmatter,
+    body_lines, body_tokens, and summary.
     """
     fm, issues = parse_frontmatter(content)
 
@@ -237,6 +267,14 @@ def validate_frontmatter(
             "severity": "high",
             "field": "body",
             "message": f"body lines {body_lines} exceeds max {max_body_lines}",
+        })
+
+    body_tokens = body_token_estimate(content)
+    if max_body_tokens is not None and body_tokens is not None and body_tokens > max_body_tokens:
+        issues.append({
+            "severity": "high",
+            "field": "body",
+            "message": f"body token estimate {body_tokens} exceeds max {max_body_tokens}",
         })
 
     if fm is not None:
@@ -301,6 +339,7 @@ def validate_frontmatter(
         "issues": issues,
         "frontmatter": fm,
         "body_lines": body_lines,
+        "body_tokens": body_tokens,
         "summary": {
             "total": len(issues),
             **severity_counts,
@@ -346,6 +385,18 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--max-body-tokens",
+        metavar="N",
+        type=int,
+        default=None,
+        help=(
+            "when set, emit a high-severity 'body' issue if the estimated body "
+            "token count exceeds N (opt-in; omitted = body tokens not checked). "
+            "Token estimate uses ceil(char_count / 4). Pass the skill-check "
+            "body.max_tokens default (5000) to pre-catch that reject."
+        ),
+    )
+    parser.add_argument(
         "-o", "--output",
         metavar="FILE",
         help="write JSON output to FILE instead of stdout",
@@ -365,7 +416,7 @@ def main() -> int:
     else:
         content = skill_md_path.read_text(encoding="utf-8")
         skill_dir_name = args.skill_dir_name or skill_md_path.parent.name
-        result = validate_frontmatter(content, skill_dir_name, args.max_body_lines)
+        result = validate_frontmatter(content, skill_dir_name, args.max_body_lines, args.max_body_tokens)
 
     output_text = json.dumps(result, indent=2)
 

--- a/src/skf-create-skill/references/generate-artifacts.md
+++ b/src/skf-create-skill/references/generate-artifacts.md
@@ -195,19 +195,14 @@ Ensure the source path used for extraction is indexed by ccc and registered in t
 
 **Registry update:**
 
-Read `{forgeTierConfig}` and update the `ccc_index_registry` array **under an exclusive `flock` on `{sidecar_path}/forge-tier.yaml.lock`** (same pattern as §6 — acquire lock → read → modify → atomic write via `skf-atomic-write.py write` → release). If `flock` is unavailable, fall back to read-CAS-by-mtime.
+Register the indexed source path via `register-ccc-index` (comment-preserving round-trip, same pattern as §6's `register-qmd-collection`). Acquire an exclusive `flock` on `{sidecar_path}/forge-tier.yaml.lock`, then:
 
-Deduplicate by `source_repo` + `skill_name` (NOT local `path`, which may be ephemeral). Replace existing match or append:
-
-```yaml
-  - source_repo: "{brief.source_repo}"
-    path: "{source_root}"
-    skill_name: "{name}"
-    indexed_at: "{current ISO date}"
-    source_workflow: "create-skill"
+```bash
+echo '{"source_repo":"{brief.source_repo}","path":"{source_root}","skill_name":"{name}","indexed_at":"{current ISO date}","source_workflow":"create-skill"}' \
+  | uv run {forgeTierRw} register-ccc-index --target {forgeTierConfig}
 ```
 
-Write the updated forge-tier.yaml.
+Deduplicates by `source_repo` + `skill_name` (NOT local `path`, which may be ephemeral). Release the lock after the command completes. If `flock` is unavailable, fall back to read-CAS-by-mtime.
 
 **Error handling:** If ccc indexing or registry update fails, log and continue — do NOT fail the workflow.
 

--- a/src/skf-create-stack-skill/references/generate-output.md
+++ b/src/skf-create-stack-skill/references/generate-output.md
@@ -226,19 +226,19 @@ Use the schema from `{provenanceMapSchemaPath}` — see that asset for the canon
 
 ### 8. Pre-Commit Frontmatter & Body-Size Gate
 
-The full schema/frontmatter validation runs in step 8 (`validate.md`) — but that runs *after* commit-dir and flip-link have already published the package. The two most common non-auto-fixable `skill-check` hard rejects — a `description` over the 1024-char limit (which `skill-check --fix` cannot trim for you) and a SKILL.md body over the `body.max_lines` limit (default **500**) — would therefore only surface on an already-committed, symlink-active artifact, forcing edits to the live `SKILL.md`. Additive re-composition of an already-large stack grows the body monotonically, so the body overflow is the likeliest trigger. Catch both here, while the package is still in `.skf-tmp`.
+The full schema/frontmatter validation runs in step 8 (`validate.md`) — but that runs *after* commit-dir and flip-link have already published the package. The most common non-auto-fixable `skill-check` hard rejects — a `description` over the 1024-char limit (which `skill-check --fix` cannot trim for you), a SKILL.md body over the `body.max_lines` limit (default **500**), and a body exceeding the `body.max_tokens` limit (default **5000**) — would therefore only surface on an already-committed, symlink-active artifact, forcing edits to the live `SKILL.md`. Additive re-composition of an already-large stack grows the body monotonically, so body overflow (lines or tokens) is the likeliest trigger. Catch all three here, while the package is still in `.skf-tmp`.
 
-Resolve `{frontmatterValidator}` from `{frontmatterValidatorProbeOrder}` (first existing path wins). Run it against the **staged** `SKILL.md`, passing the real skill name so the directory-match check is not fooled by the `.skf-tmp` staging suffix, and `--max-body-lines 500` to assert the skill-check body limit pre-commit:
+Resolve `{frontmatterValidator}` from `{frontmatterValidatorProbeOrder}` (first existing path wins). Run it against the **staged** `SKILL.md`, passing the real skill name so the directory-match check is not fooled by the `.skf-tmp` staging suffix, `--max-body-lines 500` to assert the skill-check body-line limit, and `--max-body-tokens 5000` to assert the skill-check body-token limit pre-commit:
 
 ```bash
-uv run {frontmatterValidator} {skill_staging}/SKILL.md --skill-dir-name {project_name}-stack --max-body-lines 500
+uv run {frontmatterValidator} {skill_staging}/SKILL.md --skill-dir-name {project_name}-stack --max-body-lines 500 --max-body-tokens 5000
 ```
 
-The validator emits JSON: `status` (`pass`/`warn`/`fail`), `issues[]` (each with `severity` ∈ `high|medium|low`, `field`, `message`), `body_lines` (the counted body size), and `summary`. Disposition:
+The validator emits JSON: `status` (`pass`/`warn`/`fail`), `issues[]` (each with `severity` ∈ `high|medium|low`, `field`, `message`), `body_lines` (the counted body size), `body_tokens` (the estimated token count), and `summary`. Disposition:
 
 - **`status` is `fail`, OR any `issues[]` entry has `severity` `high` or `medium`** — a hard violation that `npx skill-check` (step 8) would reject and `--fix` cannot auto-correct. HALT-to-fix **in staging**, then re-run the validator until it clears. Remediate by `field`:
   - `description` / `name` / `compatibility` — trim/correct `{skill_staging}/SKILL.md` (e.g. shorten `description` to ≤ 1024 chars).
-  - `body` (`body lines N exceeds max 500`) — reduce the staged body: prefer a **selective split** of the largest Tier-2 section(s) into `{skill_staging}/references/`, keeping Tier-1 content inline (mirrors `validate.md` §3); or trim redundant content. Re-run the gate until `body_lines ≤ 500`.
+  - `body` (`body lines N exceeds max 500` or `body token estimate N exceeds max 5000`) — reduce the staged body: prefer a **selective split** of the largest Tier-2 section(s) into `{skill_staging}/references/`, keeping Tier-1 content inline (mirrors `validate.md` §3); or trim redundant content. Re-run the gate until both `body_lines ≤ 500` and `body_tokens ≤ 5000`.
 
   Do NOT proceed to §9 commit-dir with an unresolved high/medium issue. Note: an over-long `description` is rated `medium` and exits `0`, so key the HALT on the issue severities above — not on the exit code.
 - **Only `low`-severity issues (e.g. an unexpected field)** — record each as a WARNING in the evidence report and proceed; these do not block the commit.

--- a/src/skf-test-skill/references/source-access-protocol.md
+++ b/src/skf-test-skill/references/source-access-protocol.md
@@ -58,6 +58,20 @@
 
   **When this clause does NOT apply:** any repo with a non-empty barrel file, any monorepo (use the stratified-scope clause), or any single-package repo whose `scope.type` is explicitly `public-api` / `specific-modules` / `component-library` / `docs-only` (those scope types have their own denominator semantics). Also does NOT apply when `scope.type: "reference-app"` — that scope type carries its own pattern-surface denominator semantics (the brief speaks for itself), so this clause's filesystem trigger is moot.
 
+- **Single-crate curated subset (`scope.type: "specific-modules"`):** If the source is a single-package (non-monorepo) repo whose skill brief sets `scope.type: "specific-modules"` and uses `scope.include`/`scope.exclude` to carve a subset of the crate's public surface, the coverage denominator is the **in-scope reachable barrel** — not the full barrel.
+
+  **Resolution:** Derive the barrel as normal for the language (e.g., Rust: `pub use` chain from `lib.rs`), then filter:
+
+  1. **Exclude** any modules or items that fall under `scope.exclude` patterns.
+  2. **Include only** items reachable from the modules listed in `scope.include`.
+  3. **Respect module visibility:** items behind `mod` (not `pub mod`) boundaries that are not re-exported through the barrel are unreachable and excluded. For Rust: count only unrestricted, module-level (column-0) `pub` item declarations in barrel-reachable modules; exclude `pub(crate)` / `pub(super)` / `pub(in …)` restricted items.
+
+  The resulting count is the denominator. Annotate the coverage report with: `Specific-modules subset — denominator: in-scope reachable barrel ({N} items from {M} modules, after scope.include/exclude filtering)`.
+
+  **When `effective_denominator` is present:** prefer `metadata.json.stats.effective_denominator` (same priority-1 rule as the stratified-scope clause), subject to the same deflation guard.
+
+  **When this clause does NOT apply:** monorepo packages (use the stratified-scope clause), `scope.type: "full-library"` (use the standard barrel), or empty-barrel packages (use the empty-barrel clause). This clause is specifically for single-crate repos where the brief intentionally documents a curated subset rather than the full public surface.
+
 Internal module symbols are **excluded** from the coverage denominator unless they are explicitly documented in SKILL.md (in which case they count as documented extras, not missing coverage).
 
 This matches the extraction-patterns.md convention used during skill creation: coverage measures how well SKILL.md documents what users actually import, not the entire internal codebase.

--- a/test/test-skf-forge-tier-rw.py
+++ b/test/test-skf-forge-tier-rw.py
@@ -564,6 +564,125 @@ def test_register_qmd_missing_target_is_user_error(tmp_target):
     assert "does not exist" in stderr
 
 
+# ─── End-to-end: register-ccc-index subcommand via subprocess ────────────────
+
+
+def _register_ccc(target: Path, entry: dict) -> tuple[int, dict, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "register-ccc-index",
+         "--target", str(target)],
+        input=json.dumps(entry),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    payload = json.loads(result.stdout) if result.stdout.strip() else {}
+    return result.returncode, payload, result.stderr
+
+
+def test_register_ccc_appends_when_key_is_new(tmp_target):
+    _write_tools(tmp_target, _baseline_payload())
+    code, response, _ = _register_ccc(tmp_target, {
+        "source_repo": "https://github.com/test/repo",
+        "skill_name": "test-skill",
+        "path": "/tmp/test",
+        "indexed_at": "2026-05-25T14:00:00Z",
+        "source_workflow": "create-skill",
+    })
+    assert code == 0
+    assert response["action"] == "appended"
+    assert response["ccc_index_registry_count"] == 1
+
+    persisted = _read_yaml_file(tmp_target)
+    assert len(persisted["ccc_index_registry"]) == 1
+    assert persisted["ccc_index_registry"][0]["skill_name"] == "test-skill"
+
+
+def test_register_ccc_replaces_when_composite_key_collides(tmp_target):
+    payload = _baseline_payload()
+    payload["ccc_index_registry"] = [
+        {"source_repo": "https://github.com/test/repo", "skill_name": "test-skill",
+         "path": "/old/path", "indexed_at": "2025-01-01"},
+        {"source_repo": "https://github.com/other/repo", "skill_name": "other-skill",
+         "path": "/other", "indexed_at": "2025-01-01"},
+    ]
+    _write_tools(tmp_target, payload)
+
+    code, response, _ = _register_ccc(tmp_target, {
+        "source_repo": "https://github.com/test/repo",
+        "skill_name": "test-skill",
+        "path": "/new/path",
+        "indexed_at": "2026-05-25T15:00:00Z",
+        "source_workflow": "create-skill",
+    })
+    assert code == 0
+    assert response["action"] == "replaced"
+    assert response["ccc_index_registry_count"] == 2
+
+    persisted = _read_yaml_file(tmp_target)
+    by_skill = {e["skill_name"]: e for e in persisted["ccc_index_registry"]}
+    assert by_skill["test-skill"]["path"] == "/new/path"
+    assert by_skill["other-skill"]["path"] == "/other"
+
+
+def test_register_ccc_preserves_unrelated_state(tmp_target):
+    payload = _baseline_payload()
+    payload["qmd_collections"] = [{"name": "foo-brief", "type": "brief"}]
+    payload["ccc_index"]["staleness_threshold_hours"] = 99
+    _write_tools(tmp_target, payload)
+
+    _register_ccc(tmp_target, {
+        "source_repo": "https://github.com/x/y",
+        "skill_name": "x",
+        "path": "/x",
+        "indexed_at": "2026-05-25",
+        "source_workflow": "create-skill",
+    })
+
+    persisted = _read_yaml_file(tmp_target)
+    assert persisted["qmd_collections"] == [{"name": "foo-brief", "type": "brief"}]
+    assert persisted["ccc_index"]["staleness_threshold_hours"] == 99
+    assert persisted["tier"] == payload["tier"]
+
+
+def test_register_ccc_rejects_missing_source_repo(tmp_target):
+    _write_tools(tmp_target, _baseline_payload())
+    code, _, stderr = _register_ccc(tmp_target, {"skill_name": "x", "path": "/x"})
+    assert code == 1
+    assert "source_repo" in stderr
+
+
+def test_register_ccc_rejects_missing_skill_name(tmp_target):
+    _write_tools(tmp_target, _baseline_payload())
+    code, _, stderr = _register_ccc(tmp_target, {"source_repo": "https://github.com/x/y", "path": "/x"})
+    assert code == 1
+    assert "skill_name" in stderr
+
+
+def test_register_ccc_rejects_empty_stdin(tmp_target):
+    _write_tools(tmp_target, _baseline_payload())
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "register-ccc-index",
+         "--target", str(tmp_target)],
+        input="",
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 1
+    assert "empty stdin" in result.stderr
+
+
+def test_register_ccc_missing_target_is_user_error(tmp_target):
+    code, _, stderr = _register_ccc(tmp_target, {
+        "source_repo": "https://github.com/x/y",
+        "skill_name": "x",
+        "path": "/x",
+        "indexed_at": "2026-05-25",
+        "source_workflow": "create-skill",
+    })
+    assert code == 1
+    assert "does not exist" in stderr
+
+
 class TestAtomicWriteBinary:
     """_atomic_write persists content verbatim — no CRLF injection on Windows."""
 

--- a/test/test-skf-validate-frontmatter.py
+++ b/test/test-skf-validate-frontmatter.py
@@ -335,3 +335,78 @@ class TestBodyMaxLinesGate:
         missing-delimiter error is reported by frontmatter parsing instead)."""
         r = validate_frontmatter("---\nname: foo\n", "foo", max_body_lines=500)
         assert not any(i["field"] == "body" for i in r["issues"])
+
+
+def _skill_md_with_dense_body(n_chars: int) -> str:
+    """Build a valid SKILL.md whose body is short in lines but dense in chars."""
+    body = "x" * n_chars + "\n"
+    return f"---\nname: my-skill\ndescription: hello\n---\n{body}"
+
+
+class TestBodyTokenEstimate:
+    def test_body_tokens_present_in_output(self):
+        """body_tokens is an additive output field (backward-compatible)."""
+        r = validate_frontmatter(VALID_SKILL_MD, "my-skill")
+        assert "body_tokens" in r
+        assert isinstance(r["body_tokens"], int)
+
+    def test_body_tokens_calculation(self):
+        """Token estimate = ceil(char_count / 4)."""
+        content = _skill_md_with_dense_body(100)
+        r = validate_frontmatter(content, "my-skill")
+        assert r["body_tokens"] == 25  # ceil(100/4) — 100 x-chars
+
+    def test_body_tokens_none_without_closing_delimiter(self):
+        r = validate_frontmatter("---\nname: foo\n", "foo")
+        assert r["body_tokens"] is None
+
+    def test_body_tokens_none_without_opening_delimiter(self):
+        r = validate_frontmatter("name: foo\n---\nbody\n", "foo")
+        assert r["body_tokens"] is None
+
+
+class TestBodyMaxTokensGate:
+    def test_no_check_when_flag_unset(self):
+        """Opt-in: an over-token body is ignored when max_body_tokens is None."""
+        r = validate_frontmatter(_skill_md_with_dense_body(25000), "my-skill")
+        assert r["status"] == "pass"
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_exceeds_max_emits_high_body_issue(self):
+        content = _skill_md_with_dense_body(20100)  # ceil(20101/4) = 5026 > 5000
+        r = validate_frontmatter(content, "my-skill", max_body_tokens=5000)
+        assert r["status"] == "fail"
+        body_issues = [i for i in r["issues"] if i["field"] == "body"]
+        assert len(body_issues) == 1
+        assert body_issues[0]["severity"] == "high"
+        assert "token estimate" in body_issues[0]["message"]
+        assert "exceeds max 5000" in body_issues[0]["message"]
+
+    def test_at_limit_passes(self):
+        """Strict `>`: a body exactly at the limit does not trip the gate."""
+        content = _skill_md_with_dense_body(19999)  # ceil(20000/4) = 5000 == 5000
+        r = validate_frontmatter(content, "my-skill", max_body_tokens=5000)
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_under_limit_passes(self):
+        content = _skill_md_with_dense_body(100)  # 26 tokens
+        r = validate_frontmatter(content, "my-skill", max_body_tokens=5000)
+        assert r["status"] == "pass"
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_undefined_body_does_not_trip_token_gate(self):
+        """No closing delimiter → body_tokens None → no body issue."""
+        r = validate_frontmatter("---\nname: foo\n", "foo", max_body_tokens=5000)
+        assert not any(i["field"] == "body" for i in r["issues"])
+
+    def test_dense_body_under_line_limit_but_over_token_limit(self):
+        """The exact scenario from fp-b842e0e: under 500 lines but over 5000 tokens."""
+        lines = ["x" * 120] * 200
+        body = "\n".join(lines) + "\n"
+        content = f"---\nname: my-skill\ndescription: hello\n---\n{body}"
+        r = validate_frontmatter(content, "my-skill", max_body_lines=500, max_body_tokens=5000)
+        assert r["body_lines"] == 200  # under 500 line limit
+        assert r["body_tokens"] > 5000  # over token limit
+        body_issues = [i for i in r["issues"] if i["field"] == "body"]
+        assert len(body_issues) == 1  # only token issue fires, not line
+        assert "token estimate" in body_issues[0]["message"]


### PR DESCRIPTION
## Summary

- **Add `register-ccc-index` subcommand** to `skf-forge-tier-rw.py` — mirrors `register-qmd-collection` with composite dedup key (`source_repo`+`skill_name`) and comment-preserving round-trip; update `generate-artifacts.md` §6b to route through it instead of manual YAML read-modify-write
- **Add `--max-body-tokens` flag** to `skf-validate-frontmatter.py` — estimates tokens as `ceil(chars/4)` and emits high-severity body issue when exceeded; update `generate-output.md` §8 pre-commit gate to pass `--max-body-tokens 5000` alongside `--max-body-lines 500`
- **Add single-crate `specific-modules` denominator clause** to `source-access-protocol.md` — defines in-scope reachable barrel as the denominator so testers no longer ad-hoc derive it

Also verified that the manifest-ops finding (fp-77968eb) was already fixed in commit 73271874.

Deferred two design-heavy analyze-source gaps as tracked issues: #405 (multi-ref composite source) and #406 (composite unit merge in identify-units).

## Test plan

- [x] All 1540 Python tests pass (17 new tests for register-ccc-index + body-token gate)
- [x] All JS validators, linters, formatters pass
- [x] Empirical verification: `register-ccc-index` correctly appends/replaces/preserves comments
- [x] Empirical verification: token gate catches a 200-line / 6050-token body that passes the line gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)