### PR TITLE
docs(releasing): scope post-publish evidence to launch cuts

### DIFF
--- a/docs/_internal/RELEASING.md
+++ b/docs/_internal/RELEASING.md
@@ -639,4 +639,6 @@ Cross-platform install verification for any cut is performed by the [`install-sm
 gh workflow run install-smoke.yaml -f version=latest --ref main
 ```
 
-The workflow fans a `workflow_dispatch` input over `ubuntu-latest`, `windows-latest`, and `macos-latest`, running `npx --yes bmad-module-skill-forge@<version> --version` on each runner. A clean three-leg run is the canonical post-publish evidence — its run URL + matrix table belong in the release audit artifact's `## Story <N> Post-Publish Verification` section. Any failing leg routes through the `Rollback Playbook § Scenario B` (deprecate + ship `vX.Y.Z+1`).
+The workflow fans a `workflow_dispatch` input over `ubuntu-latest`, `windows-latest`, and `macos-latest`, running `npx --yes bmad-module-skill-forge@<version> --version` on each runner. A clean three-leg run is the canonical post-publish evidence. Any failing leg routes through the `Rollback Playbook § Scenario B` (deprecate + ship `vX.Y.Z+1`).
+
+**Where the evidence lives.** For a routine release the workflow run **is** the record — the dispatch satisfies NFR9 on its own and no audit artifact is written. Launch cuts additionally transcribe the run URL and matrix table into a per-launch audit artifact under `release-audits/`; `v1.0.0-launch-audit.md § Story 5.4 Post-Publish Verification` is the worked example and remains the only such artifact. Do not append routine releases to it — each audit file is a forensic record scoped to the launch that produced it.


### PR DESCRIPTION
The post-publish verification section of `docs/_internal/RELEASING.md` instructed maintainers to record the `install-smoke.yaml` run URL and matrix table in a release audit artifact’s `## Story <N> Post-Publish Verification` section.

That reflected the v1.0.0 launch process and was never carried forward. Every release since has dispatched `install-smoke.yaml` without producing an audit artifact, and `release-audits/` still holds only the single v1.0.0 launch record.

Read literally, the instruction points a maintainer at appending routine releases to a forensic record scoped to one specific launch. This states the actual practice instead:

- routine release → the workflow run **is** the record; no audit artifact
- launch cut → additionally transcribe the run URL + matrix into a per-launch audit artifact under `release-audits/`

Docs-only; no behaviour change.

## Verification

- `npm test` green locally (validate:refs, eslint, markdownlint 251 files, prettier)
- Surfaced while shipping v2.0.2, whose smoke run ([29696769099](https://github.com/armelhbobdad/bmad-module-skill-forge/actions/runs/29696769099)) passed all three legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)