### PR TITLE
Fix auto-scope manifest scan on remote URLs (deepwiki regression)

### DIFF
--- a/src/skf-analyze-source/references/step-auto-scope.md
+++ b/src/skf-analyze-source/references/step-auto-scope.md
@@ -248,19 +248,33 @@ Load `references/step-shape-detect.md` as reference for shape detection invocati
 
 ### 2. Manifest Scan
 
-Enumerate package manifests **deterministically** — do not hand-scan. Resolve `{scanManifestsHelper}` as the first path in `{scanManifestsProbeOrder}` that exists. This is the same helper the interactive `scan-project.md` uses, so the auto and interactive paths discover manifests identically.
+Enumerate package manifests **deterministically** via `{scanManifestsHelper}` (the same helper the interactive `scan-project.md` uses) — do not hand-scan. Resolve `{scanManifestsHelper}` as the first path in `{scanManifestsProbeOrder}` that exists. The scanner reads a **local directory**, so how you point it at the target depends on the input form classified in §0:
 
 **For each path in `project_paths[]`:**
 
-```bash
-uv run {scanManifestsHelper} scan {path}
-```
+- **Local filesystem path** (starts with `/`, `./`, `~/`, `~`, or is an existing directory) — scan it directly:
 
-Parse the JSON envelope: `{manifests: [{path, ecosystem, ...}], total_unique, monorepo, warnings?}`. The scanner walks the project root plus monorepo `packages/*` members and recognizes npm/pnpm/yarn `workspaces`, Cargo `[workspace]`, and other ecosystems — so workspace member manifests are discovered without hand-listing each workspace convention.
+  ```bash
+  uv run {scanManifestsHelper} scan {path}
+  ```
+
+- **Remote git URL** (e.g. `github.com/{owner}/{repo}`) — auto-scope has no working tree yet and the scanner cannot read a URL. Fetch **just the manifests** first (blobless + sparse + depth-1 — no source blobs, typically KB–MB even for large monorepos), then scan that tree:
+
+  ```bash
+  tmp="$(mktemp -d)"
+  git clone --filter=blob:none --no-checkout --depth 1 {pinned_branch_flag} {path} "$tmp"
+  git -C "$tmp" sparse-checkout set --no-cone '**/package.json' '**/Cargo.toml' '**/pyproject.toml' 'pnpm-workspace.yaml' '**/pnpm-workspace.yaml'
+  git -C "$tmp" checkout
+  uv run {scanManifestsHelper} scan "$tmp"
+  ```
+
+  where `{pinned_branch_flag}` is `--branch {pinned_ref}` when a pin was resolved in §0b (so manifests match the target version), otherwise omitted. **Retain `"$tmp"` through §3** — shape detection reads the discovered manifest files from it — then it may be discarded.
+
+Parse the JSON envelope: `{manifests: [{path, ecosystem, ...}], total_unique, monorepo, warnings?}`. The scanner discovers the project root plus monorepo workspace members (npm/pnpm/yarn `workspaces`, Cargo `[workspace]`, and other ecosystems) and sets the `monorepo` flag — so members are found without hand-listing each workspace convention, for both local trees and remote fetches.
 
 From the envelope, record:
 
-1. **Supported manifest paths** — filter `manifests[].path` to the types `skf-shape-detect.py` accepts (`package.json`, `pyproject.toml`, `Cargo.toml`). This filtered, comma-joined list is fed to shape detection in §3. For a monorepo, it includes each workspace member's manifest, so the package surface is classified accurately rather than from a bare (and often export-less) repo root. The scanner also discovers ecosystems shape detection does not yet classify (e.g. Go `go.mod`, Maven, Gradle); those are excluded here, so a repo with no supported manifest falls back to interactive at the next check rather than auto-scoping.
+1. **Supported manifest paths** — filter `manifests[].path` to the types `skf-shape-detect.py` accepts (`package.json`, `pyproject.toml`, `Cargo.toml`). Each `manifests[].path` is **relative to the scan root**, so resolve them against that root (`{path}` for a local scan, `"$tmp"` for a remote fetch) before use. This filtered, comma-joined list of resolved paths is fed to shape detection in §3. For a monorepo, it includes each workspace member's manifest, so the package surface is classified accurately rather than from a bare (and often export-less) repo root. The scanner also discovers ecosystems shape detection does not yet classify (e.g. Go `go.mod`, Maven, Gradle); those are excluded here, so a repo with no supported manifest falls back to interactive at the next check rather than auto-scoping.
 2. **`monorepo` flag** and the count of discovered supported packages — carried forward as a signal for the decomposition decision in §3a.
 
 **IF no supported manifests are found** (the filtered list is empty):


### PR DESCRIPTION
## Summary

Auto-scope's deterministic manifest scan (added in #419) reads a **local directory**, but the `[auto]`/`deepwiki` path's primary input is a **remote repo URL** with no working tree yet. So `uv run {scanManifestsHelper} scan {path}` errored — `root not a directory: https:/github.com/...` — on every `github.com` URL, and the step silently fell back to ad-hoc manifest discovery. Output quality held (the agent worked around it), but the determinism #419 was meant to deliver was lost for the most common deepwiki input.

Surfaced by a live `deepwiki` run against `aws/aws-sdk-js-v3` (logged to the run's improvement-queue). A class of bug structural tests can't catch — the original change was fully green.

## Fix

`step-auto-scope.md` §2 now branches on input form:

- **Local filesystem path** — scan in place (unchanged).
- **Remote git URL** — fetch *only* the manifests first via a blobless + sparse + depth-1 checkout (no source blobs; KB–MB even for large monorepos; pinned to the resolved ref from §0b when set), then run the scanner on that tree. Discovered manifest paths are resolved against the scan root before shape detection.

This keeps the deterministic scanner as the single discovery mechanism for both local and remote inputs — no reintroduced hand-listing of workspace conventions.

## Validation

The recipe was verified end-to-end before writing the step (the lesson from the original regression):

| Repo | Fetch | Scanner result |
|------|-------|----------------|
| `trpc/trpc` | 1.9s, 432K | `monorepo: true`, 41 manifests |
| `aws/aws-sdk-js-v3` (442+ pkgs, `clients/`+`lib/`+`packages/`) | 8.3M | `monorepo: true`, 589 manifests (full member discovery) |

Full suite green: 2242 Python tests, refs 0 broken, lint/markdown/format — 0 errors.

## Scope

Fixes the remote-URL gap in the #419 work; relates to the auto-scope discovery thread in #418. Separate follow-ups remain (a `uv run python <script>` PEP-723 invocation friction; reframing the multi-skill-split validation box) — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)