### PR TITLE
Surface deepwiki at the first-run touchpoints (installer + setup)

### DIFF
--- a/src/skf-setup/references/report.md
+++ b/src/skf-setup/references/report.md
@@ -137,7 +137,7 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 ═══════════════════════════════════════
 
 {if {headless_mode} is false:}
-  Next: try `/skf-brief-skill` to scope your first compilation target, or `/skf-quick-skill` for a fast template-driven path. Already have a skill? `/skf-audit-skill` drift-checks an existing skill against current sources.
+  Next: the fastest start is `@Ferris deepwiki <repo-or-doc-url>` — one command auto-scopes, briefs, compiles, tests at a 90% quality gate, and exports a verified skill with zero configuration. Prefer to scope by hand? `/skf-brief-skill` scopes your first compilation target, or `/skf-quick-skill` is a fast template-driven path. Already have a skill? `/skf-audit-skill` drift-checks an existing skill against current sources.
 ```
 
 All re-run-delta context flags (`{tools_added}`, `{tools_removed}`, `{tier_changed}`) come from the detector's `deltas` block bound in stage 1 — no LLM-side recomputation, no set arithmetic in prose.

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -356,8 +356,9 @@ class UI {
         `${chalk.white.bold('Get Started')}`,
         `1. Open this folder in ${ideDisplay}`,
         `2. Activate Ferris:  ${activateLine}`,
-        '3. Ferris (your Skill Architect) will guide you through',
-        '   setting up and forging your first agent skill',
+        '3. Ferris (your Skill Architect) guides you through forge setup',
+        `4. Fastest first skill — ask Ferris to run ${brand.gold('deepwiki <repo-or-doc-url>')}:`,
+        '   one command auto-scopes, compiles, tests, and exports a verified skill',
       ].join('\n');
     }
 


### PR DESCRIPTION
## Summary

deepwiki is the recommended zero-ceremony entry point, but it was absent from the two places a brand-new user looks first: the standalone installer's post-install screen and the Setup Forge workflow's closing breadcrumb. Both steered users only to the manual `brief-skill` / `quick-skill` / `audit-skill` paths. This surfaces deepwiki at both.

## Changes

- **Installer** (`tools/cli/lib/ui.js`) — the post-install "Installation complete! → Get Started" block now has an explicit fastest-first-skill step: ask Ferris to run `deepwiki <repo-or-doc-url>`, after forge setup. This is the most upstream touchpoint — the first screen a fresh install shows.
- **Setup workflow** (`src/skf-setup/references/report.md`) — the closing "Next" breadcrumb now leads with `@Ferris deepwiki <repo-or-doc-url>` while keeping the manual-scope options.

Both preserve the setup-first ordering (deepwiki runs after `SF`) and use the agent-relative `deepwiki` form, since it is a Ferris pipeline alias rather than a standalone skill.

## Testing

Full suite green: 2242 Python tests + CLI integration, schema/install/workflow/knowledge checks, lint, markdown lint, format — 0 errors. prettier + eslint clean on the JS change. No tests pinned either message.