### PR TITLE
Scope the freshness suppression note to the branch it describes

### DIFF
--- a/tools/validate-docs-links.js
+++ b/tools/validate-docs-links.js
@@ -551,7 +551,9 @@ async function run(cfg, log = console.log) {
     // survives both `rm -rf website/.astro` and a rebuild - a stale render can
     // report a clean pass against unchanged inputs (this bit the author while
     // writing this tool). CI is immune because `npm ci` starts cold.
-    // Suppressed under --require-build, which is the CI path.
+    // Only the hedged branch is suppressed under --require-build (the CI
+    // path); a provable STALE always speaks, since a cold CI build that
+    // still mismatches its inputs is worth saying out loud.
     const freshness = buildInputsStatus(cfg);
     if (freshness.state === 'stale') {
       log('');


### PR DESCRIPTION
Comment-only follow-up to #466. No behaviour change; the full suite is green.

`// Suppressed under --require-build, which is the CI path.` sits above the entire freshness block, reading as though the CI path silences all of it. It doesn't — only the hedged "may be cached" branch is suppressed. A provable `STALE` is printed on the CI path too, and that is deliberate: a cold `npm ci` build that *still* mismatches its inputs is exactly the case worth saying out loud. The note now names the branch it describes and the reason for the asymmetry.

## Twin sync

`tools/validate-docs-links.js` is kept logic-identical to the copy in [bmad-module-ultracode-goal](https://github.com/armelhbobdad/bmad-module-ultracode-goal), each repo keeping its own narrative header. #466 fixed a JSDoc block that had been left attached to the wrong symbol in both repos, which put the two bodies temporarily out of sync; the counterpart PR there carries that fix plus this one.

Fixing only the JSDoc in the sibling would have traded one divergence for another — this comment — so both move together. The bodies converge once this and its counterpart land:

```
diff <(sed -n '/^const /,$p' tools/validate-docs-links.js) \
     <(sed -n '/^const /,$p' ../bmad-module-ultracode-goal/tools/validate-docs-links.js)
```

Verified locally against both branches: zero output.
