### PR TITLE
docs: true up pages against current workflow behavior

### DIFF
--- a/docs/_data/pinned.yaml
+++ b/docs/_data/pinned.yaml
@@ -5,7 +5,7 @@
 # canonical SKF reference output.
 #
 # Every time a skill is recompiled in oh-my-skills, update the matching
-# entry here and then run `npm run validate:docs-drift` from the SKF repo
+# entry here and then run `npm run docs:validate-drift` from the SKF repo
 # root. The script will:
 #
 #   1. Verify every skill below actually exists at the claimed version and

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -72,6 +72,7 @@ DELIVER:
 MANAGE:
   [RS] Rename Skill — Rename across all versions (transactional)
   [DS] Drop Skill — Deprecate or purge a skill version
+  [CA] Campaign — Orchestrate many coordinated skills across sessions (@Ferris campaign)
 
 [WS] Workflow Status — Show current lifecycle position
 [KI] Knowledge Index — List available knowledge fragments
@@ -81,12 +82,13 @@ PIPELINE ALIASES:
   [forge] Brief → Create → Test → Export
   [forge-quick] Quick Skill → Test → Export
   [maintain] Audit → Update → Test → Export
-  [campaign] Orchestrate many coordinated skills across sessions
 ```
 
 **Pipeline Aliases:**
 
-Ferris chains multiple workflows in one command via named aliases (`forge-auto`, `forge`, `forge-quick`, `maintain`, `campaign`). The full alias table, expansion rules, and target-resolution contract live in [Workflows → Pipeline Mode](../workflows/#pipeline-mode) — the canonical source. Example: `@Ferris forge-quick cognee` chains Quick → Test → Export with automatic data forwarding.
+Ferris chains multiple workflows in one command via named aliases (`forge-auto`, `forge`, `forge-quick`, `maintain`). The full alias table, expansion rules, and target-resolution contract live in [Workflows → Pipeline Mode](../workflows/#pipeline-mode) — the canonical source. Example: `@Ferris forge-quick cognee` chains Quick → Test → Export with automatic data forwarding.
+
+`campaign` is not a chaining alias — it is a standalone orchestrator workflow (`@Ferris campaign`) that runs its own multi-stage pipeline internally, with dependency tracking and resume. See the [Campaign](../campaign/) page.
 
 **Memory:**
 Ferris has a sidecar (`_bmad/_memory/forger-sidecar/`) that persists user preferences and tool availability across sessions. Set `headless_mode: true` in preferences to make headless the default.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,8 @@ Each workflow directory contains these files, and each has a specific job:
 | File                      | What it does                                                                                                        | When it loads                                     |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
 | `SKILL.md`                | Human-readable entry point — goals, role definition, initialization sequence, invocation contract, routes to first step | Entry point per workflow                          |
-| `references/*.md`            | **Create** steps — primary execution, 4–10 sequential files per workflow (the last one always chains to the shared health check) | One at a time (just-in-time)                      |
-| `references/*.md`         | Workflow-specific reference data — rules, patterns, protocols                                                       | Read by steps on demand                           |
+| `references/*.md` (step files)    | **Create** steps — primary execution, sequential step files per workflow (the last one always chains to the shared health check) | One at a time (just-in-time)                      |
+| `references/*.md` (reference data) | Workflow-specific reference data — rules, patterns, protocols                                                       | Read by steps on demand                           |
 | `assets/*.md`             | Workflow-specific output formats — schemas, templates, heuristics                                                   | Read by steps on demand                           |
 | `templates/*.md`          | Output skeletons with placeholder vars — steps fill these in to produce the final artifact                          | Read by steps when generating output              |
 | `scripts/*.py`            | Deterministic Python scripts — scoring, validation, structural diffing, manifest operations                         | Invoked by steps via `uv run` for reproducible computation |
@@ -35,7 +35,7 @@ Each workflow directory contains these files, and each has a specific job:
 | `skf-forger/SKILL.md`     | Expert persona — identity, principles, critical actions, menu of triggers                                           | First — always in context                         |
 | `knowledge/skf-knowledge-index.csv` | Knowledge fragment index — id, name, tags, tier, file path                                                          | Read by steps to decide which fragments to load   |
 | `knowledge/*.md`          | 14 reusable fragments + overview.md index — cross-cutting principles and patterns (e.g., `zero-hallucination.md`, `confidence-tiers.md`, `ccc-bridge.md`) | Selectively read into context when a step directs |
-| `shared/scripts/*.py`     | 7 cross-workflow Python scripts — preflight checks, manifest ops, managed-section rebuilds, frontmatter validation, severity classification, structural diffing, skill inventory | Invoked by any workflow that needs deterministic computation |
+| `shared/scripts/*.py`     | Cross-workflow Python scripts — preflight checks, manifest ops, managed-section rebuilds, frontmatter/output validation, severity classification, structural diffing, skill inventory, result-envelope emission, language/docs/tools detection, content hashing, atomic writes (see [`src/shared/scripts/`](https://github.com/armelhbobdad/bmad-module-skill-forge/tree/main/src/shared/scripts)) | Invoked by any workflow that needs deterministic computation |
 
 ```mermaid
 flowchart LR
@@ -71,7 +71,7 @@ Ferris operates in five workflow-driven modes (mode is determined by which workf
 | **Surgeon**   | US                 | Precise, semantic diffing — preserves [MANUAL] sections during regeneration |
 | **Audit**     | AS, TS, VS         | Judgmental, scoring — evaluates quality and detects drift   |
 | **Delivery**  | EX                 | Validates package, generates snippets, injects into context files |
-| **Management** | RS, DS            | Transactional rename/drop — copy-verify-delete with platform context rebuild |
+| **Management** | RS, DS, CA        | Transactional rename/drop — copy-verify-delete with platform context rebuild; campaign orchestration sequences workflows and tracks per-skill state |
 
 ---
 

--- a/docs/campaign.md
+++ b/docs/campaign.md
@@ -15,11 +15,22 @@ When your architecture declares many dependencies, running individual pipelines 
 @Ferris campaign                           — start a new campaign
 @Ferris campaign resume                    — resume from the last active skill
 @Ferris campaign resume --from=<skill>     — resume from a specific skill
+@Ferris campaign status                    — read-only progress summary
 ```
 
 - **`campaign`** starts a new campaign from stage 0 (Setup). If a `_campaign-state.yaml` already exists, Ferris offers a choice: resume the existing campaign or overwrite with a new one.
 - **`campaign resume`** picks up where the last session left off. State is validated on load — if the state file is corrupted, the `.bak` file is used as a fallback.
+- **`campaign status`** loads and validates the current state, prints the resume-detection summary plus the tail of the decision log, then stops — no backup, no mutation, no chaining. Use it to check on a long-running campaign without advancing it.
 - **`--from=<skill>`** overrides the resume point to the named skill, useful when you want to re-process a specific skill without restarting the entire campaign.
+
+### Override flags
+
+| Flag | Effect |
+|------|--------|
+| `--headless` / `-H` | Auto-proceed every gate with its default action and emit structured output (see [Headless / Automation](#headless--automation)). |
+| `--brief <file>` | Seed targets from a `campaign-brief.yaml` instead of interactive prompts. Implies `--headless`. |
+| `--manifest <file>` | Seed targets from a plain-text `name,repo_url,tier,pin` manifest (one per line; trailing `;dep1,dep2` for `depends_on`). Implies `--headless`. |
+| `--from=<skill>` | Resume override (see above). |
 
 ---
 
@@ -33,7 +44,7 @@ Campaign runs through 11 stages (0–10). All stages auto-proceed except Export,
 | 1 | Strategy | Generate the campaign brief from architecture and dependency analysis | Yes |
 | 2 | Pin Validation | Validate version pins for all declared dependencies | Yes |
 | 3 | Provenance | Establish provenance records for each target library | Yes |
-| 4 | Skill Loop | Drive each Tier A skill through the full pipeline (BS → CS → TS → EX) in dependency order | Yes |
+| 4 | Skill Loop | Drive each Tier A skill through its forge pipeline (AN → BS → CS → TS) in dependency order — export is deferred to the gated Export stage | Yes |
 | 5 | Tier B Batch | Process Tier B skills (lower-priority or transitive dependencies) in batch mode | Yes |
 | 6 | Capstone | Generate stack skill(s) that integrate individual skills into a cohesive project context | Yes |
 | 7 | Verification | Run verification passes across all produced skills for cross-skill consistency | Yes |
@@ -63,8 +74,21 @@ Campaign sorts skills topologically by their dependency graph. If skill B depend
 
 ### Tier A vs Tier B
 
-- **Tier A** — primary dependencies declared in the architecture. Each gets a full individual pipeline run (BS → CS → TS → EX) during the Skill Loop stage.
+- **Tier A** — primary dependencies declared in the architecture. Each gets a full individual pipeline run (AN → BS → CS → TS) during the Skill Loop stage; the tested skills are exported collectively at the gated Export stage.
 - **Tier B** — secondary or transitive dependencies. Processed in batch during the Tier B Batch stage with lighter-touch quality requirements.
+
+### Customization
+
+Campaign ships a `customize.toml` workflow surface you can tune without forking the skill. The resolver merges three layers (scalars override, arrays append): the bundled `customize.toml`, then a committed team override at `_bmad/custom/<skill-name>.toml`, then a personal (gitignored) override at `_bmad/custom/<skill-name>.user.toml` — both under {project-root}. What you can set:
+
+- **Quality-gate scalars** — `quality_gate_hard`, `quality_gate_soft_target`, `quality_gate_soft_fallback` (the thresholds above).
+- **`campaign_workspace_path`** — relocate the entire campaign workspace (state, backup, brief, archive, decision log) to a shared volume without editing any step file; empty means the default `{forge_data_folder}/_campaign`.
+- **`persistent_facts`** — literal sentences or `file:` references (globs supported) injected into every per-skill kickoff, so house style and guardrails reach the whole campaign.
+- **Template overrides** — `report_template_path`, `kickoff_template_path`, `brief_template_path` for house-style copies.
+- **`on_complete`** — a post-completion hook invoked with `--report-path=<…>` after the report finalizes; hook failures are logged but never fail the campaign.
+- **`activation_steps_prepend` / `activation_steps_append`** — org-wide pre-flight or context-load steps around activation.
+
+See the skill's [SKILL.md](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-campaign/SKILL.md) for the full merge contract.
 
 ---
 
@@ -72,8 +96,13 @@ Campaign sorts skills topologically by their dependency graph. If skill B depend
 
 Campaign enforces two types of quality gates:
 
-- **Hard gate** — zero critical or high-severity issues allowed. Any skill that fails the hard gate is flagged for manual intervention and blocks the campaign from proceeding past that skill.
-- **Soft gate** — per-pipeline quality thresholds (e.g., 80% for forge, 90% for forge-auto). Skills that score between the hard floor (60%) and the per-pipeline threshold receive a fallback PASS with an evidence report, and the campaign continues.
+The bar is **campaign-wide** — one set of thresholds applied to every skill, not a per-pipeline split:
+
+- **Hard gate** (`zero-critical-high`) — zero critical or high-severity issues allowed. Any skill that fails the hard gate is flagged for manual intervention and blocks the campaign from proceeding past that skill.
+- **Soft target** (default 90%) — the score a skill should reach.
+- **Soft fallback** (default 80%) — the floor. A skill scoring at or above the fallback but below the target still proceeds; only a skill below the fallback is treated as a soft-gate miss.
+
+All three are tunable via [customization](#customization); the per-campaign brief and any directive `## Quality Overrides` still take precedence at runtime.
 
 ---
 
@@ -90,6 +119,12 @@ When you resume:
 
 Use `--from=<skill>` to override the resume point if you need to re-process a specific skill.
 
+### Re-invocation and recovery
+
+- **`campaign` over an existing state** prompts resume-vs-overwrite. Choosing overwrite first archives the existing `_campaign-state.yaml` and `campaign-brief.yaml` to `archive/{name}-{timestamp}/` and logs it to the decision log, so a new campaign never silently clobbers an old one. In headless mode the default is **resume** — archive-and-overwrite happens only when `--brief`/`--manifest` explicitly seeds a new campaign.
+- **Corrupt primary, valid `.bak`** — resume auto-recovers by restoring the backup over the primary and logging the recovery; if the backup is also unusable it HALTs (exit 9, `corrupt-state`) reporting both errors.
+- **Primary behind the backup** — if the primary looks older than the `.bak` (a possible crash during the last write), Ferris offers `[R]ecover` from the backup or `[K]eep` the primary (the default; headless keeps the primary).
+
 ---
 
 ## Expected Output
@@ -105,9 +140,21 @@ The Export stage (stage 9) is the only non-auto-proceed stage. Ferris presents a
 
 ---
 
+## Headless / Automation
+
+Campaign is a first-class headless front door for unattended, multi-session production. Add `--headless` / `-H` (or set `headless_mode: true` in preferences); `--brief`/`--manifest` imply it and seed targets non-interactively. In headless mode every confirmation gate auto-proceeds with its default action, each step emits a single-line JSON progress event to **stderr** on entry and exit (`{"stage":N,"name":"<slug>","status":"start|done"}`), and the terminal step emits the `SKF_CAMPAIGN_RESULT_JSON` envelope on stdout.
+
+- **Cancel affordance** — at any interactive gate the operator can type `cancel`, `exit`, or `:q` to leave cleanly; the campaign HALTs with exit code 12 (`user-cancelled`), logs the cancellation, and leaves state intact and resumable. The Export gate is the exception: its own `[C]ancel` exits 11 (`export-cancelled`).
+- **Exit codes** — every HARD HALT exits with a stable, documented code so automators branch on the failure class without grepping message text: `0` success, `3` invalid-state, `4` circular-deps, `5` invalid-pin, `6` inaccessible-repo, `7` dependency-deadlock, `8` missing-brief, `9` corrupt-state, `10` report-failure (degraded — the campaign still completes), `11` export-cancelled, `12` user-cancelled.
+- **Error envelope** — on any HARD HALT the `SKF_CAMPAIGN_RESULT_JSON` envelope is emitted on stderr in its error variant, carrying `status: "error"`, `exit_code`, the `phase` (step slug), and an `error` object with `code` and `message`.
+
+The full exit-code table and envelope schema live in the skill's [SKILL.md](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-campaign/SKILL.md) under "Exit Codes" and "Result Contract on HARD HALT".
+
+---
+
 ## Timing
 
-Campaign duration scales with the number of declared dependencies — each Tier A skill runs a full `BS → CS → TS → EX` pipeline, and Tier B skills run in batch. A campaign is explicitly designed to **span multiple sessions**: file-based state means you can stop after any skill and resume later without losing progress. Factors that affect total time:
+Campaign duration scales with the number of declared dependencies — each Tier A skill runs a full `AN → BS → CS → TS` pipeline, and Tier B skills run in batch. A campaign is explicitly designed to **span multiple sessions**: file-based state means you can stop after any skill and resume later without losing progress. Factors that affect total time:
 
 - **Skill count and tier mix** — Tier A skills (a full pipeline each) dominate; Tier B batch processing is lighter per skill.
 - **Dependency depth** — deep graphs serialize more work (downstream skills wait on upstream APIs); wide, shallow graphs spread more naturally across sessions.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -184,7 +184,11 @@ Skills accumulate over sprints. The agent's coverage improves each iteration.
 
 Blondin, a platform lead, needs cross-service knowledge for 10 microservices so agents can navigate shared types and cross-calls.
 
-One forge project, multiple QMD collections, hub-and-spoke skills with integration patterns.
+```
+@Ferris campaign    # Orchestrate all 10 skills across sessions, in dependency order
+```
+
+Campaign reads the dependency graph, sorts the skills topologically, and drives each one through the full pipeline (brief, generate, compile, test) with quality gates enforced. State is written to disk, so Blondin can walk away and `@Ferris campaign resume` after a context death or a session break — picking up exactly where the last session stopped. One forge project, multiple QMD collections, hub-and-spoke skills with integration patterns. See [Campaign Orchestration](../campaign/) for the full stage-by-stage flow.
 
 ### Scenario C: External Dependency
 

--- a/docs/forge-auto.md
+++ b/docs/forge-auto.md
@@ -31,7 +31,7 @@ forge-auto expands to `AN[auto] BS[auto] CS TS[min:90] EX`. The two analysis sta
 
 | Stage | Workflow | Mode | What Happens |
 |-------|----------|------|-------------|
-| 1 | **Analyze Source** (AN) | `[auto]` | Scans the target, detects shape (library/framework/tool/app), discovers exports, and generates a scope + brief automatically. |
+| 1 | **Analyze Source** (AN) | `[auto]` | Scans the target, detects shape (`library-API`, `reference-app`, `language-reference`, `stack-compose`, or `unknown`), discovers exports, and generates a scope + brief automatically. |
 | 2 | **Brief Skill** (BS) | `[auto]` | Enriches the auto-generated brief with doc detection results. No interactive scoping — the brief is assembled from AN's output. |
 | 3 | **Create Skill** (CS) | standard | Compiles the skill from the enriched brief. Extracts exports, resolves documentation sources, validates structure. |
 | 4 | **Test Skill** (TS) | `[min:90]` | Verifies completeness with a **90% quality threshold** (stricter than the default 80%). Fail halts the pipeline. |
@@ -45,10 +45,11 @@ Data flows automatically between stages — the brief path from AN feeds BS, the
 
 forge-auto's `[auto]` flags activate several behaviors that normally require manual input:
 
-- **Auto-scope** — shape detection (library, framework, tool, application) drives scope decisions. No interactive scope confirmation.
+- **Auto-scope** — shape detection (`library-API`, `reference-app`, `language-reference`, `stack-compose`) drives scope decisions, mapping onto `scope.type` values like `full-library`, `public-api`, and `reference-app`. No interactive scope confirmation.
 - **Auto-brief** — the brief is generated and enriched with doc-detection results in one pass, without the interactive discovery flow that `BS` uses standalone.
 - **Coexistence detection** — if a skill for the same target already exists, forge-auto detects it and offers three options: create alongside (new version), merge into the existing skill, or skip.
-- **Auto-decomposition** — for massive repos (>500 exports or >3 packages), AN automatically decomposes into multiple analysis units before proceeding.
+- **Auto-decomposition** — multi-package monorepos (>3 packages) flag a *decomposition candidate*; a cohesion check then decides whether to merge into one cohesive skill (the usual outcome — published monorepos are mostly cohesive) or split into N. Exceeding 500 exports also flags a candidate. The default leans toward a single skill, not one-per-package.
+- **Language-reference handling** — for compiler, interpreter, or parser repos, AN classifies the target as a `language-reference`. For a *whole-language* reference (a compiler/interpreter), the skill's value is the language's prose — the guide and standard-library docs — not compiler internals, so AN seeds the canonical corpora. If none are found it records an honest **DEGRADED** caveat: the skill is low-value as code-only until you attach the language's guide and std/library docs (re-run with a doc URL, or enrich via `US`).
 
 ---
 
@@ -68,7 +69,7 @@ The quality threshold is 90% — if the skill scores below that, the pipeline ha
 
 A typical library (50–200 exports) takes **3–5 minutes** end to end. Factors that increase time:
 
-- Massive repos (>500 exports) trigger auto-decomposition, adding 1–3 minutes
+- Multi-package monorepos (>3 packages) flag a decomposition candidate; if the cohesion check splits the repo into N skills, add 1–3 minutes
 - Doc-only targets depend on documentation site size and structure
 - Deep-tier projects (with QMD and CCC) spend more time on enrichment
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -27,7 +27,7 @@ Ferris confirms the repository exists, detects its language, finds its version f
 
 ### 3. He extracts the API
 
-He reads cognee's source code, identifies the public exports, and pulls out function signatures, parameter types, and return types. At the Forge tier (with ast-grep installed), each signature is verified against the real syntax tree of the source. At Quick tier (no extra tools), he reads the file directly. Either way, nothing is invented — if he can't cite it, he doesn't include it.
+He reads cognee's source code, identifies the public exports, and pulls out function signatures, parameter types, and return types. Quick Skill always extracts at community quality — it does the same job whatever tools you have installed, reading the source directly to ground every signature. Nothing is invented — if he can't cite it, he doesn't include it.
 
 ### 4. He writes the skill with receipts
 
@@ -43,13 +43,15 @@ That tag means: *this came from AST extraction of this exact file at this exact 
 
 ### 5. You get a skill package
 
-Ferris writes a `SKILL.md` (the full instruction manual your agent loads on demand) and a `context-snippet.md` (an 80–120 token index). The snippet gets injected into your platform context file (`CLAUDE.md`, `AGENTS.md`, or `.cursorrules`) as an always-on reminder: *"This skill exists; read it before writing cognee code."* Both halves are load-bearing — see the [Dual-Output Strategy](../skill-model/#dual-output-strategy) for why.
+Ferris writes a `SKILL.md` (the full instruction manual your agent loads on demand) and a `context-snippet.md` (an 80–120 token index) alongside it. The snippet is the always-on reminder — *"This skill exists; read it before writing cognee code."* — but it isn't wired in automatically: when you run `export-skill`, the snippet gets injected into your platform context file (`CLAUDE.md`, `AGENTS.md`, or `.cursorrules`). Both halves are load-bearing — see the [Dual-Output Strategy](../skill-model/#dual-output-strategy) for why.
 
 ### 6. The audit trail stays on disk
 
-Alongside the skill, Ferris leaves a `provenance-map.json` (every receipt), an `evidence-report.md` (build audit trail), and the compilation config (`skill-brief.yaml`). Commit these with the skill and any teammate — or any skeptic — can reproduce the same output from the same source.
+Alongside the skill, Ferris leaves a `metadata.json` (the pinned source, commit SHA, and export count) and a timestamped result contract recording exactly what was written. Commit these with the skill and any teammate — or any skeptic — can see what was built from which commit.
 
 That's the whole pipeline. One trigger in, one verifiable skill out, every claim traceable back to a file and a commit.
+
+Quick Skill is the fastest path, not the most thorough one. When you want a full audit trail — a `provenance-map.json` of every receipt and an `evidence-report.md` build log, both produced from a `skill-brief.yaml` — run the brief-driven [`create-skill`](../workflows/#create-skill-cs) path instead.
 
 ---
 

--- a/docs/skill-model.md
+++ b/docs/skill-model.md
@@ -92,7 +92,7 @@ This is useful for comparing skill quality across tiers for the same target:
 # 4. Reset to tier_override: ~ (auto-detect)
 ```
 
-Set `tier_override` to `Quick`, `Forge`, `Forge+`, or `Deep`. Set to `~` (null) to return to auto-detection. The override is respected by all tier-aware workflows (CS, SS, US, AS, TS).
+Set `tier_override` to `Quick`, `Forge`, `Forge+`, or `Deep`. Set to `~` (null) to return to auto-detection. The override is respected by all tier-aware workflows (AN, BS, CS, SS, US, AS, TS).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,7 @@ If setup reports that ast-grep was not detected, install it to unlock the Forge 
 
 ### "No skill brief found"
 
-Run `@Ferris BS` first to create a skill brief, or use `@Ferris QS` for brief-less generation. `CS` requires either a brief or a direct invocation with scope arguments.
+Run `@Ferris BS` first to create a skill brief, or use `@Ferris QS` for brief-less generation. `CS` always requires a brief — either a `skill-brief.yaml` produced by `BS` (or `AN`), or pass the skill name so it resolves one from your forge-data folder. For brief-less generation use `QS`.
 
 ### "Ecosystem check: official skill exists"
 

--- a/docs/verifying-a-skill.md
+++ b/docs/verifying-a-skill.md
@@ -61,7 +61,7 @@ Every file in the per-skill output carries a specific job. Here's the lookup tab
 | Which symbols are documented and where did each come from? | `forge-data/{name}/{version}/provenance-map.json` |
 | What AST patterns were used for extraction? | `forge-data/{name}/{version}/extraction-rules.yaml` |
 | What signatures, types, and examples did the extractor actually capture? | `forge-data/{name}/{version}/evidence-report.md` |
-| How was the skill scored? Show me the math. | `forge-data/{name}/{version}/test-report-{name}.md` |
+| How was the skill scored? Show me the math. | `forge-data/{name}/{version}/test-report-{name}-{run_id}.md` (per-run, run-id-suffixed — newest wins) |
 | How was the skill scoped, and what was deliberately left out? | `forge-data/{name}/skill-brief.yaml` |
 
 Everything a reader needs to reconstruct the compilation is in the two sibling directories: `skills/` ships to consumers, `forge-data/` is the audit trail.

--- a/docs/why-skf.md
+++ b/docs/why-skf.md
@@ -52,7 +52,7 @@ See the [Verifying a Skill](../verifying-a-skill/) page for the full three-step 
 
 ### The curious developer
 
-Your agent just hallucinated a method that doesn't exist, again. You want this to stop, and you don't want to read a 569-line architecture page before running your first command.
+Your agent just hallucinated a method that doesn't exist, again. You want this to stop, and you don't want to read a long architecture reference before running your first command.
 → Start with [Getting Started](../getting-started/).
 
 ### The BMAD user

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -24,7 +24,10 @@ Trigger workflows by typing commands to [Ferris](../agents/). See [Concepts](../
 **Flags:**
 
 - `--require-tier=<Quick|Forge|Forge+|Deep>` — fail-fast for CI: if the calculated tier does not satisfy the requested tier (tool-prerequisite check, not a name comparison — Deep does NOT subsume Forge+ because Deep does not require ccc), the workflow halts with a "REQUIRED TIER NOT MET" block and exits without chaining to the health check. Pipelines branch on the JSON envelope's `require_tier_satisfied` field.
-- `--headless` / `-H` — see [Headless Mode](#headless-mode) below. For `/skf-setup` specifically, headless mode emits a single-line `SKF_SETUP_RESULT_JSON: {…}` envelope to stdout (schema-locked, includes `tier`, `previous_tier`, `tier_changed`, `tools`, `tools_added`/`removed`, `files_written`, `warnings`, `error`) and SUPPRESSES the human-readable banner — the entire payload pipelines need is on one parseable line.
+- `--orphan-action=<keep|remove>` — resolve the orphan QMD-collection removal gate non-interactively, even outside `--headless`.
+- `--ccc-skip-index` — skip CCC indexing (envelope `ccc_index.status` becomes `"skipped"`) — the fast re-probe lane to refresh the detected tier without paying the full re-index cost.
+- `--quiet` — suppress the human-readable FORGE STATUS banner and emit the envelope only.
+- `--headless` / `-H` — see [Headless Mode](#headless-mode) below. For `/skf-setup` specifically, headless mode emits a single-line `SKF_SETUP_RESULT_JSON: {…}` envelope to stdout (schema-locked, includes `status` — the primary branch field — plus `tier`, `previous_tier`, `tier_changed`, `tools`, `tools_added`/`removed`, `files_written`, `warnings`, `error`) and SUPPRESSES the human-readable banner — the entire payload pipelines need is on one parseable line.
 
 **Agent:** Ferris (Architect mode)
 
@@ -395,10 +398,10 @@ You can also set `headless_mode: true` in your forge preferences (`_bmad/_memory
 **Exception — `/skf-setup` headless emits a single-line JSON envelope.** Unlike other workflows, headless `/skf-setup` SUPPRESSES the human-readable status banner entirely and emits exactly one prefixed line on stdout:
 
 ```
-SKF_SETUP_RESULT_JSON: {"skf_setup":{"tier":"Deep","previous_tier":"Forge","tier_changed":true,"tools":{...},"tools_added":[...],"tools_removed":[],"config_path":"...","ccc_index":{...},"files_written":[...],"tier_override_active":false,"tier_override_invalid":false,"require_tier_satisfied":null,"warnings":[],"error":null}}
+SKF_SETUP_RESULT_JSON: {"skf_setup":{"status":"success","tier":"Deep","previous_tier":"Forge","tier_changed":true,"tools":{...},"tools_added":[...],"tools_removed":[],"config_path":"...","ccc_index":{...},"files_written":[...],"tier_override_active":false,"tier_override_invalid":false,"require_tier_satisfied":null,"warnings":[],"error":null}}
 ```
 
-Parent skills and CI pipelines `grep` one line out of the workflow log to learn the outcome — no ASCII-art parsing, no race against the [`forge-tier.yaml`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-setup/references/write-config.md) writer. The envelope schema is versioned at [`src/shared/scripts/schemas/skf-setup-result-envelope.v1.json`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/shared/scripts/schemas/skf-setup-result-envelope.v1.json) and asserted against on every emit.
+Parent skills and CI pipelines `grep` one line out of the workflow log to learn the outcome — no ASCII-art parsing, no race against the [`forge-tier.yaml`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-setup/references/write-config.md) writer. Branch on the top-level `status` field (`success`, `tier_failure`, `write_failure`, or `blocked`) rather than composing the outcome from `require_tier_satisfied` + `error`. The envelope schema is versioned at [`src/shared/scripts/schemas/skf-setup-result-envelope.v1.json`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/shared/scripts/schemas/skf-setup-result-envelope.v1.json) and asserted against on every emit.
 
 **Exception — `/skf-quick-skill` headless emits structured progress + result envelopes.** Headless `/skf-quick-skill` runs are first-class building blocks for batch automators. Three operational contracts beyond per-gate auto-proceed:
 
@@ -420,7 +423,7 @@ Parent skills and CI pipelines `grep` one line out of the workflow log to learn 
    | 3    | resolution-failure  |
    | 4    | write-failure       |
    | 5    | overwrite-cancelled |
-   | 6    | compile-cancelled   |
+   | 6    | user-cancelled      |
    | 7    | finalize-blocked    |
 
 3. **Error-variant result contract on every HARD HALT.** A `SKF_QUICK_SKILL_RESULT_JSON: {…}` envelope is emitted on `stderr` (always) and copied to `{skill_package}/quick-skill-result-latest.json` when the skill package is known (HALTs at step 5 §1 onward). The schema and full population rules live in [`src/skf-quick-skill/SKILL.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-quick-skill/SKILL.md) § "Result Contract on HARD HALT".
@@ -445,6 +448,12 @@ Parent skills and CI pipelines `grep` one line out of the workflow log to learn 
 3. **Final result envelope on every terminal exit.** Step-05 emits a single-line `SKF_BRIEF_RESULT_JSON: {…}` envelope on **stdout** before chaining to step 6 on success; every HARD HALT emits the same envelope shape on **stderr** with `status: "error"` and a typed `halt_reason` (`input-missing`, `input-invalid`, `forge-tier-missing`, `target-inaccessible`, `gh-auth-failed`, `write-failed`, `overwrite-cancelled`, `user-cancelled`). Full envelope schema and population rules in [`src/skf-brief-skill/SKILL.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-brief-skill/SKILL.md) § "Result Contract (Headless)".
 
 **Presets (`--preset <name>`).** Loads `{sidecar_path}/brief-presets/{name}.yaml` and merges its keys as defaults at step 1 §8; explicit headless args override preset values. The preset file is YAML containing any subset of the headless args above; unknown fields are ignored with a warning. Useful for repeated patterns — e.g. briefing 5 SaaS SDKs that all share `source_authority=community`, `scope_type=full-library`, `scripts_intent=skip`.
+
+**Exception — the management and verification workflows emit structured result envelopes too.** Beyond per-gate auto-proceed, Drop Skill, Rename Skill, and Refine Architecture each emit a single-line `SKF_*_RESULT_JSON: {…}` envelope on every terminal exit (`status: "success"` on the happy path, `status: "error"` with a typed `halt_reason` on any HARD HALT) and exit with a stable code so automators branch on the failure class without grepping message text. All three honour the universal `cancel`/`exit`/`:q` affordance at any prompt (exit `6`, `halt_reason: "user-cancelled"`).
+
+- **`/skf-drop-skill` (DS)** — exit `2` `input-missing`/`input-invalid`, `4` `write-failure` (covers manifest-write, context-rebuild, and full-purge `delete-failed`), `5` state-conflict (active-version guard). Schema and `halt_reason` list in [`src/skf-drop-skill/SKILL.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-drop-skill/SKILL.md) § "Exit Codes" / "Result Contract (Headless)".
+- **`/skf-rename-skill` (RS)** — exit `2` `input-missing`/`input-invalid`, `4` `write-failure` (`copy-failed`, `write-failed`, `manifest-write-failed`; the §7 context rebuild is best-effort and never halts), `5` state-conflict (name-collision, source-authority, concurrent-run lock). Schema in [`src/skf-rename-skill/SKILL.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-rename-skill/SKILL.md) § "Exit Codes" / "Result Contract (Headless)".
+- **`/skf-refine-architecture` (RA)** — exit `2` `input-missing`/`input-invalid`, `4` `write-failure`, `7` `inventory-unreliable`, `8` `recovery-failed` (durability state insufficient to reconstruct findings, or the compiled doc is missing its `## Refinement Summary`). Schema in [`src/skf-refine-architecture/SKILL.md`](https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/src/skf-refine-architecture/SKILL.md) § "Exit Codes" / "Result Contract (Headless)".
 
 ---
 


### PR DESCRIPTION
## Summary

Accuracy pass over `docs/` to catch up with the behavior changes merged since the last docs refresh (campaign hardening, the cross-skill headless-contract sweep, monorepo/shape-detection work, and the language-reference ladder). Every page was audited claim-by-claim against current `src/` ground truth, and each fix was independently re-verified before landing — one suspected staleness (the concepts.md cognee example) was refuted during verification and deliberately left untouched.

### Corrected claims
- **forge-auto**: real shape vocabulary (`library-API`, `reference-app`, `language-reference`, `stack-compose`, `unknown`); auto-decomposition described as it actually works — a >3-package / >500-export *candidate* flag followed by a cohesion check that usually merges into one skill
- **campaign**: quality-gate model corrected to the campaign-wide soft target (90) / soft fallback (80) + `zero-critical-high` hard gate; Skill Loop pipeline is `AN → BS → CS → TS` with export deferred to the gated Export stage
- **workflows**: Quick Skill exit 6 is `user-cancelled`; setup envelope's `status` field documented as the primary branch field
- **agents**: campaign presented as a standalone orchestrator workflow under MANAGE, not a pipeline alias
- **how-it-works**: the Quick Skill walkthrough no longer claims tier branching, automatic snippet injection, or create-skill artifacts; readers wanting the full audit trail are pointed at the brief-driven path
- **architecture**: campaign added to the Management mode row; stale fixed counts dropped; duplicate table keys disambiguated
- smaller: tier-override consumer list (+AN, BS), CS brief requirement in troubleshooting, per-run test-report filename, `docs:validate-drift` script name in pinned.yaml

### New coverage
- **campaign**: `campaign status`, override flags (`--headless`, `--brief`, `--manifest`), the customize.toml surface, headless operation with stable exit codes + result envelope, and re-invocation/recovery behavior
- **workflows**: setup's `--orphan-action`, `--ccc-skip-index`, `--quiet` flags; result-envelope contracts for Drop Skill, Rename Skill, and Refine Architecture
- **forge-auto**: language-reference handling and its DEGRADED caveat when no canonical corpora are found
- **examples**: campaign invocation in the multi-repo platform scenario

## Test plan
- [x] Full `npm test` green (validate:refs 0 broken / 0 leaks, eslint, markdownlint, prettier)
- [x] `npm run docs:validate-drift` green (pinned.yaml touched)
- [x] Every corrected claim re-verified against src/ by an independent reviewer (12/12 docs passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)