### PR TITLE
Fix auto-scope monorepo detection: use the deterministic manifest scanner

### DIFF
--- a/src/skf-analyze-source/references/step-auto-scope.md
+++ b/src/skf-analyze-source/references/step-auto-scope.md
@@ -260,7 +260,7 @@ Parse the JSON envelope: `{manifests: [{path, ecosystem, ...}], total_unique, mo
 
 From the envelope, record:
 
-1. **Supported manifest paths** — filter `manifests[].path` to the types `skf-shape-detect.py` accepts (`package.json`, `pyproject.toml`, `Cargo.toml`). This filtered, comma-joined list is fed to shape detection in §3. For a monorepo, it includes each workspace member's manifest, so the package surface is classified accurately rather than from a bare (and often export-less) repo root.
+1. **Supported manifest paths** — filter `manifests[].path` to the types `skf-shape-detect.py` accepts (`package.json`, `pyproject.toml`, `Cargo.toml`). This filtered, comma-joined list is fed to shape detection in §3. For a monorepo, it includes each workspace member's manifest, so the package surface is classified accurately rather than from a bare (and often export-less) repo root. The scanner also discovers ecosystems shape detection does not yet classify (e.g. Go `go.mod`, Maven, Gradle); those are excluded here, so a repo with no supported manifest falls back to interactive at the next check rather than auto-scoping.
 2. **`monorepo` flag** and the count of discovered supported packages — carried forward as a signal for the decomposition decision in §3a.
 
 **IF no supported manifests are found** (the filtered list is empty):
@@ -318,11 +318,10 @@ Apply the shape→scope.type mapping:
 
 Generate `scope.include` and `scope.exclude` arrays from the detected language and project structure.
 
-**Detect primary language** from manifest type:
+**Detect primary language** from manifest type (the same set shape detection classifies):
 - `package.json` → TypeScript/JavaScript
 - `pyproject.toml` → Python
 - `Cargo.toml` → Rust
-- `go.mod` → Go
 
 **Default patterns (adjust based on actual project structure):**
 

--- a/src/skf-analyze-source/references/step-auto-scope.md
+++ b/src/skf-analyze-source/references/step-auto-scope.md
@@ -2,6 +2,9 @@
 nextStepFile: 'health-check.md'
 outputFile: '{forge_data_folder}/analyze-source-report-{project_name}.md'
 shapeDetectScript: 'src/shared/scripts/skf-shape-detect.py'
+scanManifestsProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-scan-manifests.py'
+  - '{project-root}/src/shared/scripts/skf-scan-manifests.py'
 ---
 
 <!-- Config: communicate in {communication_language}. -->
@@ -245,16 +248,23 @@ Load `references/step-shape-detect.md` as reference for shape detection invocati
 
 ### 2. Manifest Scan
 
-Perform a lightweight manifest scan — find standard package manifests in the project root and workspace paths. Do NOT crawl the full directory tree.
+Enumerate package manifests **deterministically** — do not hand-scan. Resolve `{scanManifestsHelper}` as the first path in `{scanManifestsProbeOrder}` that exists. This is the same helper the interactive `scan-project.md` uses, so the auto and interactive paths discover manifests identically.
 
 **For each path in `project_paths[]`:**
 
-1. Check the project root for: `package.json`, `pyproject.toml`, `Cargo.toml`
-2. If a workspace configuration exists (e.g., `pnpm-workspace.yaml`, Cargo.toml `[workspace].members`), scan workspace member paths for additional manifests
-3. Record each discovered manifest as `{path, type}` pairs
+```bash
+uv run {scanManifestsHelper} scan {path}
+```
 
-**IF no manifests found:**
-- Emit fallback message: "**Auto-scope could not find any package manifests — switching to interactive mode.**"
+Parse the JSON envelope: `{manifests: [{path, ecosystem, ...}], total_unique, monorepo, warnings?}`. The scanner walks the project root plus monorepo `packages/*` members and recognizes npm/pnpm/yarn `workspaces`, Cargo `[workspace]`, and other ecosystems — so workspace member manifests are discovered without hand-listing each workspace convention.
+
+From the envelope, record:
+
+1. **Supported manifest paths** — filter `manifests[].path` to the types `skf-shape-detect.py` accepts (`package.json`, `pyproject.toml`, `Cargo.toml`). This filtered, comma-joined list is fed to shape detection in §3. For a monorepo, it includes each workspace member's manifest, so the package surface is classified accurately rather than from a bare (and often export-less) repo root.
+2. **`monorepo` flag** and the count of discovered supported packages — carried forward as a signal for the decomposition decision in §3a.
+
+**IF no supported manifests are found** (the filtered list is empty):
+- Emit fallback message: "**Auto-scope could not find any supported package manifests — switching to interactive mode.**"
 - Load, read fully, then execute `references/scan-project.md`. **STOP HERE.**
 
 ### 3. Invoke Shape Detection


### PR DESCRIPTION
## Summary

The `[auto]` analyze path (used by `deepwiki`) hand-scanned for package manifests with a narrow workspace-detection list that omitted the npm/Yarn `workspaces` field, so **monorepos were fed only their (often export-less) root manifest and classified as `unknown`** — silently falling back to interactive on exactly the high-value targets (React, Vue, etc.).

This switches the manifest scan to invoke `skf-scan-manifests.py` — the same deterministic scanner the **interactive** `scan-project.md` path already uses — which walks the root plus monorepo `packages/*` members across ecosystems and reports a `monorepo` flag. Workspace member manifests are now discovered and fed to shape detection, so monorepo packages classify accurately instead of from a bare repo root.

## Evidence

An empirical run of the detection layer against 10 popular repos showed shape detection returning `unknown` for every monorepo when fed only the root manifest (react, vue, rust-lang), while a recovery test feeding the actual sub-package manifest recovered correct `library-API` classification. The scanner already discovers those sub-package manifests — it just wasn't wired into the auto path. (Pin validation and doc detection, by contrast, behaved correctly across all 10 repos.)

## Changes

- `step-auto-scope.md` §2 now resolves and invokes `skf-scan-manifests.py` (via a `scanManifestsProbeOrder` frontmatter probe, mirroring the interactive path) and feeds the discovered, supported manifest paths — including monorepo members — to shape detection.
- Dropped the unreachable `go.mod → Go` language-detection entry (shape detection classifies only package.json/pyproject.toml/Cargo.toml; a Go repo never reaches that mapping) and added an explicit note that ecosystems the classifier doesn't support yet are discovered but fall back to interactive — so the docs match behavior.

## Scope

Part of #418. This addresses the monorepo manifest-discovery item; the remaining items there — full end-to-end AST/decomposition validation via a live `deepwiki` run, and `language-reference`/whole-language support — are intentionally left tracked, not closed.

## Testing

Full suite green: 2242 Python tests + schema/install/CLI/workflow/knowledge checks, lint, markdown lint, format — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)