### PR TITLE
Register skf-campaign in the module help menu

### DIFF
--- a/src/module-help.csv
+++ b/src/module-help.csv
@@ -1,6 +1,7 @@
 module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
 skf,skf-forger,Ferris — Skill Forge Agent,FF,"Skill compilation specialist — the forge master. Invoke to access all SKF workflows via guided menu.",,,anytime,,,false,,
-skf,skf-setup,Setup Forge,SF,"Initialize forge environment — detect tools and set capability tier (Quick/Forge/Forge+/Deep)",,,anytime,,"skf-analyze-source,skf-brief-skill,skf-quick-skill,skf-verify-stack",false,,forge-tier.yaml
+skf,skf-setup,Setup Forge,SF,"Initialize forge environment — detect tools and set capability tier (Quick/Forge/Forge+/Deep)",,,anytime,,"skf-analyze-source,skf-brief-skill,skf-quick-skill,skf-verify-stack,skf-campaign",false,,forge-tier.yaml
+skf,skf-campaign,Campaign,CA,"Orchestrate multi-library skill production across sessions — dependency tracking, file-based state, and resume",,resume [--from=<skill>],anytime,skf-setup,,false,forge_data_folder,_campaign-state.yaml
 skf,skf-analyze-source,Analyze Source,AN,"Discover what to skill in a large repo — produces recommended skill briefs",,,anytime,skf-setup,skf-brief-skill,false,forge_data_folder,skill-brief.yaml
 skf,skf-brief-skill,Brief Skill,BS,"Design a skill scope through guided discovery",,,anytime,"skf-setup,skf-analyze-source",skf-create-skill,false,forge_data_folder,skill-brief.yaml
 skf,skf-create-skill,Create Skill,CS,"Compile a skill from a brief — supports --batch for multiple briefs",,--batch,anytime,skf-brief-skill,"skf-test-skill,skf-create-stack-skill",false,skills_output_folder,SKILL.md


### PR DESCRIPTION
## What

Registers the `skf-campaign` skill in `src/module-help.csv` so it appears in bmad-help routing alongside the rest of the SKF menu.

## Why

The campaign orchestrator skill was added (2026-05-27) after the help CSV was last regenerated (2026-04-12). It had a `SKILL.md` and was already surfaced in the agent menu (`skf-forger`), but was missing from `module-help.csv` — so the two menu surfaces had drifted.

## Change

- New `Campaign` (menu-code `CA`) entry: `after: skf-setup`, top-level orchestrator (no `before`), outputs `_campaign-state.yaml` to `forge_data_folder`.
- Added `skf-campaign` to `skf-setup`'s `before` list to keep the before/after dependency graph bidirectionally consistent (every entry whose `after` includes `skf-setup` is mirrored in `skf-setup`'s `before`).

## Validation

- Structural validation passes: 18 entries, 0 critical/high findings, unique menu codes, both rows parse to 13 columns.
- before/after graph verified symmetric across the whole CSV.
- Full test suite green (Python, markdownlint, prettier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)