### PR TITLE
chore(module-help): use preceded-by/followed-by ordering column labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ src/skf-<name>/
 - **Manifest.** Agent-facing skills (e.g. `skf-forger`) require a `bmad-skill-manifest.yaml`. Copy the one from `src/skf-forger/` and adapt.
 - **Knowledge JiT.** If your workflow shares a principle with others, factor it into `src/knowledge/` and load it from the step rather than inlining the rule.
 - **Quality review.** Before shipping, run a [tessl](https://tessl.io) skill review pass on the SKILL.md content — SKF uses tessl for actionability scoring and AI-judge evaluation (see the references under `src/skf-create-skill/assets/`).
-- **Register the workflow** in `src/module-help.csv` (ordering / after / before fields) and in the `docs/workflows.md` reference table.
+- **Register the workflow** in `src/module-help.csv` (ordering / preceded-by / followed-by fields) and in the `docs/workflows.md` reference table.
 
 ## Adding Knowledge Fragments
 

--- a/src/module-help.csv
+++ b/src/module-help.csv
@@ -1,4 +1,4 @@
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 skf,skf-forger,Ferris — Skill Forge Agent,FF,"Skill compilation specialist — the forge master. Invoke to access all SKF workflows via guided menu.",,,anytime,,,false,,
 skf,skf-setup,Setup Forge,SF,"Initialize forge environment — detect tools and set capability tier (Quick/Forge/Forge+/Deep)",,,anytime,,"skf-analyze-source,skf-brief-skill,skf-quick-skill,skf-verify-stack,skf-campaign",false,,forge-tier.yaml
 skf,skf-campaign,Campaign,CA,"Orchestrate multi-library skill production across sessions — dependency tracking, file-based state, and resume",,resume [--from=<skill>],anytime,skf-setup,,false,forge_data_folder,_campaign-state.yaml


### PR DESCRIPTION
## What

Rename the ordering columns in `src/module-help.csv` from `after`/`before` to `preceded-by`/`followed-by`, and update the matching reference in `CONTRIBUTING.md`.

## Why

`preceded-by`/`followed-by` is the ordering-column convention shared by the other installed modules and the help-menu assembler. SKF was the only one using `after`/`before`; this aligns the header labels with that convention.

## Impact

None — purely cosmetic. The help-menu assembler reads these columns positionally, so the row data and menu behavior are unchanged. Verified:
- No code in the repo parses these column names.
- Full `npm run quality` gate passes green (validate:skills, validate:refs, docs:validate-drift, plus all tests and linters).

Diff is 2 lines across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)