### PR TITLE
Rename the deepwiki pipeline alias to forge-auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You'll be prompted for project name, output folders, and IDE configuration. When
 ## Quick Start
 
 1. **Set up your environment:** `@Ferris SF` _(Setup Forge)_ — detects your tools and sets your capability tier
-2. **Zero-ceremony path:** `@Ferris deepwiki <repo-or-doc-url>` _(Deepwiki)_ — one command turns a repo or doc URL into a verified wiki skill (auto-scope, auto-brief, 90% quality gate, export)
+2. **Zero-ceremony path:** `@Ferris forge-auto <repo-or-doc-url>` _(Forge-Auto)_ — one command turns a repo or doc URL into a verified skill (auto-scope, auto-brief, 90% quality gate, export)
 3. **Fast path:** `@Ferris QS <package-name>` _(Quick Skill)_ — creates a verified skill in under a minute
 4. **Full quality path:** `@Ferris forge <your-library>` chains Brief → Create → Test → Export automatically — or run manually: `@Ferris BS` → clear session → `@Ferris CS` for maximum control
 
@@ -146,7 +146,7 @@ The docs are organized into three buckets — **Why** (start here), **Try** (do 
 **Try**
 
 - **[Getting Started](https://armelhbobdad.github.io/bmad-module-skill-forge/getting-started/)** — Install, first skill, prereqs, and config
-- **[Deepwiki](https://armelhbobdad.github.io/bmad-module-skill-forge/deepwiki/)** — The zero-ceremony path: one command from a repo or doc URL to a verified skill
+- **[Forge-Auto](https://armelhbobdad.github.io/bmad-module-skill-forge/forge-auto/)** — The zero-ceremony path: one command from a repo or doc URL to a verified skill
 - **[Campaign](https://armelhbobdad.github.io/bmad-module-skill-forge/campaign/)** — Orchestrate many coordinated skills across sessions with dependency tracking and resume
 - **[How It Works](https://armelhbobdad.github.io/bmad-module-skill-forge/how-it-works/)** — Plain-English walkthrough of one skill being built, end to end
 - **[Examples](https://armelhbobdad.github.io/bmad-module-skill-forge/examples/)** — Real-world scenarios with full command transcripts

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -77,7 +77,7 @@ MANAGE:
 [KI] Knowledge Index — List available knowledge fragments
 
 PIPELINE ALIASES:
-  [deepwiki] Zero-ceremony wiki skill from a repo or doc URL
+  [forge-auto] Zero-ceremony skill from a repo or doc URL
   [forge] Brief → Create → Test → Export
   [forge-quick] Quick Skill → Test → Export
   [maintain] Audit → Update → Test → Export
@@ -86,7 +86,7 @@ PIPELINE ALIASES:
 
 **Pipeline Aliases:**
 
-Ferris chains multiple workflows in one command via named aliases (`deepwiki`, `forge`, `forge-quick`, `maintain`, `campaign`). The full alias table, expansion rules, and target-resolution contract live in [Workflows → Pipeline Mode](../workflows/#pipeline-mode) — the canonical source. Example: `@Ferris forge-quick cognee` chains Quick → Test → Export with automatic data forwarding.
+Ferris chains multiple workflows in one command via named aliases (`forge-auto`, `forge`, `forge-quick`, `maintain`, `campaign`). The full alias table, expansion rules, and target-resolution contract live in [Workflows → Pipeline Mode](../workflows/#pipeline-mode) — the canonical source. Example: `@Ferris forge-quick cognee` chains Quick → Test → Export with automatic data forwarding.
 
 **Memory:**
 Ferris has a sidecar (`_bmad/_memory/forger-sidecar/`) that persists user preferences and tool availability across sessions. Set `headless_mode: true` in preferences to make headless the default.

--- a/docs/bmad-synergy.md
+++ b/docs/bmad-synergy.md
@@ -29,15 +29,15 @@ When a BMAD agent runs a workflow, that workflow can consult SKF content skills 
 
 SKF works standalone — no BMAD installation required. If you found this page from a search and don't use the BMAD Method, this section is for you.
 
-The fastest way to start is [`deepwiki`](../deepwiki/). One command produces a verified wiki skill in 3–5 minutes with zero configuration:
+The fastest way to start is [`forge-auto`](../forge-auto/). One command produces a verified skill in 3–5 minutes with zero configuration:
 
 ```
-@Ferris deepwiki https://github.com/honojs/hono
+@Ferris forge-auto https://github.com/honojs/hono
 ```
 
-That's it. No brief file, no scope decisions, no multi-step pipeline to learn. deepwiki handles analysis, scoping, compilation, testing (with a 90% quality gate), and export automatically. See the [deepwiki guide](../deepwiki/) for the full syntax and input types.
+That's it. No brief file, no scope decisions, no multi-step pipeline to learn. forge-auto handles analysis, scoping, compilation, testing (with a 90% quality gate), and export automatically. See the [forge-auto guide](../forge-auto/) for the full syntax and input types.
 
-If you later adopt the BMAD Method, the skills you created via deepwiki integrate seamlessly into BMM phases — they become the verified content skills that BMAD workflows consult during planning and implementation. The [phase-by-phase playbook](#skf-and-bmm-phase-by-phase-playbook) below shows exactly where each SKF workflow fits.
+If you later adopt the BMAD Method, the skills you created via forge-auto integrate seamlessly into BMM phases — they become the verified content skills that BMAD workflows consult during planning and implementation. The [phase-by-phase playbook](#skf-and-bmm-phase-by-phase-playbook) below shows exactly where each SKF workflow fits.
 
 ---
 
@@ -45,7 +45,7 @@ If you later adopt the BMAD Method, the skills you created via deepwiki integrat
 
 BMM is BMAD's core [4-phase workflow](https://docs.bmad-method.org/) (Analysis → Planning → Solutioning → Implementation). SKF has five concrete entry points across those phases. The diagram below shows the end-to-end picture; the subsections that follow give the trigger, command, and artifact flow for each phase.
 
-> **Atomic workflows vs pipeline aliases.** The playbook below maps each phase to an *atomic* SKF workflow (`AN`, `BS`, `QS`, `VS`, `CS`…) on purpose — in BMM you often want only part of the chain (a brief to feed a risk register, a quick reference for acceptance criteria). When you instead want the *finished, exported skill* in one command, reach for a pipeline alias: [`deepwiki`](../deepwiki/) collapses `AN → BS → CS → TS → EX` for a single library, and [`campaign`](../campaign/) orchestrates that whole chain across many dependencies. Rule of thumb: **atomic when you want a stage's artifact; alias when you want the verified skill.**
+> **Atomic workflows vs pipeline aliases.** The playbook below maps each phase to an *atomic* SKF workflow (`AN`, `BS`, `QS`, `VS`, `CS`…) on purpose — in BMM you often want only part of the chain (a brief to feed a risk register, a quick reference for acceptance criteria). When you instead want the *finished, exported skill* in one command, reach for a pipeline alias: [`forge-auto`](../forge-auto/) collapses `AN → BS → CS → TS → EX` for a single library, and [`campaign`](../campaign/) orchestrates that whole chain across many dependencies. Rule of thumb: **atomic when you want a stage's artifact; alias when you want the verified skill.**
 
 ```mermaid
 flowchart TD
@@ -56,7 +56,7 @@ flowchart TD
     P1 --> P2[BMM Phase 2: Planning<br/>create-prd]
     P2 -.->|uncertain API| QS[SKF: Quick Skill]
     QS -.->|verified API ref| P2
-    P2 -.->|"one command → exported skill (alias)"| DW[SKF: deepwiki]
+    P2 -.->|"one command → exported skill (alias)"| DW[SKF: forge-auto]
     DW -.->|verified skill| P2
 
     P2 --> P3[BMM Phase 3: Solutioning<br/>create-architecture]
@@ -96,7 +96,7 @@ flowchart TD
 
 **Why now, not later:** Quick Skill is cheap insurance. It takes under a minute and prevents a whole class of "actually that function doesn't exist" moments during story writing.
 
-**Want more than a quick reference?** When the PRD leans heavily on one library and you'd rather have a thorough, doc-enriched skill behind a 90% quality gate than a fast QS pass, run [`@Ferris deepwiki <repo>`](../deepwiki/) instead — one command produces the finished, exported skill (auto-scope, auto-brief, test, export) ready for BMM workflows to consult.
+**Want more than a quick reference?** When the PRD leans heavily on one library and you'd rather have a thorough, doc-enriched skill behind a 90% quality gate than a fast QS pass, run [`@Ferris forge-auto <repo>`](../forge-auto/) instead — one command produces the finished, exported skill (auto-scope, auto-brief, test, export) ready for BMM workflows to consult.
 
 ### Phase 3 — Solutioning
 
@@ -141,7 +141,7 @@ Two distinct triggers fire during Implementation, one at the start of each story
 
 **Trigger A (before `create-story`):** The story touches a library whose API isn't already in a content skill.
 
-**SKF command:** `@Ferris CS` for a single library, or `@Ferris SS` when the story spans several dependencies. If there's no brief yet and you want the skill in one shot, [`@Ferris deepwiki <repo>`](../deepwiki/) runs the full analyze → brief → compile → test → export chain from just the repo URL.
+**SKF command:** `@Ferris CS` for a single library, or `@Ferris SS` when the story spans several dependencies. If there's no brief yet and you want the skill in one shot, [`@Ferris forge-auto <repo>`](../forge-auto/) runs the full analyze → brief → compile → test → export chain from just the repo URL.
 
 **What flows back:** A verified content skill the `dev-story` workflow can consult during implementation — no training-data guessing about function signatures.
 
@@ -214,7 +214,7 @@ For long-running BMAD projects, `@Ferris RS` (rename) and `@Ferris DS` (drop) ke
 ## Where to Go Next
 
 - [BMAD docs](https://docs.bmad-method.org/) — canonical reference for BMM phases, TEA workflows, BMB / GDS / CIS details, and the full module list
-- [Deepwiki](../deepwiki/) — the one-command alias that collapses analyze → brief → compile → test → export for a single library
+- [Forge-Auto](../forge-auto/) — the one-command alias that collapses analyze → brief → compile → test → export for a single library
 - [Campaign](../campaign/) — orchestrate the full pipeline across many declared dependencies with dependency ordering and resume
 - [Workflows](../workflows/) — complete SKF workflow reference with commands and connection diagrams
 - [Examples](../examples/) — concrete scenarios including the BMM retrospective loop and greenfield architecture verification

--- a/docs/campaign.md
+++ b/docs/campaign.md
@@ -73,7 +73,7 @@ Campaign sorts skills topologically by their dependency graph. If skill B depend
 Campaign enforces two types of quality gates:
 
 - **Hard gate** — zero critical or high-severity issues allowed. Any skill that fails the hard gate is flagged for manual intervention and blocks the campaign from proceeding past that skill.
-- **Soft gate** — per-pipeline quality thresholds (e.g., 80% for forge, 90% for deepwiki). Skills that score between the hard floor (60%) and the per-pipeline threshold receive a fallback PASS with an evidence report, and the campaign continues.
+- **Soft gate** — per-pipeline quality thresholds (e.g., 80% for forge, 90% for forge-auto). Skills that score between the hard floor (60%) and the per-pipeline threshold receive a fallback PASS with an evidence report, and the campaign continues.
 
 ---
 
@@ -121,5 +121,5 @@ Plan a campaign as multi-session work rather than a single sitting — the resum
 ## Related
 
 - [Workflows](../workflows/) — pipeline mode mechanics, headless mode, circuit breakers
-- [deepwiki](../deepwiki/) — zero-ceremony single-skill creation (campaign orchestrates many of these)
+- [forge-auto](../forge-auto/) — zero-ceremony single-skill creation (campaign orchestrates many of these)
 - [BMAD Synergy](../bmad-synergy/) — how campaign fits into BMAD Phase 3 as an orchestration layer

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -103,7 +103,7 @@ Alex, a platform engineer, adopts BMAD for 10 microservices spanning TypeScript,
 ```
 @Ferris SF                                              # Setup — Deep tier detected
 # — clear session —
-@Ferris deepwiki https://github.com/acme/auth-service   # one service: Analyze → Brief → Create → Test → Export
+@Ferris forge-auto https://github.com/acme/auth-service   # one service: Analyze → Brief → Create → Test → Export
 ```
 
 Or one workflow per session:

--- a/docs/forge-auto.md
+++ b/docs/forge-auto.md
@@ -1,9 +1,9 @@
 ---
-title: Deepwiki
-description: Zero-ceremony wiki-skill creation — one command turns a GitHub repo, doc URL, or pinned version into a verified wiki skill
+title: Forge-Auto
+description: Zero-ceremony skill creation — one command turns a GitHub repo, doc URL, or pinned version into a verified skill
 ---
 
-Deepwiki is a [pipeline alias](../workflows/#pipeline-aliases) that chains five workflows into a single command. Give it a repo URL, a documentation URL, or a pinned version, and it produces a verified wiki skill in 3–5 minutes with zero configuration.
+Forge-Auto is a [pipeline alias](../workflows/#pipeline-aliases) that chains five workflows into a single command. Give it a repo URL, a documentation URL, or a pinned version, and it produces a verified skill in 3–5 minutes with zero configuration.
 
 If you're new to SKF and want to try it without reading anything else, start here.
 
@@ -14,12 +14,12 @@ If you're new to SKF and want to try it without reading anything else, start her
 Three input types, one command pattern:
 
 ```
-@Ferris deepwiki https://github.com/honojs/hono                  — repo URL
-@Ferris deepwiki https://docs.example.com                         — doc URL (docs-only)
-@Ferris deepwiki https://github.com/honojs/hono --pin v4.6.0      — pinned version
+@Ferris forge-auto https://github.com/honojs/hono                  — repo URL
+@Ferris forge-auto https://docs.example.com                         — doc URL (docs-only)
+@Ferris forge-auto https://github.com/honojs/hono --pin v4.6.0      — pinned version
 ```
 
-- **Repo URL** — analyzes the full source repository, extracts exports, and compiles a wiki skill from code + docs.
+- **Repo URL** — analyzes the full source repository, extracts exports, and compiles a skill from code + docs.
 - **Doc URL** — skips source analysis entirely and builds the skill from documentation alone. Useful for closed-source libraries or when the docs are the canonical reference.
 - **`--pin <version>`** — targets a specific release. The version tag is resolved during analysis so the resulting skill is locked to that exact API surface.
 
@@ -27,7 +27,7 @@ Three input types, one command pattern:
 
 ## Pipeline Stages
 
-deepwiki expands to `AN[auto] BS[auto] CS TS[min:90] EX`. The two analysis stages (AN, BS) run in [headless mode](../workflows/#headless-mode) via their `[auto]` flags — no confirmation gates, no interactive prompts. The compile, test, and export stages then proceed with their standard behaviors once the analysis context is ready.
+forge-auto expands to `AN[auto] BS[auto] CS TS[min:90] EX`. The two analysis stages (AN, BS) run in [headless mode](../workflows/#headless-mode) via their `[auto]` flags — no confirmation gates, no interactive prompts. The compile, test, and export stages then proceed with their standard behaviors once the analysis context is ready.
 
 | Stage | Workflow | Mode | What Happens |
 |-------|----------|------|-------------|
@@ -43,20 +43,20 @@ Data flows automatically between stages — the brief path from AN feeds BS, the
 
 ## Automatic Behaviors
 
-deepwiki's `[auto]` flags activate several behaviors that normally require manual input:
+forge-auto's `[auto]` flags activate several behaviors that normally require manual input:
 
 - **Auto-scope** — shape detection (library, framework, tool, application) drives scope decisions. No interactive scope confirmation.
 - **Auto-brief** — the brief is generated and enriched with doc-detection results in one pass, without the interactive discovery flow that `BS` uses standalone.
-- **Coexistence detection** — if a skill for the same target already exists, deepwiki detects it and offers three options: create alongside (new version), merge into the existing skill, or skip.
+- **Coexistence detection** — if a skill for the same target already exists, forge-auto detects it and offers three options: create alongside (new version), merge into the existing skill, or skip.
 - **Auto-decomposition** — for massive repos (>500 exports or >3 packages), AN automatically decomposes into multiple analysis units before proceeding.
 
 ---
 
 ## Expected Output
 
-A successful deepwiki run produces a complete skill package in your forge data directory, exported and ready for use. The skill includes:
+A successful forge-auto run produces a complete skill package in your forge data directory, exported and ready for use. The skill includes:
 
-- `SKILL.md` — the compiled wiki skill with provenance-cited instructions
+- `SKILL.md` — the compiled skill with provenance-cited instructions
 - `metadata.json` — version, source, confidence tier breakdown
 - Context snippet injected into your IDE context file (CLAUDE.md, .cursorrules, AGENTS.md, etc.)
 
@@ -74,11 +74,11 @@ A typical library (50–200 exports) takes **3–5 minutes** end to end. Factors
 
 ---
 
-## Migration from onboard
+## Migration from `deepwiki` and `onboard`
 
-deepwiki replaces the older `onboard` alias. `onboard` has been removed — running it returns an error directing you to deepwiki.
+This pipeline was briefly named `deepwiki`. It was renamed to **`forge-auto`** to avoid confusion with the [DeepWiki MCP](https://deepwiki.com) — `forge-auto` compiles a verified skill from source and **does not** call that MCP or ingest a generated wiki. `deepwiki` still works as a **deprecated alias** (it resolves to `forge-auto` and prints a one-time notice); prefer `forge-auto` going forward.
 
-The key differences from the old alias: `onboard` ran `AN CS TS EX` with standard (interactive) modes at an 80% quality threshold. deepwiki adds auto-scope, auto-brief, a stricter quality gate (90% vs 80%), and accepts repo URLs and doc URLs — not just project paths.
+Before that, the auto pipeline replaced the older `onboard` alias. `onboard` has been removed — running it returns an error directing you to `forge-auto`. The key differences from `onboard`: it ran `AN CS TS EX` with standard (interactive) modes at an 80% quality threshold, whereas `forge-auto` adds auto-scope, auto-brief, a stricter quality gate (90% vs 80%), and accepts repo URLs and doc URLs — not just project paths.
 
 ---
 
@@ -86,4 +86,4 @@ The key differences from the old alias: `onboard` ran `AN CS TS EX` with standar
 
 - [Workflows](../workflows/) — pipeline mode mechanics, headless mode, circuit breakers
 - [Concepts](../concepts/) — provenance, confidence tiers, drift, version pinning
-- [BMAD Synergy](../bmad-synergy/) — how deepwiki fits into BMAD phases, and standalone SKF usage
+- [BMAD Synergy](../bmad-synergy/) — how forge-auto fits into BMAD phases, and standalone SKF usage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,12 +89,12 @@ This detects your tools, sets your capability tier, and initializes the forge en
 
 ### 2. Generate your first skill
 
-**Zero-ceremony path (deepwiki):**
+**Zero-ceremony path (forge-auto):**
 ```
-@Ferris deepwiki https://github.com/honojs/hono
+@Ferris forge-auto https://github.com/honojs/hono
 ```
 
-One command turns a repo URL (or a doc URL) into a verified wiki skill — auto-scope, auto-brief, a 90% quality gate, and export, with no configuration. If you only read one thing, [start with deepwiki](../deepwiki/).
+One command turns a repo URL (or a doc URL) into a verified skill — auto-scope, auto-brief, a 90% quality gate, and export, with no configuration. If you only read one thing, [start with forge-auto](../forge-auto/).
 
 **Fastest path (Quick Skill):**
 ```
@@ -190,7 +190,7 @@ Runtime configuration (tool detection, tier, and collection state) is managed by
 
 ## What's next?
 
-- [Deepwiki](../deepwiki/) — the zero-ceremony path: one command from repo or doc URL to a verified skill
+- [Forge-Auto](../forge-auto/) — the zero-ceremony path: one command from repo or doc URL to a verified skill
 - [Campaign](../campaign/) — orchestrate many coordinated skills across sessions with dependency tracking and resume
 - [Agents](../agents/) — learn about Ferris
 - [Workflows](../workflows/) — the full command reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,8 +61,8 @@ Then generate your first skill:
 
 ```
 @Ferris SF                       # Set up your forge
-@Ferris deepwiki <repo-or-url>   # Zero-ceremony: a repo or doc URL → verified skill
+@Ferris forge-auto <repo-or-url>   # Zero-ceremony: a repo or doc URL → verified skill
 @Ferris QS <package>             # Or a fast skill from a package name in under a minute
 ```
 
-[deepwiki](./deepwiki/) is the recommended starting point — one command, no configuration. See [Getting Started](./getting-started/) for platform support, tier selection, and troubleshooting.
+[forge-auto](./forge-auto/) is the recommended starting point — one command, no configuration. See [Getting Started](./getting-started/) for platform support, tier selection, and troubleshooting.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,13 +41,17 @@ Quick tier reads source without AST analysis, so signatures are read directly fr
 
 Install [cocoindex-code](https://github.com/cocoindex-io/cocoindex-code) to unlock the Forge+ tier. CCC indexes your codebase and pre-ranks files by semantic relevance before AST extraction, improving coverage on projects with 500+ files.
 
+### `@Ferris deepwiki` shows a deprecation notice
+
+The auto pipeline was briefly named `deepwiki`; it's now [`forge-auto`](../forge-auto/) — renamed to avoid confusion with the DeepWiki MCP, since the pipeline compiles a verified skill from source and does **not** call that MCP. `deepwiki` still works (it resolves to `forge-auto`) but prints a one-time notice. Switch your commands to `@Ferris forge-auto <repo-or-doc-url>`.
+
 ### `@Ferris onboard` returns an error
 
-The `onboard` alias was removed. Its replacement is [`deepwiki`](../deepwiki/), which does everything `onboard` did plus auto-scope, auto-brief, and a stricter 90% quality gate. Run `@Ferris deepwiki <repo-or-doc-url>` instead.
+The `onboard` alias was removed. Its replacement is [`forge-auto`](../forge-auto/), which does everything `onboard` did plus auto-scope, auto-brief, and a stricter 90% quality gate. Run `@Ferris forge-auto <repo-or-doc-url>` instead.
 
-### deepwiki halted at the Test stage
+### forge-auto halted at the Test stage
 
-deepwiki runs Test Skill with a stricter **90% quality threshold** (vs the default 80%), so a skill that scores below 90% halts at TS with a gap report rather than exporting a weak skill. Run `@Ferris US` to address the gaps it lists, then `@Ferris TS EX` to re-test and export. If 90% is stricter than you need, run the individual workflows or `forge` instead, which use the default threshold.
+forge-auto runs Test Skill with a stricter **90% quality threshold** (vs the default 80%), so a skill that scores below 90% halts at TS with a gap report rather than exporting a weak skill. Run `@Ferris US` to address the gaps it lists, then `@Ferris TS EX` to re-test and export. If 90% is stricter than you need, run the individual workflows or `forge` instead, which use the default threshold.
 
 ### My campaign stopped partway — how do I resume?
 

--- a/docs/verifying-a-skill.md
+++ b/docs/verifying-a-skill.md
@@ -169,7 +169,7 @@ score >= threshold  →  PASS  →  Recommend export-skill
 score <  threshold  →  FAIL  →  Recommend update-skill
 ```
 
-The default threshold is **80%**. Pipeline aliases declare their own defaults: `deepwiki` targets **90%**, `forge` and `forge-quick` target **80%**. You can override any default with a custom threshold (e.g., `TS[min:85]`).
+The default threshold is **80%**. Pipeline aliases declare their own defaults: `forge-auto` targets **90%**, `forge` and `forge-quick` target **80%**. You can override any default with a custom threshold (e.g., `TS[min:85]`).
 
 When a skill scores between 80% and its target threshold (e.g., 82% against a 90% target), the soft gate falls back to the 80% floor — the skill passes, but an evidence report is written to `forge-data/{skill}/{version}/evidence-report-fallback.md` documenting the quality compromise.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -80,7 +80,7 @@ Trigger workflows by typing commands to [Ferris](../agents/). See [Concepts](../
 
 **Purpose:** Brief-less fast skill with package-to-repo resolution.
 
-**Note:** QS is **tier-unaware** — it always runs at community tier and does not use ast-grep, CCC, or QMD even when your forge is configured at Forge+/Deep. For tier-aware compilation, use `BS → CS`, `forge`, or `deepwiki`. See [Skill Model](../skill-model/).
+**Note:** QS is **tier-unaware** — it always runs at community tier and does not use ast-grep, CCC, or QMD even when your forge is configured at Forge+/Deep. For tier-aware compilation, use `BS → CS`, `forge`, or `forge-auto`. See [Skill Model](../skill-model/).
 
 **When to Use:** When you need a skill quickly — no brief needed. Accepts package names or GitHub URLs. Append `@version` to target a specific version (e.g., `@Ferris QS cognee@1.0.0`).
 
@@ -161,7 +161,7 @@ Trigger workflows by typing commands to [Ferris](../agents/). See [Concepts](../
 
 **Key Steps:** Load skill → Detect mode → Coverage check → Coherence check → External validation (skill-check, tessl) → Hard gate → Score → Gap report
 
-**Scored Categories:** Export Coverage (36%), Signature Accuracy (22%), Type Coverage (14%), Coherence (18%), External Validation (10%). Default pass threshold: **80%** (per-pipeline defaults: deepwiki 90%, forge 80%). Pass routes to Export Skill; fail routes to Update Skill with a gap report. See [Completeness Scoring](../verifying-a-skill/#how-the-score-is-computed) for the full formula and tier adjustments.
+**Scored Categories:** Export Coverage (36%), Signature Accuracy (22%), Type Coverage (14%), Coherence (18%), External Validation (10%). Default pass threshold: **80%** (per-pipeline defaults: forge-auto 90%, forge 80%). Pass routes to Export Skill; fail routes to Update Skill with a gap report. See [Completeness Scoring](../verifying-a-skill/#how-the-score-is-computed) for the full formula and tier adjustments.
 
 **Agent:** Ferris (Audit mode)
 
@@ -346,11 +346,11 @@ Instead of running one workflow per session, you can chain multiple workflows in
 
 ### Pipeline Aliases
 
-The `deepwiki` alias is the recommended way to create wiki skills — one command, zero configuration. It chains five workflows with auto-mode flags so you get a verified skill without touching a brief or scope file.
+The `forge-auto` alias is the recommended way to create skills — one command, zero configuration. It chains five workflows with auto-mode flags so you get a verified skill without touching a brief or scope file.
 
 | Alias         | Expands To                             | First Workflow | Required Target                              |
 | ------------- | -------------------------------------- | -------------- | -------------------------------------------- |
-| `deepwiki`    | `AN[auto] BS[auto] CS TS[min:90] EX`  | AN             | GitHub URL, doc URL, or `--pin <version>`    |
+| `forge-auto`    | `AN[auto] BS[auto] CS TS[min:90] EX`  | AN             | GitHub URL, doc URL, or `--pin <version>`    |
 | `forge`       | `BS CS TS EX`                          | BS             | GitHub URL or local path **+** skill name    |
 | `forge-quick` | `QS TS EX`                            | QS             | GitHub URL **or** package name               |
 | `maintain`    | `AS US TS EX`                          | AS             | Existing skill name                          |
@@ -369,9 +369,9 @@ The `deepwiki` alias is the recommended way to create wiki skills — one comman
 ### Examples
 
 ```
-@Ferris deepwiki https://github.com/honojs/hono                     — zero-ceremony wiki skill
-@Ferris deepwiki https://docs.example.com                            — docs-only wiki skill
-@Ferris deepwiki https://github.com/honojs/hono --pin v4.6.0         — pinned version
+@Ferris forge-auto https://github.com/honojs/hono                     — zero-ceremony skill
+@Ferris forge-auto https://docs.example.com                            — docs-only skill
+@Ferris forge-auto https://github.com/honojs/hono --pin v4.6.0         — pinned version
 @Ferris forge-quick @tanstack/query                                  — QS + TS + EX for TanStack Query
 @Ferris forge https://github.com/topoteretes/cognee cognee           — BS + CS + TS + EX, explicit URL + name
 @Ferris forge https://github.com/topoteretes/cognee cognee "public API only"   — with scope hint

--- a/src/shared/references/pipeline-contracts.md
+++ b/src/shared/references/pipeline-contracts.md
@@ -19,10 +19,12 @@ The forger also accepts common pipeline aliases:
 
 | Alias | Expands To | Description |
 |-------|-----------|-------------|
-| `deepwiki` | `AN[auto] BS[auto] CS TS[min:90] EX` | Full zero-ceremony wiki-skill pipeline |
+| `forge-auto` | `AN[auto] BS[auto] CS TS[min:90] EX` | Zero-ceremony auto-compile pipeline (bare repo/doc URL → verified skill) |
 | `forge` | `BS CS TS EX` | Full skill creation pipeline (brief through export) |
 | `forge-quick` | `QS TS EX` | Quick skill pipeline |
 | `maintain` | `AS US TS EX` | Maintenance cycle (audit → update → test → export) |
+
+**Deprecated alias:** `deepwiki` resolves to `forge-auto` (renamed to avoid collision with the DeepWiki MCP — the pipeline auto-forges a verified skill and does not call that MCP). It still works but emits a one-time deprecation notice.
 
 **Note:** `campaign` is a standalone workflow invoked via `@Ferris campaign`, not a pipeline alias. It orchestrates its own multi-stage pipeline internally with dependency tracking and resume.
 
@@ -37,7 +39,7 @@ The forger also accepts common pipeline aliases:
 
 ## Pipeline Arguments
 
-Pipeline-level arguments (e.g., `--pin <version>`) are passed to the first workflow's data context. The workflow decides how to consume them. For the `deepwiki` pipeline, `--pin` flows to AN, where `step-auto-scope.md §0b` uses it for pin resolution.
+Pipeline-level arguments (e.g., `--pin <version>`) are passed to the first workflow's data context. The workflow decides how to consume them. For the `forge-auto` pipeline, `--pin` flows to AN, where `step-auto-scope.md §0b` uses it for pin resolution.
 
 ## Data Flow
 

--- a/src/shared/scripts/skf-validate-pins.py
+++ b/src/shared/scripts/skf-validate-pins.py
@@ -5,7 +5,7 @@
 """SKF Validate Pins — resolve and validate version pins for a GitHub repository.
 
 Shared pin validation script consumed by skf-analyze-source (AN auto-scope,
-deepwiki --pin) and campaign workflows.  Validates that a user-supplied --pin
+forge-auto --pin) and campaign workflows.  Validates that a user-supplied --pin
 resolves to an existing tag or branch, or auto-resolves the latest release tag
 when no --pin is provided.
 

--- a/src/skf-analyze-source/references/step-shape-detect.md
+++ b/src/skf-analyze-source/references/step-shape-detect.md
@@ -62,7 +62,7 @@ When auto-scope detects a repo exceeding complexity thresholds, it recommends mu
 | Large export surface | `export_count > 500` `[PENDING VALIDATION]` | Shape detection `export_count` | Group by top-level source directory modules |
 | Multi-package / monorepo | `package_count > 3` `[PENDING VALIDATION]` | Shape detection `package_count` | One skill per workspace package |
 
-Both thresholds are marked `[PENDING VALIDATION]` — no empirical data exists yet for real-world repos. Expected tuning: after running deepwiki against 5–10 real repos, adjust thresholds based on whether decomposition produces useful skill boundaries or noise.
+Both thresholds are marked `[PENDING VALIDATION]` — no empirical data exists yet for real-world repos. Expected tuning: after running forge-auto against 5–10 real repos, adjust thresholds based on whether decomposition produces useful skill boundaries or noise.
 
 When both thresholds are met simultaneously, the monorepo path takes priority (package boundaries are explicit; export-count grouping is heuristic).
 

--- a/src/skf-brief-skill/references/step-auto-validate.md
+++ b/src/skf-brief-skill/references/step-auto-validate.md
@@ -75,7 +75,7 @@ Scope:        {scope_type} ({N} include, {M} exclude patterns)
 Docs:         {doc_urls count} sources detected | "None detected"
 Version:      {version}
 Forge Tier:   {forge_tier}
-Quality:      90% target (deepwiki pipeline)
+Quality:      90% target (forge-auto pipeline)
 Description:  "{description}"
 ```
 

--- a/src/skf-campaign/references/campaign-directive-spec.md
+++ b/src/skf-campaign/references/campaign-directive-spec.md
@@ -59,7 +59,7 @@ Example:
 ## Pipeline Flags
 
 - Use `--pin main` for all unpinned skills
-- Force deepwiki mode for large-repo-z
+- Force forge-auto mode for large-repo-z
 ```
 
 ### `## Notes`

--- a/src/skf-create-skill/references/step-doc-sources.md
+++ b/src/skf-create-skill/references/step-doc-sources.md
@@ -21,7 +21,7 @@ Record detected documentation pages and README with content hashes in metadata.j
 
 ### 1. Check for Upstream Doc Detection Results
 
-Check if `doc_detection_results` is already populated in the workflow context (set by BS auto-brief in the deepwiki pipeline).
+Check if `doc_detection_results` is already populated in the workflow context (set by BS auto-brief in the forge-auto pipeline).
 
 - **If upstream results exist:** use them directly, skip to step 3.
 - **If no upstream results:** continue to step 2.

--- a/src/skf-forger/SKILL.md
+++ b/src/skf-forger/SKILL.md
@@ -85,17 +85,21 @@ When the user provides multiple workflow codes (e.g., `BS CS TS EX`, `QS TS EX`,
 
 **Pipeline activation:**
 
-1. **Parse the sequence** — split codes, expand aliases (`deepwiki` → `AN[auto] BS[auto] CS TS[min:90] EX`, `forge` → `BS CS TS EX`, `forge-quick` → `QS TS EX`, `maintain` → `AS US TS EX`), extract any bracket arguments (`CS[cocoindex]`, `TS[min:80]`)
+1. **Parse the sequence** — split codes, expand aliases (`forge-auto` → `AN[auto] BS[auto] CS TS[min:90] EX`, `forge` → `BS CS TS EX`, `forge-quick` → `QS TS EX`, `maintain` → `AS US TS EX`), extract any bracket arguments (`CS[cocoindex]`, `TS[min:80]`)
+   **Deprecated aliases:** If the parsed alias is `deepwiki`, expand it exactly as `forge-auto` and set `{pipeline_alias}` to `forge-auto`, but first emit a one-time notice:
+
+   > ⚠️ **`deepwiki` is now `forge-auto`.** The alias was renamed to avoid confusion with the DeepWiki MCP — this pipeline auto-forges a verified skill from source and does **not** call that MCP. `deepwiki` still works as a deprecated alias; prefer `forge-auto <repo-url>` going forward.
+
    **Removed aliases:** If the parsed alias is `onboard`, do NOT expand it. Instead, HALT with:
 
-   > 🚫 **onboard has been removed.** Use `deepwiki <repo-url>` instead. deepwiki auto-scopes, auto-briefs, and tests at 90% quality. Run `deepwiki` with any GitHub URL, doc URL, or `--pin <version>`.
+   > 🚫 **onboard has been removed.** Use `forge-auto <repo-url>` instead. forge-auto auto-scopes, auto-briefs, and tests at 90% quality. Run `forge-auto` with any GitHub URL, doc URL, or `--pin <version>`.
 
 2. **Validate the sequence** — check for anti-patterns (EX before TS, CS without BS, duplicates). If found, warn the user and ask to confirm or adjust. In `{headless_mode}`, warn but proceed.
 3. **Set `{headless_mode}` = true** — pipelines auto-activate headless mode for all workflows in the chain. The user committed to the sequence by providing it.
 4. **Execute left to right** — for each workflow in the sequence:
    - a. **Report start**: "Pipeline [{current}/{total}]: Starting {code} ({description})..."
    - b. **Resolve inputs** from the previous workflow's output using the Data Flow table in pipeline-contracts.md. If the previous workflow produced a `skill_name`, `brief_path`, or other handoff data, pass it as the input argument.
-   - c. **Invoke the workflow** with `{headless_mode}` = true, `{pipeline_alias}` set to the alias name (`deepwiki`, `forge`, `forge-quick`, `maintain`, or `null` for ad-hoc sequences), and any resolved arguments.
+   - c. **Invoke the workflow** with `{headless_mode}` = true, `{pipeline_alias}` set to the alias name (`forge-auto`, `forge`, `forge-quick`, `maintain`, or `null` for ad-hoc sequences; a `deepwiki` invocation resolves to `forge-auto`), and any resolved arguments.
    - d. **Check circuit breaker** after completion. Load the output artifact and validate against the threshold (default or user-specified via `[min:N]`). If the check fails: halt the pipeline, report what completed and what remains.
    - e. **Report completion**: "Pipeline [{current}/{total}]: {code} complete — {brief summary of output}."
 5. **Pipeline summary** — after all workflows complete (or on halt), present a summary:
@@ -105,7 +109,7 @@ When the user provides multiple workflow codes (e.g., `BS CS TS EX`, `QS TS EX`,
    - Next steps recommendation
 6. **Result Contract** — write the pipeline result contract per `shared/references/output-contract-schema.md`: the per-run record at `{sidecar_path}/pipeline-result-{YYYYMMDD-HHmmss}.json` (UTC timestamp, resolution to seconds) and a copy at `{sidecar_path}/pipeline-result-latest.json` (stable path for pipeline consumers — copy, not symlink). Include one entry per completed workflow in `outputs` (referencing each workflow's own `-latest.json` result record); include per-step status and the overall pipeline status in `summary`.
 
-**deepwiki pipeline note:** `deepwiki <repo-url> --pin <version>` — the `--pin` argument is passed to AN's pipeline data context alongside the `[auto]` flag. AN's `step-auto-scope.md §0b` consumes it for pin resolution.
+**forge-auto pipeline note:** `forge-auto <repo-url> --pin <version>` — the `--pin` argument is passed to AN's pipeline data context alongside the `[auto]` flag. AN's `step-auto-scope.md §0b` consumes it for pin resolution.
 
 **Special pipeline behaviors:**
 - `AN` in a pipeline with `CS`: if AN produces multiple recommended briefs, auto-select all and process sequentially in batch mode. If only one unit found, auto-select it.

--- a/src/skf-setup/references/report.md
+++ b/src/skf-setup/references/report.md
@@ -137,7 +137,7 @@ Load and read {tierRulesData} for the tier capability descriptions and re-run me
 ═══════════════════════════════════════
 
 {if {headless_mode} is false:}
-  Next: the fastest start is `@Ferris deepwiki <repo-or-doc-url>` — one command auto-scopes, briefs, compiles, tests at a 90% quality gate, and exports a verified skill with zero configuration. Prefer to scope by hand? `/skf-brief-skill` scopes your first compilation target, or `/skf-quick-skill` is a fast template-driven path. Already have a skill? `/skf-audit-skill` drift-checks an existing skill against current sources.
+  Next: the fastest start is `@Ferris forge-auto <repo-or-doc-url>` — one command auto-scopes, briefs, compiles, tests at a 90% quality gate, and exports a verified skill with zero configuration. Prefer to scope by hand? `/skf-brief-skill` scopes your first compilation target, or `/skf-quick-skill` is a fast template-driven path. Already have a skill? `/skf-audit-skill` drift-checks an existing skill against current sources.
 ```
 
 All re-run-delta context flags (`{tools_added}`, `{tools_removed}`, `{tier_changed}`) come from the detector's `deltas` block bound in stage 1 — no LLM-side recomputation, no set arithmetic in prose.

--- a/src/skf-test-skill/references/init.md
+++ b/src/skf-test-skill/references/init.md
@@ -46,7 +46,7 @@ If `{pipeline_alias}` is set in the workflow data context (forwarded by the forg
 
 | Pipeline Alias | Default Threshold |
 |----------------|-------------------|
-| `deepwiki`     | 90                |
+| `forge-auto`   | 90                |
 | `forge`        | 80                |
 | `forge-quick`  | 80                |
 | `campaign`     | 90                |

--- a/test/test-skf-per-pipeline-thresholds.py
+++ b/test/test-skf-per-pipeline-thresholds.py
@@ -67,7 +67,7 @@ class TestInitPipelineThresholdSection:
     @pytest.mark.parametrize(
         "alias,threshold",
         [
-            ("deepwiki", "90"),
+            ("forge-auto", "90"),
             ("forge", "80"),
             ("forge-quick", "80"),
             ("campaign", "90"),
@@ -338,7 +338,7 @@ class TestForgerPipelineAlias:
         )
 
     def test_step_4c_lists_alias_names(self, pipeline_section: str) -> None:
-        for alias in ("deepwiki", "forge", "forge-quick", "onboard", "maintain"):
+        for alias in ("forge-auto", "forge", "forge-quick", "maintain"):
             assert alias in pipeline_section, (
                 f"Pipeline Mode §4.c must list '{alias}' as a possible alias value"
             )
@@ -472,14 +472,14 @@ class TestCrossFileConsistency:
             "init.md --threshold flag description must reference per-pipeline defaults"
         )
 
-    def test_deepwiki_alias_threshold_matches_lookup_table(self) -> None:
+    def test_forge_auto_alias_threshold_matches_lookup_table(self) -> None:
         forger_text = _read(FORGER_MD)
         assert re.search(r"TS\[min:90\]", forger_text), (
-            "deepwiki alias expansion must include TS[min:90]"
+            "forge-auto alias expansion must include TS[min:90]"
         )
         init_text = _read(INIT_FILE)
-        assert re.search(r"\|\s*`deepwiki`\s*\|\s*90\s*\|", init_text), (
-            "init.md lookup table must map deepwiki → 90 matching the forger alias"
+        assert re.search(r"\|\s*`forge-auto`\s*\|\s*90\s*\|", init_text), (
+            "init.md lookup table must map forge-auto → 90 matching the forger alias"
         )
 
     def test_forge_alias_has_no_min_override(self) -> None:

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -357,7 +357,7 @@ class UI {
         `1. Open this folder in ${ideDisplay}`,
         `2. Activate Ferris:  ${activateLine}`,
         '3. Ferris (your Skill Architect) guides you through forge setup',
-        `4. Fastest first skill — ask Ferris to run ${brand.gold('deepwiki <repo-or-doc-url>')}:`,
+        `4. Fastest first skill — ask Ferris to run ${brand.gold('forge-auto <repo-or-doc-url>')}:`,
         '   one command auto-scopes, compiles, tests, and exports a verified skill',
       ].join('\n');
     }

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -111,7 +111,7 @@ export default defineConfig({
           label: 'Try',
           items: [
             { label: 'Getting Started', slug: 'getting-started' },
-            { label: 'Deepwiki', slug: 'deepwiki' },
+            { label: 'Forge-Auto', slug: 'forge-auto' },
             { label: 'Campaign', slug: 'campaign' },
             { label: 'How It Works', slug: 'how-it-works' },
             { label: 'Examples', slug: 'examples' },


### PR DESCRIPTION
## Summary

The `deepwiki` pipeline alias (`AN[auto] BS[auto] CS TS[min:90] EX`) collided with the **DeepWiki MCP** product: a user with that MCP installed ran `@Ferris deepwiki <aws-sdk repo>` and was confused the output wasn't a deepwiki-style wiki — because the alias is just a codename for a zero-ceremony auto-compile pipeline and **never calls the MCP**. This renames it to **`forge-auto`**, which fits the `forge` / `forge-quick` family and describes what it does.

The name was chosen via a multi-perspective review (PM/Architect/UX/Analyst) plus an empirical collision check that **ruled out `autoforge`** — it has a 1,757★ AI-space namesake (`AutoForgeAI/autoforge`), i.e. the exact failure mode we're escaping. `forge-auto` had no external or internal collision.

## What changed

- **Canonical alias** → `forge-auto`, in `skf-forger/SKILL.md` and `shared/references/pipeline-contracts.md`, plus the per-pipeline threshold tables (`init.md`) and prose references across step files.
- **`deepwiki` kept as a deprecated alias** — it resolves to `forge-auto` and emits a one-time notice (`"deepwiki is now forge-auto — it does not call the DeepWiki MCP"`), so nothing breaks.
- **Real DeepWiki MCP references left untouched** — `skf-update-skill/re-extract.md` and `skf-test-skill/source-access-protocol.md` use the actual MCP as a source-access fallback; those were deliberately *not* renamed.
- **Docs:** renamed `docs/deepwiki.md → docs/forge-auto.md`, updated the sidebar, README, getting-started, installer (`ui.js`), and setup breadcrumb, and **dropped the misleading "wiki skill" framing** throughout (the whole point of the rename).
- **Tests** updated (`test-skf-per-pipeline-thresholds.py`).

## Decision trail

The rename resolves the naming collision; the alternative — wiring the DeepWiki MCP into the pipeline to "make the name honest" — was rejected because the MCP can be stale vs. the pinned commit or absent for many repos, which would break SKF's reproducible-provenance guarantee. That capability is parked as a separate, firewalled, opt-in experiment in #425.

## Testing

Full suite green: 2251 Python tests, 0 broken refs, markdown lint / doc links / file refs all clean. The page rename is tracked as a git rename; the deprecated alias means zero breakage for existing `deepwiki` invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)