### PR TITLE
Fix PEP-723 helper invocation: use uv run <script>, not uv run python

### DIFF
--- a/src/shared/scripts/skf-detect-docs.py
+++ b/src/shared/scripts/skf-detect-docs.py
@@ -16,7 +16,7 @@ Detection chain (all four methods attempted, results aggregated):
   4. docs_folder    — markdown files in the repo's docs/ directory
 
 CLI:
-  uv run python src/shared/scripts/skf-detect-docs.py \\
+  uv run src/shared/scripts/skf-detect-docs.py \\
       --repo-url <url> [--local-path <path>] [--skip-pages-api]
 
 Input:

--- a/src/shared/scripts/skf-preapply.py
+++ b/src/shared/scripts/skf-preapply.py
@@ -9,7 +9,7 @@ registry, then scans target directory files for fingerprint matches and applies
 the corresponding fixes.
 
 CLI:
-  uv run python src/shared/scripts/skf-preapply.py \
+  uv run src/shared/scripts/skf-preapply.py \
       --target-dir <path> [--registry <path>] [--local-registry <path>] [--log-dir <path>]
 
 Input:

--- a/src/shared/scripts/skf-shape-detect.py
+++ b/src/shared/scripts/skf-shape-detect.py
@@ -23,7 +23,7 @@ The five-shape heuristic ladder (apply in order, first match wins):
   5. unknown           — no heuristic matched
 
 CLI:
-  uv run python src/shared/scripts/skf-shape-detect.py \\
+  uv run src/shared/scripts/skf-shape-detect.py \\
       --repo-url <url> --manifests <path1,path2,...>
 
 Input:

--- a/src/shared/scripts/skf-validate-pins.py
+++ b/src/shared/scripts/skf-validate-pins.py
@@ -17,7 +17,7 @@ Tag matching priority mirrors source-resolution-protocols.md:
   4. Crate prefix:  {name}/v{pin}, {name}/{pin}, {name}-v{pin}
 
 CLI:
-  uv run python src/shared/scripts/skf-validate-pins.py \\
+  uv run src/shared/scripts/skf-validate-pins.py \\
       --repo-url <url> [--pin <version>] [--format tag|branch|any]
 
 Input:

--- a/src/skf-analyze-source/references/step-auto-scope.md
+++ b/src/skf-analyze-source/references/step-auto-scope.md
@@ -52,7 +52,7 @@ This section validates and resolves version pins. It runs for repo URLs and loca
 **For repo URLs when `--pin` is provided:**
 
 ```bash
-uv run python src/shared/scripts/skf-validate-pins.py --repo-url {project_path} --pin {pin_value}
+uv run src/shared/scripts/skf-validate-pins.py --repo-url {project_path} --pin {pin_value}
 ```
 
 Handle exit codes:
@@ -67,7 +67,7 @@ Handle exit codes:
 **For repo URLs when `--pin` is NOT provided (default):**
 
 ```bash
-uv run python src/shared/scripts/skf-validate-pins.py --repo-url {project_path}
+uv run src/shared/scripts/skf-validate-pins.py --repo-url {project_path}
 ```
 
 Handle exit codes:
@@ -83,7 +83,7 @@ This section checks for existing skills matching the target before proceeding. I
 **1. Load skill inventory:**
 
 ```bash
-uv run python src/shared/scripts/skf-skill-inventory.py {skills_output_folder}
+uv run src/shared/scripts/skf-skill-inventory.py {skills_output_folder}
 ```
 
 Parse the JSON output. If the exit code is non-zero or the `skills` array is empty, skip coexistence detection silently (no existing skills to conflict with) and continue to the next section: §0a for documentation URLs, §1 for all other input types.
@@ -286,7 +286,7 @@ From the envelope, record:
 Invoke the shape detection script with discovered manifests:
 
 ```
-uv run python {shapeDetectScript} --repo-url <project_path_or_url> --manifests <comma_separated_manifest_paths>
+uv run {shapeDetectScript} --repo-url <project_path_or_url> --manifests <comma_separated_manifest_paths>
 ```
 
 Parse the JSON output: `{shape, signals, confidence, export_count, package_count}`

--- a/src/skf-analyze-source/references/step-shape-detect.md
+++ b/src/skf-analyze-source/references/step-shape-detect.md
@@ -8,7 +8,7 @@ Reference document for invoking `skf-shape-detect.py` — the shared shape class
 
 **Command:**
 ```
-uv run python src/shared/scripts/skf-shape-detect.py --repo-url <url> --manifests <path1,path2,...>
+uv run src/shared/scripts/skf-shape-detect.py --repo-url <url> --manifests <path1,path2,...>
 ```
 
 **Arguments:**

--- a/src/skf-brief-skill/references/step-auto-brief.md
+++ b/src/skf-brief-skill/references/step-auto-brief.md
@@ -72,7 +72,7 @@ Extract from the parsed brief:
 Invoke doc detection to discover documentation URLs for the source repo:
 
 ```bash
-uv run python {project-root}/{detectDocsScript} --repo-url {source_repo}
+uv run {project-root}/{detectDocsScript} --repo-url {source_repo}
 ```
 
 `--repo-url` is always required (the script uses it for GitHub API calls). If a local clone is also available at `{local_clone_path}`, add `--local-path {local_clone_path}` to enable docs-folder scanning in addition to API-based detection.

--- a/src/skf-campaign/references/step-03-pins.md
+++ b/src/skf-campaign/references/step-03-pins.md
@@ -41,7 +41,7 @@ Copy `{stateFile}` to `{backupFile}` before any modification.
 
 ### §4 — Validate Pins
 
-Run `uv run python {pinScript} --state-file {stateFile} --brief-file {briefFile}`. Parse the JSON output. For each result: if `status` is `"valid"` or `"resolved"`, the pin is good; if `"invalid"`, collect the failure with suggestions.
+Run `uv run {pinScript} --state-file {stateFile} --brief-file {briefFile}`. Parse the JSON output. For each result: if `status` is `"valid"` or `"resolved"`, the pin is good; if `"invalid"`, collect the failure with suggestions.
 
 ### §5 — Handle Invalid Pins
 

--- a/src/skf-campaign/references/step-05-skill-loop.md
+++ b/src/skf-campaign/references/step-05-skill-loop.md
@@ -46,7 +46,7 @@ For each skill in `dependency_graph.execution_order`, before processing:
 
 1. Skip Tier B skills — they are processed in step-06 via batch mode.
 2. Skip skills whose status is already `"completed"`, `"failed"`, or `"skipped"` (resume support).
-3. Run `uv run python {depsScript} --check --state-file {stateFile} --skill {skill_name}`.
+3. Run `uv run {depsScript} --check --state-file {stateFile} --skill {skill_name}`.
 4. If `ready: true` — proceed to §5 for this skill.
 5. If `ready: false` — present the blocked skill and its unmet dependencies:
    - `[S]kip` — mark skill as `"skipped"`, backup and write state, continue to next skill.

--- a/src/skf-campaign/references/step-11-maintenance.md
+++ b/src/skf-campaign/references/step-11-maintenance.md
@@ -35,7 +35,7 @@ Load `{stateFile}`. Validate the loaded state against `{stateSchemaFile}`. HALT 
 Invoke the campaign report script:
 
 ```
-uv run python {reportScript} \
+uv run {reportScript} \
     --state-file {stateFile} \
     --template-file {reportTemplate} \
     --output-file forge-data/_campaign/campaign-report.md

--- a/src/skf-campaign/scripts/campaign-deps.py
+++ b/src/skf-campaign/scripts/campaign-deps.py
@@ -9,9 +9,9 @@ Two modes:
   --check:   verify a single skill's dependencies are satisfied
 
 CLI:
-  uv run python campaign-deps.py --compute --state-file <path>
-  uv run python campaign-deps.py --check --state-file <path> --skill <name>
-  uv run python campaign-deps.py --check --state-file <path> --skill <name> --force
+  uv run campaign-deps.py --compute --state-file <path>
+  uv run campaign-deps.py --check --state-file <path> --skill <name>
+  uv run campaign-deps.py --check --state-file <path> --skill <name> --force
 
 Output (JSON on stdout):
   --compute:

--- a/src/skf-campaign/scripts/campaign-report.py
+++ b/src/skf-campaign/scripts/campaign-report.py
@@ -5,7 +5,7 @@
 """Campaign Report — generate a markdown report from campaign state + template.
 
 CLI:
-  uv run python campaign-report.py \
+  uv run campaign-report.py \
       --state-file <path> --template-file <path> --output-file <path>
 
 Output (JSON on stdout):

--- a/src/skf-campaign/scripts/campaign-validate-pins.py
+++ b/src/skf-campaign/scripts/campaign-validate-pins.py
@@ -9,7 +9,7 @@ Reads the campaign state and brief, validates every skill's pin against
 real GitHub releases/tags, and outputs consolidated JSON.
 
 CLI:
-  uv run python src/skf-campaign/scripts/campaign-validate-pins.py \
+  uv run src/skf-campaign/scripts/campaign-validate-pins.py \
       --state-file <path> --brief-file <path>
 
 Input:

--- a/src/skf-create-skill/references/step-doc-sources.md
+++ b/src/skf-create-skill/references/step-doc-sources.md
@@ -40,7 +40,7 @@ Check that `{source_repo}` is available from the skill brief.
 Invoke the detect-docs script:
 
 ```bash
-uv run python src/shared/scripts/skf-detect-docs.py \
+uv run src/shared/scripts/skf-detect-docs.py \
   --repo-url {source_repo} \
   [--local-path {source_path}] \
   [--skip-pages-api]


### PR DESCRIPTION
## Summary

`uv run python <script>` runs the interpreter directly and **skips the script's `# /// script` inline-dependency block**, so any helper with PEP-723 deps fails with `ModuleNotFoundError`. Several step files invoked helpers this way. Three of them target **dep-bearing campaign helpers** — `campaign-report.py`, `campaign-deps.py`, `campaign-validate-pins.py` (all require `pyyaml`) — so they would fail on the first real campaign run. These are **latent**: the campaign workflow has no end-to-end coverage yet, so nothing had hit them.

Surfaced indirectly during the v2.0 deepwiki validation campaign (the agent logged the `uv run python` footgun); a repo-wide grep found the real offenders in the campaign workflow.

## Changes

**Fix (`fix(scripts)`):** drop `python` from every `uv run python <script>` invocation across step files so uv resolves inline deps. Dependency-free helpers (`shape-detect`, `detect-docs`, `validate-pins`, `skill-inventory`) are normalized to the same idiom to remove the footgun if they ever gain a dependency.

**Docs (`docs(scripts)`):** normalize the in-script CLI usage docstrings (4 shared + 3 campaign helpers) so the documented invocation matches the working form.

After this, there are **zero `uv run python` invocations** anywhere in step files, docs, or script docstrings.

## Verification

Empirically confirmed the bug and the fix:
- `uv run python campaign-report.py` → errors on `import yaml`
- `uv run campaign-report.py` → runs cleanly (PEP-723 `pyyaml` resolved)

Full suite green: 2242 Python tests, 0 broken refs, lint/markdown/format — 0 errors.

## Note

Three dep-bearing invocations were broken and only a grep caught them, because the **campaign workflow has never run end-to-end**. Worth prioritizing an end-to-end campaign run as a follow-up — its building blocks (the per-skill deepwiki pipeline) are validated, but the orchestrator itself is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)