### PR TITLE
Fix installed-layout, resume-routing, and denominator gaps across SKF workflows

### DIFF
--- a/src/shared/scripts/skf-validate-brief-schema.py
+++ b/src/shared/scripts/skf-validate-brief-schema.py
@@ -5,7 +5,7 @@
 """SKF Validate Brief Schema — schema check for a skill-brief.yaml on disk.
 
 Loads `skill-brief.yaml` from a path (or from stdin/inline-YAML), validates
-it against `src/shared/scripts/schemas/skill-brief.v1.json`, and applies the
+it against `schemas/skill-brief.v1.json` (sibling of this script), and applies the
 two conditional rules from `skf-create-skill/references/load-brief.md §3`
 that the JSON schema doesn't express today:
 
@@ -56,10 +56,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-SCHEMA_PATH = (
-    REPO_ROOT / "src" / "shared" / "scripts" / "schemas" / "skill-brief.v1.json"
-)
+SCHEMA_PATH = Path(__file__).resolve().parent / "schemas" / "skill-brief.v1.json"
 
 
 # --------------------------------------------------------------------------

--- a/src/skf-analyze-source/references/step-auto-scope.md
+++ b/src/skf-analyze-source/references/step-auto-scope.md
@@ -19,6 +19,9 @@ detectLanguageProbeOrder:
 languageCorporaProbeOrder:
   - '{project-root}/_bmad/skf/shared/scripts/skf-language-corpora.py'
   - '{project-root}/src/shared/scripts/skf-language-corpora.py'
+writeSkillBriefProbeOrder:
+  - '{project-root}/_bmad/skf/shared/scripts/skf-write-skill-brief.py'
+  - '{project-root}/src/shared/scripts/skf-write-skill-brief.py'
 ---
 
 <!-- Config: communicate in {communication_language}. -->
@@ -206,9 +209,11 @@ confirmed_units:
 
 **4. Write skill brief via canonical writer:**
 
+**Resolve `{writeSkillBriefHelper}`** from `{writeSkillBriefProbeOrder}`; first existing path wins; HALT if neither resolves.
+
 Create directory `{forge_data_folder}/{skill_name}/` if it does not exist.
 
-Write `{forge_data_folder}/{skill_name}/skill-brief.yaml` through the canonical writer (`skf-write-skill-brief.py`) with the following context:
+Pipe the flat context JSON below into the resolved writer with the `--from-flat` flag:
 
 ```json
 {
@@ -217,7 +222,7 @@ Write `{forge_data_folder}/{skill_name}/skill-brief.yaml` through the canonical 
   "detected_version": null,
   "source_type":      "docs-only",
   "source_repo":      "{url}",
-  "language":         "",
+  "language":         "documentation",
   "description":      "Skill created from documentation at {url}",
   "forge_tier":       "{forge_tier}",
   "created":          "{current_date}",
@@ -237,6 +242,10 @@ Write `{forge_data_folder}/{skill_name}/skill-brief.yaml` through the canonical 
   "source_ref":       null,
   "version_resolved": "1.0.0"
 }
+```
+
+```bash
+echo '<context-json>' | uv run {writeSkillBriefHelper} write --target {forge_data_folder}/{skill_name}/skill-brief.yaml --from-flat
 ```
 
 **5. Emit success envelope:**

--- a/src/skf-campaign/SKILL.md
+++ b/src/skf-campaign/SKILL.md
@@ -105,7 +105,7 @@ These rules apply to every step in this workflow:
 | 9 | Export | references/step-10-export.md | No (write-gate HALT) |
 | 10 | Maintenance | references/step-11-maintenance.md | Yes |
 
-**Stage numbering:** step files are 1-indexed (`step-01` … `step-11`); `campaign.current_stage` in state is 0-indexed, so step-`NN` runs stage `NN − 1` (e.g. step-01 = stage 0, step-11 = stage 10). The Resume Routing table in `references/step-resume.md` maps each `current_stage` back to its step file.
+**Stage numbering:** step files are 1-indexed (`step-01` … `step-11`); `campaign.current_stage` in state is 0-indexed, so step-`NN` runs stage `NN − 1` (e.g. step-01 = stage 0, step-11 = stage 10). The Resume Routing table in `references/step-resume.md` maps a resolved stage number to its step file; because `current_stage` records the highest *completed* stage, resume without an active skill advances to `current_stage + 1` (the stage that still needs to run) before consulting the table.
 
 ## Invocation Contract
 
@@ -161,7 +161,7 @@ When resuming:
 
 1. Read `_campaign-state.yaml`
 2. Validate via `campaign-validate-state.py` (halt on invalid; attempt `.bak` recovery per step-resume)
-3. Find last active or completed stage from `campaign.current_stage`
+3. Find last active or completed stage from `campaign.current_stage` (the highest completed stage); when no skill is active, resume continues from the stage *after* it (`current_stage + 1`, terminal-capped)
 4. Skip completed skills (status = `completed` or `skipped`)
 5. If `--from=<skill>` is provided, find the named skill and resume from its stage
 6. Continue from the next incomplete skill in `dependency_graph.execution_order`

--- a/src/skf-campaign/references/step-resume.md
+++ b/src/skf-campaign/references/step-resume.md
@@ -73,12 +73,12 @@ Two paths based on whether `--from=<skill>` was provided in the invocation:
 1. Scan `skills[]` for any skill with `status == "active"`.
    - If found and `tier == "A"` → resume target is stage 4 (`step-05-skill-loop.md`). The skill loop's §4 will skip completed skills until it reaches the active one.
    - If found and `tier == "B"` → resume target is stage 5 (`step-06-batch.md`). The batch step processes Tier B skills.
-2. If no active skill → use `campaign.current_stage` from state.
-3. Map `current_stage` to the corresponding step file using the stage table in §4.
+2. If no active skill → the next stage to run is `campaign.current_stage + 1`, because `current_stage` records the highest **completed** stage (each stage writes its own number only after its work and gates finish, so a mid-stage halt leaves the previous stage's number on disk). **Terminal cap:** if `campaign.current_stage` is `10`, the resolved stage is `10` itself (`step-11-maintenance.md`) — never `11`; the existing terminal-HALT check in §4 governs whether a stage-10 campaign is already done.
+3. Map the resolved stage number to the corresponding step file using the stage table in §4.
 
 ### §4 — Resume Routing
 
-Map `current_stage` to step file:
+Map the resolved stage number to its step file. Both §3 branches feed this table an **already-resolved** stage number: the active-skill branch supplies stage 4 or 5 directly (and BYPASSES the `+1`), while the no-active-skill branch supplies `current_stage + 1` (terminal-capped at 10). Do not apply the `+1` again here.
 
 | Stage | Step File |
 |-------|-----------|

--- a/src/skf-create-skill/references/extraction-patterns.md
+++ b/src/skf-create-skill/references/extraction-patterns.md
@@ -287,7 +287,7 @@ rule:
   pattern: 'export class $NAME { $$$ }'
 ```
 
-> **Important:** The body (`{ $$$ }`) is required on ast-grep 0.42.x. The bare `export class $NAME` pattern returns zero matches — and emits a `Pattern contains an ERROR node` warning — through **both** `find_code()` and the CLI, because an incomplete class declaration does not parse as a complete statement (see Known Limitation #9). With the body present, the simple `find_code()` pattern detects class exports reliably; `find_code_by_rule` would additionally require an explicit AST `kind` rule.
+> **Important:** The body (`{ $$$ }`) is required on ast-grep 0.42.x. The bare `export class $NAME` pattern returns zero matches — and emits a `Pattern contains an ERROR node` warning — through **both** `find_code()` and the CLI, because an incomplete class declaration does not parse as a complete statement (see Known Limitation #9). With the body present, the simple `find_code()` pattern detects class exports reliably — it matches non-generic classes only; generic (`export class $NAME<T>`) and generic-extends (`export class $NAME<T> extends $BASE`) forms are skipped, so source-read them via `^export (abstract )?class` and merge by name+file (see Known Limitation #10). `find_code_by_rule` would additionally require an explicit AST `kind` rule.
 
 **JavaScript/TypeScript — re-export detection (use `find_code`):**
 
@@ -410,6 +410,8 @@ When using ast-grep for extraction, be aware of these documented limitations:
    - **function:** the body form `export function $NAME($$$PARAMS) { $$$ }` matches only functions with no return-type annotation and no `async` modifier, so it is unreliable. Prefer a source-read fallback (or a barrel cross-check) at T1-low for `export function`, mirroring the tsx guidance in #5.
 
    Never silently accept zero results for a declaration form the source language commonly uses.
+
+10. **Generic class declarations do not match non-generic class patterns (ast-grep 0.42.x):** The non-generic patterns `export class $NAME { $$$ }` and `export class $NAME extends $BASE { $$$ }` silently skip every generic form on ast-grep 0.42.2 — verified via both the CLI (`ast-grep run -p ... -l typescript`) and `find_code()`, the first matched only a plain `Plain` and the second only a plain `PlainExtends` on a fixture of `Plain` / `Generic<T>` / `GenericExtends<T> extends Base<T>` / `abstract AbstractGeneric<T>` / `PlainExtends`. The per-shape generic patterns `export class $NAME<$$$P> { $$$ }`, `export class $NAME<$$$P> extends $BASE { $$$ }`, and `export abstract class $NAME<$$$P> { $$$ }` each match exactly **one** shape — no single pattern covers all of them. **Workaround:** Always run a source-read fallback `^export (abstract )?class` over the in-scope `.ts` sources (T1-low) and merge by name+file with the AST results, mirroring the `export function` guidance in #9. The bare `class $NAME` pattern catches every form but over-captures non-exported classes, so it still needs the source-read pass to re-impose the exported-only filter — this is the opposite trade from the Python #7 `^[^_]` re-filter, since TS has no name-prefix convention for exports. Never accept a class inventory that omits generic classes when the source uses them.
 
 ### Component Library Demo/Example Auto-Exclusion
 

--- a/src/skf-test-skill/references/coverage-check.md
+++ b/src/skf-test-skill/references/coverage-check.md
@@ -260,11 +260,21 @@ as-observed (or `absent` when the candidate was not present for this skill):
 - `stats.effective_denominator`: {N | absent}  {← chosen if priority (1) applied}
 - `scope.tier_a_include` union: {N | absent}    {← chosen if priority (2) applied}
 - `scope.include` union: {N | absent}           {← chosen if priority (3) applied}
+- exports-map subpath union: {N | absent}        {← chosen if the multi-entry clause applied}
+- root barrel: {N}                               {secondary candidate — root-barrel-vs-subpath-union audit}
 ```
 
 Readers can then spot-check whether the chosen denominator is reasonable
 against the other two without re-running the extraction. A future reviewer who
 suspects denominator gaming has the evidence inline.
+
+**Multi-entry (exports-map) denominator (single-package multi-subpath libraries):** Before computing Export Coverage, check whether the Source Access Protocol's multi-entry clause applies to this skill (see `{sourceAccessProtocol}` §Source API Surface Definition — "Multi-entry (exports-map) packages"). It applies when the in-scope `package.json` declares an `exports` map with multiple non-root subpath entries, no monorepo markers — covering `scope.type: "full-library"` AND `scope.type: "public-api"` for such packages. When it applies:
+
+1. **Prefer `metadata.json.stats.effective_denominator`** when present. Use it directly as `total_exports` — subject to the same **denominator deflation guard** the stratified-scope branch applies.
+2. **Otherwise prefer `scope.tier_a_include`** (filtered by `scope.exclude`, excluding umbrella barrel files per the protocol's umbrella-barrel note) when the brief supplies it; **else** re-derive the **union of named exports across the files each NON-WILDCARD `exports` subpath resolves to** per the protocol (resolving committed `.d.ts` / `.d.mts` targets, applying the multi-line brace-accumulation and `export *` star-resolution rules, and excluding `"./*"` wildcard subpaths). Use the resulting count as `total_exports`. When the `exports` map has only a root `"."` entry or only wildcards, fall back to the standard root-barrel rule instead.
+3. **Report the root-barrel named-export count as a secondary candidate** in the Denominator Candidates block so the root-barrel-vs-subpath-union choice is auditable.
+
+Record the denominator source in the Coverage Analysis section as `Denominator: multi-entry ({effective_denominator | tier_a_include union | subpath union}, {N} subpaths resolved; root barrel: {R})`.
 
 **State 2 denominator validation:** When using provenance-map as the baseline (State 2), cross-reference the provenance-map entry count against `metadata.json`'s `exports[]` array before computing Export Coverage. If they diverge, use the union as the denominator per the source-access-protocol rules. Log the gap size if any. The stratified-scope rule above takes precedence when both conditions apply — compute the stratified denominator first, then validate the provenance-map entry count against it.
 

--- a/src/skf-test-skill/references/source-access-protocol.md
+++ b/src/skf-test-skill/references/source-access-protocol.md
@@ -41,14 +41,14 @@
 
   Leave `analysis_confidence` unchanged (still `full` or `provenance-map` per the waterfall) — stratified scope does not degrade confidence, only the denominator. Annotate the coverage report with: `Stratified scope — denominator: {effective_denominator | tier_a_include union | scope.include union} ({N} files matched, {M} exports union)`.
 
-  **When this clause does NOT apply:** `scope.type: "full-library"` skills, single-package repositories, or stratified briefs where the full monorepo is intentionally in scope. For those, use the standard barrel-based denominator — **unless** the single-package repo is a pattern-reference app (see next bullet).
+  **When this clause does NOT apply:** `scope.type: "full-library"` skills, single-package repositories, or stratified briefs where the full monorepo is intentionally in scope. For those, use the standard barrel-based denominator — **unless** the single-package repo is a pattern-reference app (see next bullet) or publishes a multi-subpath `exports` map (use the multi-entry clause below).
 
 - **Pattern-reference apps (non-library source):** If the source is a single-package repo whose purpose is demonstrating an integration pattern rather than distributing a library API — typical markers are `scope.type: "full-library"` **without** a barrel file at any recognized entry-point path (`__init__.py`, `index.ts`/`index.js`, `lib.rs`, `mod.rs`) AND without a monorepo layout — the skill's value lives in wiring patterns, not exports. None of the preceding three clauses fits: there is no barrel to count from, no empty-barrel `scope.include` to consult, and no monorepo stratification to re-derive.
 
   **Trigger (either fires):**
 
   1. `scope.notes` in `forge-data/{skill_name}/skill-brief.yaml` flags pattern-reference intent (phrases such as "Reference app, not a library", "pattern-reference", "embedded-pattern skill", or "skill value is the … pattern"). The `scope.notes` field is authoritative when the author wrote it.
-  2. Source tree lacks a barrel file at every recognized entry-point path AND the repo is not a monorepo (no `packages/`, `workspaces`, `lerna.json`, `rush.json`, `nx.json`, or Cargo `[workspace]`). Detected at test time by filesystem inspection of `{source_path}`.
+  2. Source tree lacks a barrel file at every recognized entry-point path AND the repo is not a monorepo (no `packages/`, `workspaces`, `lerna.json`, `rush.json`, `nx.json`, or Cargo `[workspace]`) AND the package does not declare a multi-subpath `exports` map (those route to the multi-entry clause below). Detected at test time by filesystem inspection of `{source_path}`.
 
   **Denominator:** canonicalized provenance-map entry count (same canonicalization as the "Provenance-map canonicalization" section below). `skf-create-skill`'s extraction pass has already curated the provenance-map to the authored pattern surface; treat it as the authoritative enumeration of the skill's documented reach.
 
@@ -56,7 +56,7 @@
 
   **Confidence:** leave `analysis_confidence` unchanged (still `full` or `provenance-map` per the waterfall). Pattern-reference does not degrade confidence — the surface is smaller than a library barrel, not lower quality. Annotate the coverage report with: `Pattern-reference — denominator: {tier_a_include union | canonicalized provenance-map count} ({N} pattern surfaces)`.
 
-  **When this clause does NOT apply:** any repo with a non-empty barrel file, any monorepo (use the stratified-scope clause), or any single-package repo whose `scope.type` is explicitly `public-api` / `specific-modules` / `component-library` / `docs-only` (those scope types have their own denominator semantics). Also does NOT apply when `scope.type: "reference-app"` — that scope type carries its own pattern-surface denominator semantics (the brief speaks for itself), so this clause's filesystem trigger is moot.
+  **When this clause does NOT apply:** any repo with a non-empty barrel file, any monorepo (use the stratified-scope clause), or any single-package repo whose `scope.type` is explicitly `specific-modules` (use the specific-modules clause), `public-api` with a multi-subpath `exports` map (use the multi-entry clause below — a `public-api` package WITHOUT such a map keeps the standard root-barrel rule), `component-library`, or `docs-only`. Also does NOT apply when `scope.type: "reference-app"` — that scope type carries its own pattern-surface denominator semantics (the brief speaks for itself), so this clause's filesystem trigger is moot.
 
 - **Single-crate curated subset (`scope.type: "specific-modules"`):** If the source is a single-package (non-monorepo) repo whose skill brief sets `scope.type: "specific-modules"` and uses `scope.include`/`scope.exclude` to carve a subset of the crate's public surface, the coverage denominator is the **in-scope reachable barrel** — not the full barrel.
 
@@ -71,6 +71,16 @@
   **When `effective_denominator` is present:** prefer `metadata.json.stats.effective_denominator` (same priority-1 rule as the stratified-scope clause), subject to the same deflation guard.
 
   **When this clause does NOT apply:** monorepo packages (use the stratified-scope clause), `scope.type: "full-library"` (use the standard barrel), or empty-barrel packages (use the empty-barrel clause). This clause is specifically for single-crate repos where the brief intentionally documents a curated subset rather than the full public surface.
+
+- **Multi-entry (exports-map) packages (single-package libraries publishing via a `package.json` `exports` map):** If the in-scope `package.json` declares an `exports` map with **multiple non-root subpath entries** (more than just `"."`) and the repo carries **no** monorepo markers (`packages/` layout, `workspaces` field, `lerna.json`, `rush.json`, `nx.json`, Cargo `[workspace]`), the package's public surface spans every published subpath, not just the root barrel. The standard "named exports from `index.ts`" rule undercounts: it measures only the `"."` barrel while installers reach the full subpath set. This clause covers both `scope.type: "full-library"` AND `scope.type: "public-api"` for such packages.
+
+  **Denominator:** the **union of named exports across the files each NON-WILDCARD `exports` subpath resolves to**. Resolve each subpath to its target file (or its committed `.d.ts` / `.d.mts` declaration), then apply the same multi-line brace-accumulation and `export *` star-resolution rules documented for barrel re-derivation earlier in this file ("TypeScript / JavaScript barrel re-derivation"). **Explicitly exclude wildcard subpaths** (`"./*"` forms — they map to an open-ended file set whose surface is unbounded and uncountable). If the `exports` map has only a root `"."` entry, or only wildcard subpaths, fall back to the standard root-barrel rule.
+
+  **Curation/priority (same ladder the specific-modules clause uses):** prefer `metadata.json.stats.effective_denominator` first (subject to the existing deflation guard), then `scope.tier_a_include` globs (filtered by `scope.exclude`, the umbrella-barrel note applies) when the brief supplies it, else the full subpath union.
+
+  **Audit:** the root-barrel named-export count MUST be reported as a **secondary candidate** in the Denominator Candidates audit block (coverage-check.md §4) so the root-barrel-vs-subpath-union choice is auditable. Annotate the coverage report with: `Multi-entry (exports-map) — denominator: {effective_denominator | tier_a_include union | subpath union} ({N} subpaths resolved, {M} exports union; root barrel: {R})`.
+
+  **When this clause does NOT apply:** monorepo packages (use the stratified-scope clause), empty-barrel packages (use the empty-barrel clause), pattern-reference apps (use the pattern-reference clause), `scope.type: "specific-modules"` (use the specific-modules clause), or single-entry / wildcard-only `exports` maps (use the standard root-barrel rule).
 
 Internal module symbols are **excluded** from the coverage denominator unless they are explicitly documented in SKILL.md (in which case they count as documented extras, not missing coverage).
 

--- a/test/test-skf-validate-brief-schema.py
+++ b/test/test-skf-validate-brief-schema.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime
 import importlib.util
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -349,6 +350,41 @@ class TestCli:
         # argparse missing-required exits 2
         result = _run_cli()
         assert result.returncode == 2
+
+
+# --------------------------------------------------------------------------
+# Installed-layout regression — schema resolves as a sibling of the script
+# --------------------------------------------------------------------------
+
+
+class TestInstalledLayout:
+    def test_installed_layout_resolves_sibling_schema(self, tmp_path: Path) -> None:
+        # When the installer copies `src/shared` recursively, the script lands at
+        # `_bmad/skf/shared/scripts/` with `schemas/` as a sibling — there is no
+        # `src/shared/scripts/schemas/` four levels up. The schema must resolve
+        # relative to the script's own directory so the CLI still exits 0.
+        installed_scripts = tmp_path / "_bmad" / "skf" / "shared" / "scripts"
+        installed_scripts.mkdir(parents=True)
+        installed_script = installed_scripts / SCRIPT_PATH.name
+        installed_script.write_text(
+            SCRIPT_PATH.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        shutil.copytree(SCRIPT_PATH.parent / "schemas", installed_scripts / "schemas")
+        assert (installed_scripts / "schemas" / "skill-brief.v1.json").is_file()
+
+        brief_path = tmp_path / "skill-brief.yaml"
+        brief_path.write_text(_valid_yaml_text(), encoding="utf-8")
+
+        result = subprocess.run(
+            [sys.executable, installed_script.as_posix(), brief_path.as_posix()],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["valid"] is True
+        assert payload["halt_reason"] is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Five targeted fixes across the SKF workflows, one commit per issue:

- **fix(shared): resolve skill-brief schema beside the validator script** — `skf-validate-brief-schema.py` resolved its schema through a four-parent dev-layout walk and crashed with `FileNotFoundError` in installed layouts. The schema now resolves as a sibling of the script (correct in both layouts, matching the `skf-emit-result-envelope.py` convention), with a regression test that simulates the installed layout and fails on the old resolution.
- **fix(analyze-source): wire docs-only brief write through the canonical writer** — the docs-only short-circuit named `skf-write-skill-brief.py` with no probe order, resolution step, or invocation. It now uses the standard `writeSkillBriefProbeOrder` + resolve-or-HALT + `--from-flat` pipe convention, and the context's `language` field carries a non-empty sentinel so the writer's schema validation accepts it (verified end-to-end through writer and schema validator).
- **fix(campaign): resume to the next incomplete stage after a mid-stage halt** — `current_stage` records the highest *completed* stage, but resume routed it to that same stage's step file, re-running completed work and re-prompting its interactive gate. Resume now resolves `current_stage + 1` (terminal-capped), with the active-skill branch explicitly bypassing the increment; the completion-write contract is unchanged.
- **docs(create-skill): document generic-class gap in ast-grep class recipes** — on ast-grep 0.42.x the class recipes match only non-generic classes; generic declarations are silently skipped. Known Limitation #10 documents the verified behavior and mandates the `^export (abstract )?class` source-read fallback merged by name+file.
- **fix(test-skill): add multi-entry exports-map denominator clause** — single-package libraries publishing via a multi-subpath `exports` map matched no denominator clause, leaving a potentially 20x root-barrel-vs-subpath-union choice to tester judgment. A fifth clause pins the denominator to the non-wildcard subpath union (with the existing priority ladder and the root barrel reported as a secondary audit candidate), aligned with the producer-side entry-point contract in skf-create-skill, and cross-clause carve-outs are reconciled so no repo shape matches two clauses.

## Verification

- Full `npm test` suite green (schemas, install, cli, workflow, python, knowledge, validate:*, lint, format)
- New installed-layout regression test added to the brief-schema suite (red on old code, green on new)
- Docs-only writer context verified end-to-end: piped through `skf-write-skill-brief.py` (exit 0) and the written brief passes `skf-validate-brief-schema.py`
- ast-grep claims re-verified against the real 0.42.2 binary on a five-shape class fixture
- No headings or table headers renamed; `validate:refs --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)