### PR TITLE
The docs build records its inputs, and llms.txt joins the link check

### DIFF
--- a/test/test-validate-docs-links.js
+++ b/test/test-validate-docs-links.js
@@ -15,7 +15,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { resolveConfig, run, blankCode, assetUrls } = require('../tools/validate-docs-links.js');
+const { resolveConfig, run, blankCode, assetUrls, buildInputsStatus, checkLlmsIndex } = require('../tools/validate-docs-links.js');
 
 let passed = 0;
 let failed = 0;
@@ -264,6 +264,154 @@ async function main() {
     const r = await run(cfg, (m) => lines.push(m));
     assert.strictEqual(r.ok, true);
     assert.ok(/All documentation links valid/.test(lines.join('\n')));
+  });
+
+  // --- build-inputs freshness -------------------------------------------------
+
+  test('a matching manifest reads match, and never claims freshness', () => {
+    const { root, cfg } = fixture({ docs: { 'a.md': '# A\n' } });
+    const crypto = require('node:crypto');
+    const sha = crypto
+      .createHash('sha1')
+      .update(fs.readFileSync(path.join(root, 'docs', 'a.md')))
+      .digest('hex');
+    fs.mkdirSync(path.join(root, 'build'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'build', '.build-inputs.json'), JSON.stringify({ inputs: { 'docs/a.md': sha } }));
+    assert.deepStrictEqual(buildInputsStatus(cfg), { state: 'match', changed: [] });
+  });
+
+  test('a changed or added input reads stale and names the files', () => {
+    const { root, cfg } = fixture({ docs: { 'a.md': '# A\n', 'b.md': '# B\n' } });
+    const crypto = require('node:crypto');
+    const sha = crypto
+      .createHash('sha1')
+      .update(fs.readFileSync(path.join(root, 'docs', 'a.md')))
+      .digest('hex');
+    fs.mkdirSync(path.join(root, 'build'), { recursive: true });
+    // Manifest knows a.md (stale hash lies about nothing) but predates b.md.
+    fs.writeFileSync(
+      path.join(root, 'build', '.build-inputs.json'),
+      JSON.stringify({ inputs: { 'docs/a.md': sha, 'docs/gone.md': 'deadbeef' } }),
+    );
+    const status = buildInputsStatus(cfg);
+    assert.strictEqual(status.state, 'stale');
+    assert.deepStrictEqual(status.changed, ['docs/b.md', 'docs/gone.md']);
+  });
+
+  test('a missing or corrupt manifest reads missing, never stale', () => {
+    const { cfg } = fixture({ docs: { 'a.md': '# A\n' } });
+    assert.strictEqual(buildInputsStatus(cfg).state, 'missing');
+    fs.mkdirSync(path.join(cfg.projectRoot, 'build'), { recursive: true });
+    fs.writeFileSync(path.join(cfg.projectRoot, 'build', '.build-inputs.json'), 'not json');
+    assert.strictEqual(buildInputsStatus(cfg).state, 'missing');
+  });
+
+  await testAsync('run() prints the definite STALE block when inputs changed', async () => {
+    const lines = [];
+    const { root, cfg } = fixture({
+      docs: { 'a.md': '# A\n' },
+      build: { 'index.html': page('<p>hi</p>') },
+    });
+    fs.mkdirSync(path.join(root, 'build'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'build', '.build-inputs.json'), JSON.stringify({ inputs: { 'docs/a.md': 'deadbeef' } }));
+    await run(cfg, (m) => lines.push(m));
+    const text = lines.join('\n');
+    assert.match(text, /STALE BUILD: 1 input\(s\) changed/);
+    assert.match(text, /docs\/a\.md/);
+    assert.doesNotMatch(text, /may be cached/, 'the hedge yields to the definite block');
+  });
+
+  await testAsync('run() keeps the hedged note on a matching manifest', async () => {
+    const crypto = require('node:crypto');
+    const lines = [];
+    const { root, cfg } = fixture({
+      docs: { 'a.md': '# A\n' },
+      build: { 'index.html': page('<p>hi</p>') },
+    });
+    const sha = crypto
+      .createHash('sha1')
+      .update(fs.readFileSync(path.join(root, 'docs', 'a.md')))
+      .digest('hex');
+    fs.mkdirSync(path.join(root, 'build'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'build', '.build-inputs.json'), JSON.stringify({ inputs: { 'docs/a.md': sha } }));
+    await run(cfg, (m) => lines.push(m));
+    const text = lines.join('\n');
+    assert.doesNotMatch(text, /STALE BUILD/);
+    assert.match(text, /may be cached/, 'a match never claims freshness');
+  });
+
+  // --- llms.txt route coverage -----------------------------------------------
+  // This link class is not HTML, so the built pass never sees it; a deleted
+  // page's index entry survived every check exactly this way.
+
+  test('a live llms.txt route passes and an external link is skipped', () => {
+    const { cfg } = fixture({
+      build: {
+        'llms.txt': 'Documentation: https://x.io/base\n\n- [Ok](https://x.io/base/ok/)\n- [Ext](https://github.com/o/r)\n',
+        'ok/index.html': page('<p>ok</p>'),
+      },
+    });
+    const issues = [];
+    const checked = checkLlmsIndex(cfg, (file, detail) => issues.push({ file, detail }));
+    assert.strictEqual(checked, 1, 'one site link checked; the external one skipped');
+    assert.deepStrictEqual(issues, []);
+  });
+
+  test('a dead llms.txt route is a reported issue', () => {
+    const { cfg } = fixture({
+      build: {
+        'llms.txt': 'Documentation: https://x.io/base\n\n- [Gone](https://x.io/base/gone/)\n',
+      },
+    });
+    const issues = [];
+    checkLlmsIndex(cfg, (file, detail) => issues.push({ file, detail }));
+    assert.strictEqual(issues.length, 1);
+    assert.ok(issues[0].detail.includes('https://x.io/base/gone/'), issues[0].detail);
+  });
+
+  test('a file target like llms-full.txt resolves as a file, not a route', () => {
+    const { cfg } = fixture({
+      build: {
+        'llms.txt': 'Documentation: https://x.io/base\n\n- [Full](https://x.io/base/llms-full.txt)\n',
+        'llms-full.txt': 'bundle\n',
+      },
+    });
+    const issues = [];
+    checkLlmsIndex(cfg, (file, detail) => issues.push({ file, detail }));
+    assert.deepStrictEqual(issues, []);
+  });
+
+  test('no llms.txt or no Documentation header checks nothing and reports nothing', () => {
+    const bare = fixture({ build: { 'index.html': page('<p>hi</p>') } });
+    assert.strictEqual(
+      checkLlmsIndex(bare.cfg, () => {
+        throw new Error('no');
+      }),
+      0,
+    );
+    const headerless = fixture({ build: { 'llms.txt': '- [X](https://x.io/base/x/)\n' } });
+    assert.strictEqual(
+      checkLlmsIndex(headerless.cfg, () => {
+        throw new Error('no');
+      }),
+      0,
+    );
+  });
+
+  await testAsync('a dead llms.txt route fails a strict run end to end', async () => {
+    const { cfg } = fixture(
+      {
+        docs: { 'a.md': '# A\n' },
+        build: {
+          'index.html': page('<p>hi</p>'),
+          'llms.txt': 'Documentation: https://x.io/base\n\n- [Gone](https://x.io/base/gone/)\n',
+        },
+      },
+      ['--strict'],
+    );
+    const result = await runQuiet(cfg);
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.issues.some((issue) => issue.file === 'build/site/llms.txt'));
   });
 
   await testAsync('a missing docs dir raises rather than exiting the process', async () => {

--- a/tools/build-docs.js
+++ b/tools/build-docs.js
@@ -52,7 +52,32 @@ async function main() {
   const artifactsDir = await generateArtifacts(docsDir);
   const siteDir = buildAstroSite();
 
+  writeBuildInputsManifest();
+
   printBuildSummary(docsDir, artifactsDir, siteDir);
+}
+
+/**
+ * Record what this render was built FROM, so the validator can detect a stale
+ * build instead of hedging. One sha1 per input: the flat docs/*.md set plus
+ * the route-shaping infrastructure enumerated by BUILD_INFRA_INPUTS in the
+ * validator, which owns that list (see collectBuildInputs). Written to build/,
+ * NOT build/site/ - the site dir is uploaded to Pages and this manifest is
+ * local bookkeeping, not a public artifact.
+ *
+ * Deliberately NOT a freshness certificate: Astro's content cache can replay a
+ * stale render against unchanged inputs, so a matching manifest never proves
+ * the render is current - only a MISmatching one proves it is stale.
+ */
+function writeBuildInputsManifest() {
+  // The input set is owned by the validator (collectBuildInputs), so the
+  // manifest writer and the freshness checker can never disagree about what
+  // shapes the render.
+  const { collectBuildInputs } = require('./validate-docs-links.js');
+  const inputs = collectBuildInputs(PROJECT_ROOT);
+  const manifestPath = path.join(BUILD_DIR, '.build-inputs.json');
+  fs.writeFileSync(manifestPath, `${JSON.stringify({ inputs }, null, 2)}\n`, 'utf-8');
+  console.log(`  \u2192 Wrote build-inputs manifest (${Object.keys(inputs).length} inputs)`);
 }
 
 main().catch((error) => {

--- a/tools/validate-docs-links.js
+++ b/tools/validate-docs-links.js
@@ -377,6 +377,136 @@ function checkBuilt({ projectRoot, buildDir }, base, report) {
 
 // ---------------------------------------------------------------------------
 
+const BUILD_INFRA_INPUTS = [
+  'website/src/rehype-markdown-links.js',
+  'website/src/rehype-base-paths.js',
+  'website/src/lib/site-url.js',
+  'website/astro.config.mjs',
+  'tools/build-docs.js',
+];
+
+/**
+ * One sha1 per build input: the flat docs/*.md set plus BUILD_INFRA_INPUTS,
+ * the route-shaping infrastructure (BOTH rehype rewriters, the base/site
+ * resolver, the Astro config, and the builder itself). Canonical for both the
+ * manifest writer in tools/build-docs.js and the freshness check below - the
+ * first cut duplicated the list in both tools and both copies missed the
+ * second rehype rewriter, which is exactly the drift a single owner prevents.
+ */
+function collectBuildInputs(projectRoot) {
+  const crypto = require('node:crypto');
+  const sha1 = (file) => crypto.createHash('sha1').update(fs.readFileSync(file)).digest('hex');
+  const inputs = {};
+  const docsDir = path.join(projectRoot, 'docs');
+  if (fs.existsSync(docsDir)) {
+    for (const name of fs.readdirSync(docsDir).sort()) {
+      if (name.endsWith('.md')) {
+        inputs[`docs/${name}`] = sha1(path.join(docsDir, name));
+      }
+    }
+  }
+  for (const rel of BUILD_INFRA_INPUTS) {
+    const file = path.join(projectRoot, rel);
+    if (fs.existsSync(file)) {
+      inputs[rel] = sha1(file);
+    }
+  }
+  return inputs;
+}
+
+/**
+ * Compare the build-inputs manifest against the tree as it is NOW.
+ *
+ * Returns {state, changed}: state is 'missing' (no manifest - an older build,
+ * nothing to compare), 'match', or 'stale' with the changed inputs listed.
+ * A 'match' is deliberately NOT a freshness certificate: Astro's content cache
+ * can replay a stale render against unchanged inputs, so a matching manifest
+ * proves nothing - only a MISmatch proves staleness. That asymmetry is why the
+ * stale branch speaks definitely and the match branch stays hedged.
+ */
+function buildInputsStatus({ projectRoot, buildDir }) {
+  const manifestPath = path.join(path.dirname(buildDir), '.build-inputs.json');
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch {
+    return { state: 'missing', changed: [] };
+  }
+  if (!manifest || typeof manifest.inputs !== 'object' || manifest.inputs === null) {
+    return { state: 'missing', changed: [] };
+  }
+  const current = collectBuildInputs(projectRoot);
+  const changed = [];
+  for (const key of new Set([...Object.keys(manifest.inputs), ...Object.keys(current)])) {
+    if (manifest.inputs[key] !== current[key]) {
+      changed.push(key);
+    }
+  }
+  changed.sort();
+  return { state: changed.length > 0 ? 'stale' : 'match', changed };
+}
+
+/**
+ * Resolve every site-internal link in the built llms.txt against the built
+ * tree. This link class is invisible to the HTML pass (llms.txt is not HTML),
+ * which is exactly how a deleted page's index entry survived every check.
+ *
+ * The site root is read off the file's own `Documentation: <url>` header line
+ * rather than off the build base, so the check is independent of what base the
+ * local render happened to use. No header, or no file: nothing to check -
+ * reported as a count of 0, never as a pass over content that was not read.
+ */
+function checkLlmsIndex({ buildDir }, report) {
+  const llmsPath = path.join(buildDir, 'llms.txt');
+  let text;
+  try {
+    text = fs.readFileSync(llmsPath, 'utf-8');
+  } catch {
+    return 0;
+  }
+  const rootMatch = text.match(/^Documentation:\s+(\S+)$/m);
+  if (!rootMatch) {
+    return 0;
+  }
+  let rootPath;
+  try {
+    rootPath = new URL(rootMatch[1]).pathname;
+  } catch {
+    return 0;
+  }
+  if (!rootPath.endsWith('/')) {
+    rootPath += '/';
+  }
+  let checked = 0;
+  for (const match of text.matchAll(/\]\((\S+?)\)/g)) {
+    const target = match[1];
+    let url;
+    try {
+      url = new URL(target);
+    } catch {
+      continue; // relative or malformed: llms.txt only carries absolute links
+    }
+    if (!url.pathname.startsWith(rootPath)) {
+      continue; // external link, not a site route
+    }
+    checked += 1;
+    const route = url.pathname.slice(rootPath.length);
+    const candidates =
+      route === ''
+        ? [path.join(buildDir, 'index.html')]
+        : [path.join(buildDir, route.replace(/\/$/, ''), 'index.html'), path.join(buildDir, route)];
+    if (!candidates.some((candidate) => fs.existsSync(candidate))) {
+      report(
+        'build/site/llms.txt',
+        `links a route that resolves to nothing: ${target} (looked for ${candidates
+          .map((candidate) => path.relative(buildDir, candidate))
+          .join(' or ')})`,
+      );
+    }
+  }
+  return checked;
+}
+
 /**
  * Run both passes and return what happened, without touching the process.
  *
@@ -411,13 +541,30 @@ async function run(cfg, log = console.log) {
     builtCount = checkBuilt(cfg, base, report);
     log(`Built pass:   ${builtCount} page(s) in build/site (base ${base})`);
 
-    // This pass is only as honest as the build it reads. Astro caches rendered
-    // content in website/node_modules/.astro, and that cache survives both
-    // `rm -rf website/.astro` and a rebuild, so a stale render can report a
-    // clean pass against source that is actually broken (this bit the author
-    // while writing this tool). CI is immune because `npm ci` starts cold.
+    const llmsCount = checkLlmsIndex(cfg, report);
+    log(`llms.txt:     ${llmsCount} site link(s) checked`);
+
+    // This pass is only as honest as the build it reads. The manifest turns
+    // "may be stale" into a definite STALE where inputs provably changed; a
+    // matching manifest is still no freshness certificate, because Astro
+    // caches rendered content in website/node_modules/.astro and that cache
+    // survives both `rm -rf website/.astro` and a rebuild - a stale render can
+    // report a clean pass against unchanged inputs (this bit the author while
+    // writing this tool). CI is immune because `npm ci` starts cold.
     // Suppressed under --require-build, which is the CI path.
-    if (!cfg.requireBuild) {
+    const freshness = buildInputsStatus(cfg);
+    if (freshness.state === 'stale') {
+      log('');
+      log(`   STALE BUILD: ${freshness.changed.length} input(s) changed since this render:`);
+      for (const name of freshness.changed.slice(0, 5)) {
+        log(`     - ${name}`);
+      }
+      if (freshness.changed.length > 5) {
+        log(`     - (and ${freshness.changed.length - 5} more)`);
+      }
+      log('   This pass validated the OLD render. Rebuild before trusting it:');
+      log('     npm run docs:build');
+    } else if (!cfg.requireBuild) {
       log('');
       log('   Reading an existing build. If results look impossible, the render');
       log('   may be cached. Clear it and rebuild:');
@@ -486,7 +633,19 @@ async function run(cfg, log = console.log) {
   return { issues, sourceCount, builtCount, haveBuild, missingRequiredBuild, ok };
 }
 
-module.exports = { resolveConfig, run, checkSource, checkBuilt, resolveBase, blankCode, assetUrls, walk };
+module.exports = {
+  resolveConfig,
+  run,
+  checkSource,
+  checkBuilt,
+  resolveBase,
+  blankCode,
+  assetUrls,
+  walk,
+  buildInputsStatus,
+  collectBuildInputs,
+  checkLlmsIndex,
+};
 
 /* c8 ignore start -- CLI entry point */
 if (require.main === module) {


### PR DESCRIPTION
## What this changes

The docs link validator could report a clean pass against a render that no longer matched its source, and one whole class of link — the entries in `llms.txt` — was never checked at all because that file is not HTML.

**1. The build records its inputs.** `tools/build-docs.js` now writes `build/.build-inputs.json`: one sha1 per input, covering the flat `docs/*.md` set plus the route-shaping infrastructure (both rehype rewriters, the base/site resolver, the Astro config, and the builder itself). It lands in `build/`, never `build/site/` — the site dir is what gets uploaded to Pages, and this is local bookkeeping.

The input list lives in the validator (`collectBuildInputs`) and the builder imports it, so the writer and the checker cannot drift apart about what shapes a render.

**2. The validator turns the hedge into a fact where it can.** When inputs provably changed since the render, `validate-docs-links.js` prints a definite `STALE BUILD` block naming the changed files instead of the old "results may be cached" note. A *matching* manifest deliberately keeps the hedge: Astro's content cache can replay a stale render against unchanged inputs, so a match proves nothing — only a mismatch proves staleness. Exit codes are untouched; this is diagnostic output, not a new failure mode.

**3. `llms.txt` joins the link check.** Every site-internal link in the built `llms.txt` is resolved against the built tree, with dead routes failing under `--strict`. The site root is read off the file's own `Documentation:` header rather than off the build base, so the check works regardless of what base the local render used. No file or no header means nothing is checked and a count of `0` is reported — never a pass over content that was not read.

Eight new cases in `test/test-validate-docs-links.js` (33 total, all passing).

## Verified against the real build, not just fixtures

- `npm run docs:build` writes a 21-input manifest (16 docs + 5 infra files).
- `npm run validate:docs-links` reports `llms.txt: 14 site link(s) checked`, clean, with the local base `/` while `llms.txt` uses the published base — confirming the header-derived root resolution.
- Appending a line to `docs/agents.md` produces `STALE BUILD: 1 input(s) changed` naming that file; reverting clears it.
- Moving aside a target only `llms.txt` references (`downloads/skf-prompts.zip`) makes a strict run report `build/site/llms.txt — links a route that resolves to nothing` and exit 1; restoring it returns exit 0.

## Two review fixes on top of the prepared change

- The new helpers were inserted between `run`'s JSDoc block and `run` itself, which left that doc comment describing `BUILD_INFRA_INPUTS`. Moved the block back onto `run`.
- The manifest-writer comment in `build-docs.js` still described "the three files that shape routes" from an earlier cut, while the canonical list holds five. It now defers to `BUILD_INFRA_INPUTS` instead of restating a count — the same drift its neighbouring note warns about.

## Note on the shared validator

`tools/validate-docs-links.js` is kept logic-identical to the copy in [bmad-module-ultracode-goal](https://github.com/armelhbobdad/bmad-module-ultracode-goal), each repo keeping its own narrative header. After this change the two bodies differ **only** by the JSDoc relocation above — the sibling carries the same misplacement and should get the same one-line move so the files converge again. No logic differs.

One nit left deliberately unfixed to avoid a second divergence: the `Suppressed under --require-build` comment above the freshness block now reads as if it covers the whole block, when it only describes the hedged branch. Worth correcting in both repos at once.
